### PR TITLE
small fix in get_slab_decomposition

### DIFF
--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -90,7 +90,7 @@ def get_slab_decomposition(kernel, iname):
                         iname_rel_aff(space,
                             iname, "<=", upper_bound_aff-upper_incr)))
         else:
-            lower_slab = None
+            upper_slab = None
 
         slabs = []
 


### PR DESCRIPTION
The variable `upper_slab` was referenced without initialisation. I suppose that was a typo. 
This causes a crash in the code generation (maybe earlier?) if a kernel with initial slab but no final slab was created. Example:
```
import loopy as lp

knl = lp.make_kernel("{[i]: 0<=i<10}",
                     "out[i] = 2",
                     iname_slab_increments={'i':(1,0)})

print(lp.generate_code_v2(knl).device_code())
```