### PR TITLE
[bugfix] The var_subst_map is a member of codegen_state not of the ecm

### DIFF
--- a/loopy/codegen/instruction.py
+++ b/loopy/codegen/instruction.py
@@ -232,7 +232,7 @@ def generate_c_instruction_code(kernel, insn, codegen_state):
     from pymbolic.primitives import Variable
     for name, iname_expr in insn.iname_exprs:
         if (isinstance(iname_expr, Variable)
-                and name not in ecm.var_subst_map):
+                and name not in codegen_state.var_subst_map):
             # No need, the bare symbol will work
             continue
 


### PR DESCRIPTION
When using CInstructions with plain CTarget() as code generation target,
an AttributeError was thrown when evaluating the if clause here.
This commit uses the var_subst_map of the codegen_state instead.