### PR TITLE
WIP: Batched get_usable_inames_for_conditional

### DIFF
--- a/loopy/codegen/bounds.py
+++ b/loopy/codegen/bounds.py
@@ -74,10 +74,10 @@ def get_usable_inames_for_conditional(kernel, sched_indices):
         insn_ids_for_subkernel = get_insn_ids_for_block_at(
                 kernel.schedule, subknl_idx)
 
-        all_inames_in_the_subknl = [
+        all_inames_in_the_subknl = set([
             iname
             for insn in insn_ids_for_subkernel
-            for iname in kernel.insn_inames(insn)]
+            for iname in kernel.insn_inames(insn)])
 
         def is_eligible_in_conditional(iname):
             # Parallel inames are defined within a subkernel, BUT:

--- a/loopy/codegen/bounds.py
+++ b/loopy/codegen/bounds.py
@@ -75,10 +75,10 @@ def get_usable_inames_for_conditional(kernel, sched_indices):
         insn_ids_for_subkernel = get_insn_ids_for_block_at(
                 kernel.schedule, subknl_idx)
 
-        inames_for_subkernel[subknl_idx] = (
+        inames_for_subkernel[subknl_idx] = [
             iname
             for insn in insn_ids_for_subkernel
-            for iname in kernel.insn_inames(insn))
+            for iname in kernel.insn_inames(insn)]
 
     result = []
 

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -279,15 +279,17 @@ def build_loop_nest(codegen_state, schedule_index):
     from loopy.schedule import find_used_inames_within
     from loopy.codegen.bounds import get_usable_inames_for_conditional
 
+    admissible_cond_inames = get_usable_inames_for_conditional(kernel,
+            my_sched_indices)
+
     sched_index_info_entries = [
             ScheduleIndexInfo(
-                schedule_indices=[i],
-                admissible_cond_inames=(
-                    get_usable_inames_for_conditional(kernel, i)),
-                required_predicates=get_required_predicates(kernel, i),
-                used_inames_within=find_used_inames_within(kernel, i)
+                schedule_indices=[my_sched_idx],
+                admissible_cond_inames=admissible_cond_inames[i],
+                required_predicates=get_required_predicates(kernel, my_sched_idx),
+                used_inames_within=find_used_inames_within(kernel, my_sched_idx)
                 )
-            for i in my_sched_indices
+            for i, my_sched_idx in enumerate(my_sched_indices)
             ]
 
     sched_index_info_entries = group_by(

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -358,7 +358,7 @@ def generate_sequential_loop_dim_code(codegen_state, sched_index):
     from loopy.codegen.bounds import get_usable_inames_for_conditional
 
     # Note: this does not include loop_iname itself!
-    usable_inames = get_usable_inames_for_conditional(kernel, (sched_index,))
+    usable_inames, = get_usable_inames_for_conditional(kernel, (sched_index,))
     domain = kernel.get_inames_domain(loop_iname)
 
     result = []

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -358,7 +358,7 @@ def generate_sequential_loop_dim_code(codegen_state, sched_index):
     from loopy.codegen.bounds import get_usable_inames_for_conditional
 
     # Note: this does not include loop_iname itself!
-    usable_inames = get_usable_inames_for_conditional(kernel, sched_index)
+    usable_inames = get_usable_inames_for_conditional(kernel, (sched_index,))
     domain = kernel.get_inames_domain(loop_iname)
 
     result = []

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -529,7 +529,7 @@ def get_subkernel_indices(kernel, sched_indices):
 
         if sched_idx == (sorted_sched_indices[0]-1):
             sched_idx_to_subkernel_idx[sched_idx+1] = subkernel_index
-            sorted_sched_indices.pop()
+            sorted_sched_indices.pop(0)
 
     # eventually everythin should be popped
     assert sorted_sched_indices in ([], [0])

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -190,8 +190,13 @@ def find_active_inames_at(kernel, sched_indices):
 
     from loopy.schedule import EnterLoop, LeaveLoop
 
+    max_sched_idx = sorted_sched_indices[-1]
+
+    if sorted_sched_indices and sorted_sched_indices[0] == 0:
+        sorted_sched_indices.pop(0)
+
     for sched_idx, sched_item in enumerate(
-            kernel.schedule[:sorted_sched_indices[-1]]):
+            kernel.schedule[:max_sched_idx]):
         if isinstance(sched_item, EnterLoop):
             active_inames.append(sched_item.iname)
         if isinstance(sched_item, LeaveLoop):
@@ -202,7 +207,7 @@ def find_active_inames_at(kernel, sched_indices):
             sorted_sched_indices.pop(0)
 
     # eventually everythin should be popped
-    assert sorted_sched_indices in ([], [0])
+    assert len(sorted_sched_indices) == 0
 
     return [sched_idx_to_active_inames[idx] for idx in sched_indices]
 
@@ -520,8 +525,13 @@ def get_subkernel_indices(kernel, sched_indices):
     sorted_sched_indices = sorted(sched_indices)
     sched_idx_to_subkernel_idx = {0: None}
 
+    max_sched_idx = sorted_sched_indices[-1]
+
+    if sorted_sched_indices and sorted_sched_indices[0] == 0:
+        sorted_sched_indices.pop(0)
+
     for sched_idx, sched_item in enumerate(
-            kernel.schedule[:sorted_sched_indices[-1]]):
+            kernel.schedule[:max_sched_idx]):
         if isinstance(sched_item, CallKernel):
             subkernel_index = sched_idx
         elif isinstance(sched_item, ReturnFromKernel):
@@ -532,7 +542,7 @@ def get_subkernel_indices(kernel, sched_indices):
             sorted_sched_indices.pop(0)
 
     # eventually everythin should be popped
-    assert sorted_sched_indices in ([], [0])
+    assert len(sorted_sched_indices) == 0
 
     return [sched_idx_to_subkernel_idx[sched_idx] for sched_idx in
             sched_indices]


### PR DESCRIPTION
- `get_usable_inames_for_conditional` has been reported at multiple occasions to be time consuming (see #117 for some examples)
 - Here the operation complexity  in of the codegen phase is brought down by sharing equivalent operations across  invocations of `get_usable_inames_for_conditional`.