### PR TITLE
Doc fixes

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -1064,6 +1064,27 @@ More complicated programs
 
 SCOP
 
+External Functions
+~~~~~~~~~~~~~~~~~~
+
+Loopy currently supports calls to several commonly used mathematical functions,
+e.g. exp/log, min/max, sin/cos/tan, sinh/cosh, abs, etc.  They may be used in
+a loopy kernel by simply calling them, e.g.::
+
+    knl = lp.make_kernel(
+            "{ [i]: 0<=i<n }",
+            """
+            for i
+                a[i] = sqrt(i)
+            end
+            """)
+
+Additionally, all functions of one variable are currently recognized during
+code-generation however additional implementation may be required for custom
+functions.  The full lists of available functions may be found in a the
+:class:`TargetBase` implementation (e.g. :class:`CudaTarget`)
+
+
 Data-dependent control flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -1084,6 +1084,8 @@ code-generation however additional implementation may be required for custom
 functions.  The full lists of available functions may be found in a the
 :class:`TargetBase` implementation (e.g. :class:`CudaTarget`)
 
+Custom user functions may be represented using the method described in :ref:`_functions`
+
 
 Data-dependent control flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -214,6 +214,7 @@ class KernelArgument(Record):
 
 
 class GlobalArg(ArrayBase, KernelArgument):
+    __doc__ = ArrayBase.__doc__
     min_target_axes = 0
     max_target_axes = 1
 
@@ -223,6 +224,7 @@ class GlobalArg(ArrayBase, KernelArgument):
 
 
 class ConstantArg(ArrayBase, KernelArgument):
+    __doc__ = ArrayBase.__doc__
     min_target_axes = 0
     max_target_axes = 1
 
@@ -232,6 +234,7 @@ class ConstantArg(ArrayBase, KernelArgument):
 
 
 class ImageArg(ArrayBase, KernelArgument):
+    __doc__ = ArrayBase.__doc__
     min_target_axes = 1
     max_target_axes = 3
 


### PR DESCRIPTION
A few minor proposed documentation tweaks:

1.  Make it clear that the ArrayBase args are in the various GlobalArg, ConstantArg, etc. by adding them to the documentation.
2.  Add a note on function calls that are currently recognized by Loopy. 
3.  Direct more complicated function queries to the (as yet fairly undocumented) methods in the Functions section