### PR TITLE
Duplicating inames for non-schedulable kernels

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -65,7 +65,8 @@ from loopy.transform.iname import (
         rename_iname, remove_unused_inames,
         split_reduction_inward, split_reduction_outward,
         affine_map_inames, find_unused_axis_tag,
-        make_reduction_inames_unique)
+        make_reduction_inames_unique,
+        needs_iname_duplication, get_iname_duplication_options)
 
 from loopy.transform.instruction import (
         find_instructions, map_instructions,

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -800,17 +800,8 @@ def duplicate_inames(knl, inames, within, new_inames=None, suffix=None,
 
 def _get_iname_duplication_options(insn_deps):
     # Remove common inames of the current insn_deps, as they are not relevant for splitting.
-    def remove_common_iname(deps):
-        common = frozenset({}).union(*insn_deps).intersection(*insn_deps)
-        if common:
-            iname = iter(common).next()
-            return frozenset(d - frozenset([iname]) for d in deps) - frozenset([frozenset([])]), False
-        else:
-            return deps, True
-
-    stop = False
-    while not stop:
-        insn_deps, stop = remove_common_iname(insn_deps)
+    common = frozenset([]).union(*insn_deps).intersection(*insn_deps)
+    insn_deps = frozenset(dep - common for dep in insn_deps) - frozenset([frozenset([])])
 
     # Try finding a partitioning of the remaining inames, such that all instructions
     # use only inames from one of the disjoint sets from the partitioning.

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -796,6 +796,86 @@ def duplicate_inames(knl, inames, within, new_inames=None, suffix=None,
 
 # }}}
 
+# {{{ iname duplication for schedulability
+
+def _get_iname_duplication_options(insn_deps):
+    # Remove common inames of the current insn_deps, as they are not relevant for splitting.
+    def remove_common_iname(deps):
+        common = frozenset({}).union(*insn_deps).intersection(*insn_deps)
+        if common:
+            iname = iter(common).next()
+            return frozenset(d - frozenset([iname]) for d in deps) - frozenset([frozenset([])]), False
+        else:
+            return deps, True
+
+    stop = False
+    while not stop:
+        insn_deps, stop = remove_common_iname(insn_deps)
+
+    # Try finding a partitioning of the remaining inames, such that all instructions
+    # use only inames from one of the disjoint sets from the partitioning.
+    def join_sets_if_not_disjoint(sets):
+        for s1 in sets:
+            for s2 in sets:
+                if s1 != s2 and s1.intersection(s2):
+                    return (sets - frozenset([s1, s2])).union(frozenset([s1.union(s2)])), False
+
+        return sets, True
+
+    partitioning = insn_deps
+    stop = False
+    while not stop:
+        partitioning, stop = join_sets_if_not_disjoint(partitioning)
+
+    # If a partitioning was found we recursively apply this algorithm to the subproblems
+    if len(partitioning) > 1:
+        for part in partitioning:
+            working_set = frozenset(s for s in insn_deps if s.issubset(part))
+            for option in _get_iname_duplication_options(working_set):
+                yield option
+    # If exactly one set was found, an iname duplication is necessary
+    elif len(partitioning) == 1:
+        inames, = partitioning
+
+        # There are splitting options for all inames
+        for iname in inames:
+            iname_insns = frozenset(insn for insn in insn_deps if frozenset([iname]).issubset(insn))
+
+            import itertools as it
+            # For a given iname, the set of instructions containing this iname is inspected.
+            # For each element of the power set without the empty and the full set, one
+            # duplication option is generated.
+            for insns_to_dup in it.chain.from_iterable(it.combinations(iname_insns, l) for l in range(1, len(iname_insns))):
+                yield iname, insns_to_dup
+
+    # If partitioning was empty, we have recursed successfully and yield nothing
+
+
+def get_iname_duplication_options(knl):
+    """
+    returns all options to duplicate inames, if duplication of an iname is necessary
+    to ensure the schedulability of the kernel. duplication options are returned as
+    tuples (iname, within) as understood by loopy.duplicate_inames
+    """
+    # First we extract the minimal necessary information from the kernel
+    insn_deps = frozenset(insn.forced_iname_deps for insn in knl.instructions)
+
+    # Get the duplication options as a tuple of iname and a set
+    for iname, insns in _get_iname_duplication_options(insn_deps):
+        # Reconstruct an object that may be passed to the within parameter of
+        # loopy.duplicate_inames
+        within = ' or '.join('id:%s' % insn.id for insn in knl.instructions if insn.forced_iname_deps in insns)
+        yield iname, within
+
+
+def needs_iname_duplication(knl):
+    """
+    returns a bool indicating whether this kernel needs an iname duplication
+    in order to be schedulable.
+    """
+    return bool(next(get_iname_duplication_options(knl), False))
+
+# }}}
 
 # {{{ rename_inames
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -837,7 +837,7 @@ def _get_iname_duplication_options(insn_deps):
             # For each element of the power set without the empty and the full set, one
             # duplication option is generated.
             for insns_to_dup in it.chain.from_iterable(it.combinations(iname_insns, l) for l in range(1, len(iname_insns))):
-                yield iname, insns_to_dup
+                yield iname, tuple(insn.union(common) for insn in insns_to_dup)
 
     # If partitioning was empty, we have recursed successfully and yield nothing
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -798,10 +798,12 @@ def duplicate_inames(knl, inames, within, new_inames=None, suffix=None,
 
 # {{{ iname duplication for schedulability
 
-def _get_iname_duplication_options(insn_deps):
+def _get_iname_duplication_options(insn_deps, old_common_inames=frozenset([])):
     # Remove common inames of the current insn_deps, as they are not relevant for splitting.
     common = frozenset([]).union(*insn_deps).intersection(*insn_deps)
     insn_deps = frozenset(dep - common for dep in insn_deps) - frozenset([frozenset([])])
+    # Join the common inames with those found in recursion
+    common = common.union(old_common_inames)
 
     # Try finding a partitioning of the remaining inames, such that all instructions
     # use only inames from one of the disjoint sets from the partitioning.
@@ -822,7 +824,7 @@ def _get_iname_duplication_options(insn_deps):
     if len(partitioning) > 1:
         for part in partitioning:
             working_set = frozenset(s for s in insn_deps if s.issubset(part))
-            for option in _get_iname_duplication_options(working_set):
+            for option in _get_iname_duplication_options(working_set, common):
                 yield option
     # If exactly one set was found, an iname duplication is necessary
     elif len(partitioning) == 1:

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1255,6 +1255,17 @@ def test_unschedulable_kernel_detection():
         fixed_knl = lp.duplicate_inames(knl, inames, insns)
         assert not lp.needs_iname_duplication(fixed_knl)
 
+    knl = lp.make_kernel(["{[i,j,k,l,m]:0<=i,j,k,l,m<n}"],
+                         """
+                         mat1[l,m,i,j,k] = mat1[l,m,i,j,k] + 1 {inames=i:j:k:l:m}
+                         mat2[l,m,j,k] = mat2[l,m,j,k] + 1 {inames=j:k:l:m}
+                         mat3[l,m,k] = mat3[l,m,k] + 11 {inames=k:l:m}
+                         mat4[l,m,i] = mat4[l,m,i] + 1 {inames=i:l:m}
+                         """)
+
+    assert lp.needs_iname_duplication(knl)
+    assert len([opt for opt in lp.get_iname_duplication_options(knl)]) == 10
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1249,7 +1249,7 @@ def test_unschedulable_kernel_detection():
 
     # Check that loopy can detect the unschedulability of the kernel
     assert lp.needs_iname_duplication(knl)
-    assert len([opt for opt in lp.get_iname_duplication_options(knl)]) == 4
+    assert len(list(lp.get_iname_duplication_options(knl))) == 4
 
     for inames, insns in lp.get_iname_duplication_options(knl):
         fixed_knl = lp.duplicate_inames(knl, inames, insns)
@@ -1264,7 +1264,7 @@ def test_unschedulable_kernel_detection():
                          """)
 
     assert lp.needs_iname_duplication(knl)
-    assert len([opt for opt in lp.get_iname_duplication_options(knl)]) == 10
+    assert len(list(lp.get_iname_duplication_options(knl))) == 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some kernels require the duplication of an iname to be logically schedulable.
This commit introduces an algorithm that lists such options. It also provides
a function to check whether such transformation is needed.

I finished and cleaned up the implementation from Warwick a bit.
The choice of names is of course delicate, I am totally open to suggestions there.
If you want something changed, extended, removed etc. just let me know.