### PR TITLE
Bounds check improvements, BoundsCheckError

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -24,7 +24,8 @@ THE SOFTWARE.
 from islpy import dim_type
 import islpy as isl
 from loopy.symbolic import WalkMapper
-from loopy.diagnostic import LoopyError, WriteRaceConditionWarning, warn_with_kernel
+from loopy.diagnostic import (LoopyError, BoundsCheckError,
+        WriteRaceConditionWarning, warn_with_kernel)
 from loopy.type_inference import TypeInferenceMapper
 from loopy.kernel.instruction import (MultiAssignmentBase, CallInstruction,
         CInstruction, _DataObliviousInstruction)
@@ -438,7 +439,7 @@ class _AccessCheckMapper(WalkMapper):
                     shape_domain = shape_domain.intersect(slab)
 
             if not access_range.is_subset(shape_domain):
-                raise LoopyError("'%s' in instruction '%s' "
+                raise BoundsCheckError("'%s' in instruction '%s' "
                         "accesses out-of-bounds array element (could not"
                         " establish '%s' is a subset of '%s')."
                         % (expr, self.insn_id, access_range, shape_domain))

--- a/loopy/diagnostic.py
+++ b/loopy/diagnostic.py
@@ -125,6 +125,10 @@ class VariableAccessNotOrdered(LoopyError):
 class DependencyCycleFound(LoopyError):
     pass
 
+
+class BoundsCheckError(LoopyError):
+    pass
+
 # }}}
 
 


### PR DESCRIPTION
#162 has made loopy quite strict in its bounds checking. (cf. https://github.com/inducer/meshmode/issues/81) That's probably a good direction, but we need to

- [ ] improve what `assume` can do in order to counter all those new bounds check failures.
- [ ] make an option to turn bounds checking off, for emergencies.

cc @kaushikcfd 