### PR TITLE
LoopKernel.insn_inames(insn: InstructionBase) -> insn.within_inames

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -215,7 +215,7 @@ def check_for_double_use_of_hw_axes(kernel):
 
     for insn in kernel.instructions:
         insn_tag_keys = set()
-        for iname in kernel.insn_inames(insn):
+        for iname in insn.within_inames:
             for tag in kernel.iname_tags_of_type(iname, UniqueTag):
                 key = tag.key
                 if key in insn_tag_keys:
@@ -232,12 +232,12 @@ def check_for_inactive_iname_access(kernel):
     for insn in kernel.instructions:
         expression_inames = insn.read_dependency_names() & kernel.all_inames()
 
-        if not expression_inames <= kernel.insn_inames(insn):
+        if not expression_inames <= insn.within_inames:
             raise LoopyError(
                     "instruction '%s' references "
                     "inames '%s' that the instruction does not depend on"
                     % (insn.id,
-                        ", ".join(expression_inames - kernel.insn_inames(insn))))
+                        ", ".join(expression_inames - insn.within_inames)))
 
 
 def check_for_unused_inames(kernel):
@@ -293,7 +293,7 @@ def check_for_write_races(kernel):
                 insn.assignee_var_names(),
                 insn.assignee_subscript_deps()):
             assignee_inames = assignee_indices & kernel.all_inames()
-            if not assignee_inames <= kernel.insn_inames(insn):
+            if not assignee_inames <= insn.within_inames:
                 raise LoopyError(
                         "assignee of instructions '%s' references "
                         "iname that the instruction does not depend on"
@@ -304,13 +304,13 @@ def check_for_write_races(kernel):
                 # will cause write races.
 
                 raceable_parallel_insn_inames = {
-                    iname for iname in kernel.insn_inames(insn)
+                    iname for iname in insn.within_inames
                     if kernel.iname_tags_of_type(iname, ConcurrentTag)}
 
             elif assignee_name in kernel.temporary_variables:
                 temp_var = kernel.temporary_variables[assignee_name]
                 raceable_parallel_insn_inames = {
-                        iname for iname in kernel.insn_inames(insn)
+                        iname for iname in insn.within_inames
                         if any(_is_racing_iname_tag(temp_var, tag)
                             for tag in kernel.iname_tags(iname))}
 
@@ -491,7 +491,7 @@ def check_write_destinations(kernel):
             if wvar in kernel.all_inames():
                 raise LoopyError("iname '%s' may not be written" % wvar)
 
-            insn_domain = kernel.get_inames_domain(kernel.insn_inames(insn))
+            insn_domain = kernel.get_inames_domain(insn.within_inames)
             insn_params = set(insn_domain.get_var_names(dim_type.param))
 
             if wvar in kernel.all_params():
@@ -936,7 +936,7 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, sched_index=None):
             group_axes_used = set()
             local_axes_used = set()
 
-            for iname in kernel.insn_inames(insn):
+            for iname in insn.within_inames:
                 ltags = kernel.iname_tags_of_type(iname, LocalIndexTag, max_num=1)
                 gtags = kernel.iname_tags_of_type(iname, GroupIndexTag, max_num=1)
                 altags = kernel.iname_tags_of_type(
@@ -1192,7 +1192,7 @@ def check_implemented_domains(kernel, implemented_domains, code=None):
 
         assert idomains
 
-        insn_inames = kernel.insn_inames(insn)
+        insn_inames = insn.within_inames
 
         # {{{ if we've checked the same thing before, no need to check it again
 
@@ -1269,7 +1269,7 @@ def check_implemented_domains(kernel, implemented_domains, code=None):
 
                 iname_to_dim = pt.get_space().get_var_dict()
                 point_axes = []
-                for iname in kernel.insn_inames(insn) | parameter_inames:
+                for iname in insn_inames | parameter_inames:
                     tp, dim = iname_to_dim[iname]
                     point_axes.append("%s=%d" % (
                         iname, pt.get_coordinate_val(tp, dim).to_python()))

--- a/loopy/codegen/instruction.py
+++ b/loopy/codegen/instruction.py
@@ -89,7 +89,7 @@ def generate_instruction_code(codegen_state, insn):
     else:
         raise RuntimeError("unexpected instruction type")
 
-    insn_inames = kernel.insn_inames(insn)
+    insn_inames = insn.within_inames
 
     return to_codegen_result(
             codegen_state,

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -824,7 +824,7 @@ class LoopKernel(ImmutableRecordWithoutPickling):
         result = {
                 iname: set() for iname in self.all_inames()}
         for insn in self.instructions:
-            for iname in self.insn_inames(insn):
+            for iname in insn.within_inames:
                 result[iname].add(insn.id)
 
         return result

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -1523,7 +1523,7 @@ def determine_shapes_of_temporaries(knl):
     def feed_all_expressions(receiver):
         for insn in knl.instructions:
             insn.with_transformed_expressions(
-                lambda expr: receiver(expr, knl.insn_inames(insn)))
+                lambda expr: receiver(expr, insn.within_inames))
 
     var_to_base_indices, var_to_shape, var_to_error = (
         find_shapes_of_vars(
@@ -1543,7 +1543,7 @@ def determine_shapes_of_temporaries(knl):
         def feed_assignee_of_instruction(receiver):
             for insn in knl.instructions:
                 for assignee in insn.assignees:
-                    receiver(assignee, knl.insn_inames(insn))
+                    receiver(assignee, insn.within_inames)
 
         var_to_base_indices_fallback, var_to_shape_fallback, var_to_error = (
             find_shapes_of_vars(

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -685,7 +685,7 @@ def get_auto_axis_iname_ranking_by_stride(kernel, insn):
 
     from loopy.kernel.data import AutoLocalIndexTagBase
     auto_axis_inames = {
-        iname for iname in kernel.insn_inames(insn)
+        iname for iname in insn.within_inames
         if kernel.iname_tags_of_type(iname, AutoLocalIndexTagBase)}
 
     # }}}
@@ -744,7 +744,7 @@ def get_auto_axis_iname_ranking_by_stride(kernel, insn):
     if aggregate_strides:
         very_large_stride = int(np.iinfo(np.int32).max)
 
-        return sorted((iname for iname in kernel.insn_inames(insn)),
+        return sorted((iname for iname in insn.within_inames),
                 key=lambda iname: (
                     aggregate_strides.get(iname, very_large_stride),
                     iname))
@@ -885,7 +885,7 @@ def assign_automatic_axes(kernel, axis=0, local_size=None):
             continue
 
         auto_axis_inames = [
-            iname for iname in kernel.insn_inames(insn)
+            iname for iname in insn.within_inames
             if kernel.iname_tags_of_type(iname, AutoLocalIndexTagBase)]
 
         if not auto_axis_inames:
@@ -893,7 +893,7 @@ def assign_automatic_axes(kernel, axis=0, local_size=None):
 
         assigned_local_axes = set()
 
-        for iname in kernel.insn_inames(insn):
+        for iname in insn.within_inames:
             tags = kernel.iname_tags_of_type(iname, LocalIndexTag, max_num=1)
             if tags:
                 tag, = tags
@@ -1000,7 +1000,7 @@ def guess_var_shape(kernel, var_name):
     submap = SubstitutionRuleExpander(kernel.substitutions)
 
     def run_through_armap(expr):
-        armap(submap(expr), kernel.insn_inames(insn))
+        armap(submap(expr), insn.within_inames)
         return expr
 
     try:
@@ -1533,7 +1533,7 @@ def stringify_instruction_list(kernel):
             raise LoopyError("unexpected instruction type: %s"
                     % type(insn).__name__)
 
-        adapt_to_new_inames_list(kernel.insn_inames(insn))
+        adapt_to_new_inames_list(insn.within_inames)
 
         options = ["id="+Fore.GREEN+insn.id+Style.RESET_ALL]
         if insn.priority:

--- a/loopy/preprocess.py
+++ b/loopy/preprocess.py
@@ -1004,7 +1004,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
 
     def map_reduction_seq(expr, rec, nresults, arg_dtypes,
             reduction_dtypes):
-        outer_insn_inames = temp_kernel.insn_inames(insn)
+        outer_insn_inames = insn.within_inames
 
         from loopy.kernel.data import AddressSpace
         acc_var_names = make_temporaries(
@@ -1041,7 +1041,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
         update_id = insn_id_gen(
                 based_on="{}_{}_update".format(insn.id, "_".join(expr.inames)))
 
-        update_insn_iname_deps = temp_kernel.insn_inames(insn) | set(expr.inames)
+        update_insn_iname_deps = insn.within_inames | set(expr.inames)
         if insn.within_inames_is_final:
             update_insn_iname_deps = insn.within_inames | set(expr.inames)
 
@@ -1126,7 +1126,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
 
         size = _get_int_iname_size(red_iname)
 
-        outer_insn_inames = temp_kernel.insn_inames(insn)
+        outer_insn_inames = insn.within_inames
 
         from loopy.kernel.data import LocalIndexTagBase
         outer_local_inames = tuple(oiname for oiname in outer_insn_inames
@@ -1363,7 +1363,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
     def map_scan_seq(expr, rec, nresults, arg_dtypes,
             reduction_dtypes, sweep_iname, scan_iname, sweep_min_value,
             scan_min_value, stride):
-        outer_insn_inames = temp_kernel.insn_inames(insn)
+        outer_insn_inames = insn.within_inames
         inames_to_remove.add(scan_iname)
 
         track_iname = var_name_gen(
@@ -1417,7 +1417,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
         update_id = insn_id_gen(
                 based_on="{}_{}_update".format(insn.id, "_".join(expr.inames)))
 
-        update_insn_iname_deps = temp_kernel.insn_inames(insn) | {track_iname}
+        update_insn_iname_deps = insn.within_inames | {track_iname}
         if insn.within_inames_is_final:
             update_insn_iname_deps = insn.within_inames | {track_iname}
 
@@ -1461,7 +1461,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
             return map_reduction_seq(
                     expr, rec, nresults, arg_dtypes, reduction_dtypes)
 
-        outer_insn_inames = temp_kernel.insn_inames(insn)
+        outer_insn_inames = insn.within_inames
 
         from loopy.kernel.data import LocalIndexTagBase
         outer_local_inames = tuple(oiname for oiname in outer_insn_inames
@@ -1668,7 +1668,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
                 infer_arg_and_reduction_dtypes_for_reduction_expression(
                         temp_kernel, expr, unknown_types_ok))
 
-        outer_insn_inames = temp_kernel.insn_inames(insn)
+        outer_insn_inames = insn.within_inames
         bad_inames = frozenset(expr.inames) & outer_insn_inames
         if bad_inames:
             raise LoopyError("reduction used within loop(s) that it was "
@@ -1854,7 +1854,7 @@ def realize_reduction(kernel, insn_id_filter=None, unknown_types_ok=True,
                     no_sync_with=insn.no_sync_with
                     | frozenset(new_insn_add_no_sync_with),
                     within_inames=(
-                        temp_kernel.insn_inames(insn)
+                        insn.within_inames
                         | new_insn_add_within_inames))
 
             kwargs.pop("id")

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -296,7 +296,7 @@ def find_loop_insn_dep_map(kernel, loop_nest_with_map, loop_nest_around_map):
                     continue
 
                 dep_insn = kernel.id_to_insn[dep_insn_id]
-                dep_insn_inames = kernel.insn_inames(dep_insn)
+                dep_insn_inames = dep_insn.within_inames
 
                 if iname in dep_insn_inames:
                     # Nothing to be learned, dependency is in loop over iname
@@ -940,7 +940,7 @@ def generate_loop_schedules_internal(
         if not is_ready:
             continue
 
-        want = kernel.insn_inames(insn) - sched_state.parallel_inames
+        want = insn.within_inames - sched_state.parallel_inames
         have = active_inames_set - sched_state.parallel_inames
 
         if want != have:
@@ -1106,7 +1106,7 @@ def generate_loop_schedules_internal(
 
             for insn_id in sched_state.unscheduled_insn_ids:
                 insn = kernel.id_to_insn[insn_id]
-                if last_entered_loop in kernel.insn_inames(insn):
+                if last_entered_loop in insn.within_inames:
                     if debug_mode:
                         print("cannot leave '%s' because '%s' still depends on it"
                                 % (last_entered_loop, format_insn(kernel, insn.id)))
@@ -1294,7 +1294,7 @@ def generate_loop_schedules_internal(
             for insn_id in reachable_insn_ids:
                 insn = kernel.id_to_insn[insn_id]
 
-                want = kernel.insn_inames(insn)
+                want = insn.within_inames
 
                 if hypothetically_active_loops <= want:
                     if usefulness is None:

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1239,7 +1239,7 @@ def get_unused_hw_axes_factor(knl, insn, disregard_local_axes, space=None):
     l_used = set()
 
     from loopy.kernel.data import LocalIndexTag, GroupIndexTag
-    for iname in knl.insn_inames(insn):
+    for iname in insn.within_inames:
         tags = knl.iname_tags_of_type(iname,
                               (LocalIndexTag, GroupIndexTag), max_num=1)
         if tags:
@@ -1273,7 +1273,7 @@ def get_unused_hw_axes_factor(knl, insn, disregard_local_axes, space=None):
 
 def count_insn_runs(knl, insn, count_redundant_work, disregard_local_axes=False):
 
-    insn_inames = knl.insn_inames(insn)
+    insn_inames = insn.within_inames
 
     if disregard_local_axes:
         from loopy.kernel.data import LocalIndexTag

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -2118,7 +2118,7 @@ class AccessRangeOverlapChecker:
         arm = BatchedAccessRangeMapper(self.kernel, self.vars, overestimate=True)
 
         for expr in exprs:
-            arm(expr, self.kernel.insn_inames(insn))
+            arm(expr, insn.within_inames)
 
         for name, arange in arm.access_ranges.items():
             if arm.bad_subscripts[name]:

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1609,7 +1609,7 @@ def find_unused_axis_tag(kernel, kind, insn_match=None):
     insns = [insn for insn in kernel.instructions if match(kernel, insn)]
 
     for insn in insns:
-        for iname in kernel.insn_inames(insn):
+        for iname in insn.within_inames:
             if kernel.iname_tags_of_type(iname, kind):
                 used_axes.add(kind.axis)
 

--- a/loopy/transform/privatize.py
+++ b/loopy/transform/privatize.py
@@ -124,7 +124,7 @@ def privatize_temporaries_with_inames(
         for writer_insn_id in wmap.get(tv.name, []):
             writer_insn = kernel.id_to_insn[writer_insn_id]
 
-            priv_axis_inames = kernel.insn_inames(writer_insn) & privatizing_inames
+            priv_axis_inames = writer_insn.within_inames & privatizing_inames
 
             referenced_priv_axis_inames = (priv_axis_inames
                     & writer_insn.write_dependency_names())


### PR DESCRIPTION
Simple fix to get ~25% speedup in the scheduling stage for the kernel in #178.
```
(loopy-dev) kgk2@koelsch:~/loopy$ echo $LOOPY_NO_CACHE 
1
(loopy-dev) kgk2@koelsch:~/loopy$ git checkout master 
Already on 'master'
Your branch is up to date with 'origin/master'.
(loopy-dev) kgk2@koelsch:~/oopy$ python disjoint_loop_nests.py 
INFO:loopy.schedule:loopy_kernel: schedule: completed (78.36s wall, 1.0x CPU)
(loopy-dev) kgk2@koelsch:~/loopy$ git checkout replace_insn_inames 
Switched to branch 'replace_insn_inames'
(loopy-dev) kgk2@koelsch:~/loopy$ python disjoint_loop_nests.py                                                                                                                                            
INFO:loopy.schedule:loopy_kernel: schedule: completed (60.10s wall, 1.0x CPU)
```