### PR TITLE
Fixes use of lp.ConstantArg on input arrays

### DIFF
--- a/loopy/auto_test.py
+++ b/loopy/auto_test.py
@@ -198,7 +198,8 @@ def make_args(kernel, impl_arg_info, queue, ref_arg_data, parameters):
     import pyopencl as cl
     import pyopencl.array as cl_array
 
-    from loopy.kernel.data import ValueArg, GlobalArg, ImageArg, TemporaryVariable
+    from loopy.kernel.data import ValueArg, GlobalArg, ImageArg,\
+            TemporaryVariable, ConstantArg
 
     from pymbolic import evaluate
 
@@ -231,7 +232,8 @@ def make_args(kernel, impl_arg_info, queue, ref_arg_data, parameters):
             args[arg.name] = cl.image_from_array(
                     queue.context, arg_desc.ref_pre_run_array.get())
 
-        elif arg.arg_class is GlobalArg or arg.arg_class is ConstantArg:
+        elif arg.arg_class is GlobalArg or\
+                arg.arg_class is ConstantArg:
             shape = evaluate(arg.unvec_shape, parameters)
             strides = evaluate(arg.unvec_strides, parameters)
 

--- a/loopy/auto_test.py
+++ b/loopy/auto_test.py
@@ -79,7 +79,8 @@ def make_ref_args(kernel, impl_arg_info, queue, parameters):
     import pyopencl as cl
     import pyopencl.array as cl_array
 
-    from loopy.kernel.data import ValueArg, GlobalArg, ImageArg, TemporaryVariable
+    from loopy.kernel.data import ValueArg, GlobalArg, ImageArg, \
+            TemporaryVariable, ConstantArg
 
     from pymbolic import evaluate
 
@@ -107,7 +108,8 @@ def make_ref_args(kernel, impl_arg_info, queue, parameters):
 
             ref_arg_data.append(None)
 
-        elif arg.arg_class is GlobalArg or arg.arg_class is ImageArg:
+        elif arg.arg_class is GlobalArg or arg.arg_class is ImageArg \
+            or arg.arg_class is ConstantArg:
             if arg.shape is None or any(saxis is None for saxis in arg.shape):
                 raise LoopyError("array '%s' needs known shape to use automatic "
                         "testing" % arg.name)

--- a/loopy/auto_test.py
+++ b/loopy/auto_test.py
@@ -231,7 +231,7 @@ def make_args(kernel, impl_arg_info, queue, ref_arg_data, parameters):
             args[arg.name] = cl.image_from_array(
                     queue.context, arg_desc.ref_pre_run_array.get())
 
-        elif arg.arg_class is GlobalArg:
+        elif arg.arg_class is GlobalArg or arg.arg_class is ConstantArg:
             shape = evaluate(arg.unvec_shape, parameters)
             strides = evaluate(arg.unvec_strides, parameters)
 

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -211,7 +211,8 @@ class ExpressionToCExpressionMapper(IdentityMapper):
 
         elif isinstance(ary, (GlobalArg, TemporaryVariable, ConstantArg)):
             if len(access_info.subscripts) == 0:
-                if isinstance(ary, GlobalArg):
+                if isinstance(ary, GlobalArg) or\
+                    isinstance(ary, ConstantArg):
                     # unsubscripted global args are pointers
                     result = var(access_info.array_name)[0]
 

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -176,7 +176,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                 lambda expr: evaluate(expr, self.codegen_state.var_subst_map),
                 self.codegen_state.vectorization_info)
 
-        from loopy.kernel.data import ImageArg, GlobalArg, TemporaryVariable
+        from loopy.kernel.data import ImageArg, GlobalArg, TemporaryVariable, ConstantArg
 
         if isinstance(ary, ImageArg):
             extra_axes = 0
@@ -209,7 +209,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                 raise NotImplementedError(
                         "non-floating-point images not supported for now")
 
-        elif isinstance(ary, (GlobalArg, TemporaryVariable)):
+        elif isinstance(ary, (GlobalArg, TemporaryVariable, ConstantArg)):
             if len(access_info.subscripts) == 0:
                 if isinstance(ary, GlobalArg):
                     # unsubscripted global args are pointers

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -486,11 +486,11 @@ class OpenCLCASTBuilder(CASTBuilder):
         return CLImage(num_target_axes, mode, name)
 
     def get_constant_arg_decl(self, name, shape, dtype, is_written):
-        from loopy.codegen import POD  # uses the correct complex type
+        from loopy.target.c import POD  # uses the correct complex type
         from cgen import RestrictPointer, Const
         from cgen.opencl import CLConstant
 
-        arg_decl = RestrictPointer(POD(dtype, name))
+        arg_decl = RestrictPointer(POD(self, dtype, name))
 
         if not is_written:
             arg_decl = Const(arg_decl)

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1459,6 +1459,25 @@ def test_unr_and_conditionals(ctx_factory):
 
     lp.auto_test_vs_ref(ref_knl, ctx, knl)
 
+def test_constant_array_args(ctx_factory):
+    ctx = ctx_factory()
+
+    knl = lp.make_kernel('{[k]: 0<=k<n}}',
+         """
+         for k
+             <> Tcond[k] = T[k] < 0.5
+             if Tcond[k]
+                 cp[k] = 2 * T[k] + Tcond[k]
+             end
+         end
+         """,
+         [lp.ConstantArg('T', shape=(200,), dtype=np.float32),
+         '...'])
+
+    knl = lp.fix_parameters(knl, n=200)
+
+    print(lp.generate_code_v2(knl).device_code())
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:


### PR DESCRIPTION
Previously use of a ConstantArg would cause an error in `loopy/target/c/codegen/expression.py:253`.
This fix re-enables ConstantArgs, and adds a simple test to `test/test_loopy.py`