### PR TITLE
Minor fix for global temporary declarations in C-based targets

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -334,7 +334,7 @@ class CASTBuilder(ASTBuilderBase):
                                 index_dtype=kernel.index_dtype)
                 decl = self.wrap_global_constant(
                         self.get_temporary_decl(
-                            kernel, schedule_index, tv,
+                            codegen_state, schedule_index, tv,
                             decl_info))
 
                 if tv.initializer is not None:


### PR DESCRIPTION
get_temporary_decl expects the codegen_state.