### PR TITLE
Explicitly state the required verison of six.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name="loo.py",
           "pymbolic>=2015.2.1",
           "cgen>=2013.1.2",
           "islpy>=2014.2",
-          "six",
+          "six>=1.8.0",
           ],
 
       scripts=["bin/loopy"],


### PR DESCRIPTION
six.intern was only introduced in 1.8.0.
This patch makes it possible to work in a virtualenv
with --system-site-packages despite an ancient six
(as provided by Ubuntu 14.04 for whatever reasons).