### PR TITLE
Fixes int-exponent exponentiation for C-like targets

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -130,6 +130,41 @@ def check_for_integer_subscript_indices(kernel):
                 type(insn).__name__))
 
 
+class ExponentIsUnsignedChecker(TypeInferenceMapper):
+    def map_power(self, expr):
+        res_dtype = super().map_power(expr)
+        exp_dtype = self.rec(expr.exponent)
+        if not res_dtype:
+            raise LoopyError(
+                "When checking for unsigned exponents for int-int"
+                f"pow expressions, type inference did not find type of {expr}.")
+
+        if res_dtype[0].is_integral():
+            if exp_dtype[0].numpy_dtype.kind == "i":
+                raise LoopyError("Integers to signed integer powers are not"
+                        " allowed.")
+
+        return res_dtype
+
+
+def check_int_pow_has_unsigned_exponent(kernel):
+    """
+    Checks that all expressions of the ``a**b``, where both ``a``
+    and ``b`` are integers (signed or unsigned) have exponents of type
+    unsigned.
+    """
+    exp_is_uint_checker = ExponentIsUnsignedChecker(kernel)
+    for insn in kernel.instructions:
+        if isinstance(insn, MultiAssignmentBase):
+            exp_is_uint_checker(insn.expression, return_tuple=isinstance(insn,
+                CallInstruction), return_dtype_set=True)
+        elif isinstance(insn, (CInstruction, _DataObliviousInstruction)):
+            pass
+        else:
+            raise NotImplementedError("Unknown insn type %s." % (
+                type(insn).__name__))
+
+
 def check_insn_attributes(kernel):
     """
     Check for legality of attributes of every instruction in *kernel*.
@@ -801,6 +836,7 @@ def pre_schedule_checks(kernel):
         logger.debug("%s: pre-schedule check: start" % kernel.name)
 
         check_for_integer_subscript_indices(kernel)
+        check_int_pow_has_unsigned_exponent(kernel)
         check_for_duplicate_insn_ids(kernel)
         check_for_orphaned_user_hardware_axes(kernel)
         check_for_double_use_of_hw_axes(kernel)

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -152,7 +152,7 @@ class SeenFunction(ImmutableRecord):
         a tuple of result dtypes
     """
 
-    def __init__(self, name, c_name, arg_dtypes, result_dtypes=()):
+    def __init__(self, name, c_name, arg_dtypes, result_dtypes):
         ImmutableRecord.__init__(self,
                 name=name,
                 c_name=c_name,

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -147,17 +147,17 @@ class SeenFunction(ImmutableRecord):
 
         a tuple of arg dtypes
 
-    .. attribute:: res_dtypes
+    .. attribute:: result_dtypes
 
         a tuple of result dtypes
     """
 
-    def __init__(self, name, c_name, arg_dtypes, res_dtypes=()):
+    def __init__(self, name, c_name, arg_dtypes, result_dtypes=()):
         ImmutableRecord.__init__(self,
                 name=name,
                 c_name=c_name,
                 arg_dtypes=arg_dtypes,
-                res_dtypes=res_dtypes)
+                result_dtypes=result_dtypes)
 
 
 class CodeGenerationState:

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -146,13 +146,18 @@ class SeenFunction(ImmutableRecord):
     .. attribute:: arg_dtypes
 
         a tuple of arg dtypes
+
+    .. attribute:: res_dtypes
+
+        a tuple of result dtypes
     """
 
-    def __init__(self, name, c_name, arg_dtypes):
+    def __init__(self, name, c_name, arg_dtypes, res_dtypes=()):
         ImmutableRecord.__init__(self,
                 name=name,
                 c_name=c_name,
-                arg_dtypes=arg_dtypes)
+                arg_dtypes=arg_dtypes,
+                res_dtypes=res_dtypes)
 
 
 class CodeGenerationState:

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -179,7 +179,7 @@ def _preamble_generator(preamble_info):
             exp_ctype = preamble_info.kernel.target.dtype_to_typename(
                     func.arg_dtypes[1])
             res_ctype = preamble_info.kernel.target.dtype_to_typename(
-                    func.res_dtypes[0])
+                    func.result_dtypes[0])
 
             if func.arg_dtypes[1].numpy_dtype.kind == "u":
                 signed_exponent_preamble = ""

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -497,7 +497,7 @@ def c_math_mangler(target, name, arg_dtypes, modify_name=True):
             [], [dtype.numpy_dtype for dtype in arg_dtypes])
 
         if dtype.kind == "c":
-            raise LoopyTypeError("%s does not support complex numbers")
+            raise LoopyTypeError(f"{name} does not support complex numbers")
 
         elif dtype.kind == "f":
             if modify_name:
@@ -516,6 +516,17 @@ def c_math_mangler(target, name, arg_dtypes, modify_name=True):
                     target_name=name,
                     result_dtypes=(result_dtype,),
                     arg_dtypes=2*(result_dtype,))
+
+    if name == "pow" and len(arg_dtypes) == 2:
+        if any(dtype.is_complex() == "c" for dtype in arg_dtypes):
+            raise LoopyTypeError(f"{name} does not support complex numbers")
+
+        f64_dtype = NumpyType(np.float64)
+
+        # math.h only provides double pow(double, double)
+        return CallMangleInfo(target_name=name,
+                              arg_dtypes=(f64_dtype, f64_dtype),
+                              result_dtypes=(f64_dtype,))
 
     return None
 

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -172,6 +172,31 @@ def _preamble_generator(preamble_info):
             yield ("04_%s" % func_name, func_body)
             yield undef_integer_types_macro
 
+    for func in preamble_info.seen_functions:
+        if func.name == "int_pow":
+            base_ctype = preamble_info.kernel.target.dtype_to_typename(
+                    func.arg_dtypes[0])
+            exp_ctype = preamble_info.kernel.target.dtype_to_typename(
+                    func.arg_dtypes[1])
+
+            yield("07_int_pow", f"""
+            inline {base_ctype} {func.c_name}({base_ctype} b, {exp_ctype} n) {{
+              if (n == 0)
+                return 1
+
+              {base_ctype} y = 1;
+
+              while (n > 1) {{
+                if (n % 2) {{
+                  x = x * x;
+                  y = x * y;
+                }}
+                else
+                  x = x * x;
+                n = n / 2;
+              }}
+            }}""")
+
 # }}}
 
 

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -981,7 +981,8 @@ class CFamilyASTBuilder(ASTBuilderBase):
         codegen_state.seen_functions.add(
                 SeenFunction(func_id,
                     mangle_result.target_name,
-                    mangle_result.arg_dtypes))
+                    mangle_result.arg_dtypes,
+                    mangle_result.result_dtypes))
 
         from pymbolic import var
         for i, (a, tgt_dtype) in enumerate(

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -34,6 +34,9 @@ from loopy.symbolic import IdentityMapper
 from loopy.types import NumpyType
 import pymbolic.primitives as p
 
+from loopy.tools import remove_common_indentation
+import re
+
 from pytools import memoize_method
 
 __doc__ = """
@@ -184,17 +187,18 @@ def _preamble_generator(preamble_info):
             if func.arg_dtypes[1].numpy_dtype.kind == "u":
                 signed_exponent_preamble = ""
             else:
-                signed_exponent_preamble = """
-              if (n < 0) {
-                x = 1.0/x;
-                n =  -n;
-              }"""
+                signed_exponent_preamble = "\n" + remove_common_indentation(
+                        """
+                        if (n < 0) {
+                          x = 1.0/x;
+                          n =  -n;
+                        }""")
 
             yield("07_int_pow", f"""
             inline {res_ctype} {func.c_name}({base_ctype} x, {exp_ctype} n) {{
               if (n == 0)
                 return 1;
-              {signed_exponent_preamble}
+              {re.sub("^", 14*" ", signed_exponent_preamble, flags=re.M)}
 
               {res_ctype} y = 1;
 

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -490,7 +490,7 @@ def c_math_mangler(target, name, arg_dtypes, modify_name=True):
                 arg_dtypes=arg_dtypes)
 
     # binary functions
-    if (name in ["fmax", "fmin", "copysign"]
+    if (name in ["fmax", "fmin", "copysign", "pow"]
             and len(arg_dtypes) == 2):
 
         dtype = np.find_common_type(
@@ -516,17 +516,6 @@ def c_math_mangler(target, name, arg_dtypes, modify_name=True):
                     target_name=name,
                     result_dtypes=(result_dtype,),
                     arg_dtypes=2*(result_dtype,))
-
-    if name == "pow" and len(arg_dtypes) == 2:
-        if any(dtype.is_complex() == "c" for dtype in arg_dtypes):
-            raise LoopyTypeError(f"{name} does not support complex numbers")
-
-        f64_dtype = NumpyType(np.float64)
-
-        # math.h only provides double pow(double, double)
-        return CallMangleInfo(target_name=name,
-                              arg_dtypes=(f64_dtype, f64_dtype),
-                              result_dtypes=(f64_dtype,))
 
     return None
 

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -194,7 +194,7 @@ def _preamble_generator(preamble_info):
                           n =  -n;
                         }""")
 
-            yield("07_int_pow", f"""
+            yield(f"07_{func.c_name}", f"""
             inline {res_ctype} {func.c_name}({base_ctype} x, {exp_ctype} n) {{
               if (n == 0)
                 return 1;

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -972,7 +972,8 @@ class CExpressionToCodeMapper(RecursiveMapper):
         return self._map_division_operator("%", expr, enclosing_prec)
 
     def map_power(self, expr, enclosing_prec):
-        raise RuntimeError(f"'{expr}' should have been transformed to 'Call' expression node.")
+        raise RuntimeError(f"'{expr}' should have been transformed to 'Call'"
+                           " expression node.")
 
     def map_array_literal(self, expr, enclosing_prec):
         return "{ %s }" % self.join_rec(", ", expr.children, PREC_NONE)

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -981,7 +981,9 @@ class CExpressionToCodeMapper(RecursiveMapper):
         return self._map_division_operator("%", expr, enclosing_prec)
 
     def map_power(self, expr, enclosing_prec):
-        raise NotImplementedError()
+        # No trivial "**" operator for C-like targets, should have been preprocessed
+        # into other expression types.
+        raise RuntimeError()
 
     def map_array_literal(self, expr, enclosing_prec):
         return "{ %s }" % self.join_rec(", ", expr.children, PREC_NONE)

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -731,16 +731,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                         f"{base_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")(
                                 self.rec(expr.base), self.rec(expr.exponent))
             else:
-                from loopy.types import to_loopy_type
-                loopy_f64_dtype = to_loopy_type(np.float64,
-                        target=self.kernel.target)
-                return self.wrap_in_typecast(
-                        loopy_f64_dtype,
-                        tgt_dtype,
-                        var("pow")(self.rec(expr.base, type_context,
-                                            loopy_f64_dtype),
-                                   self.rec(expr.exponent, type_context,
-                                            loopy_f64_dtype)))
+                return self.rec(var("pow")(expr.base, expr.exponent), type_context)
 
         if not self.allow_complex:
             return base_impl(expr, type_context)
@@ -981,9 +972,7 @@ class CExpressionToCodeMapper(RecursiveMapper):
         return self._map_division_operator("%", expr, enclosing_prec)
 
     def map_power(self, expr, enclosing_prec):
-        # No trivial "**" operator for C-like targets, should have been preprocessed
-        # into other expression types.
-        raise RuntimeError()
+        raise RuntimeError(f"'{expr}' should have been transformed to 'Call' expression node.")
 
     def map_array_literal(self, expr, enclosing_prec):
         return "{ %s }" % self.join_rec(", ", expr.children, PREC_NONE)

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -720,16 +720,14 @@ class ExpressionToCExpressionMapper(IdentityMapper):
             if exponent_dtype.is_integral():
                 from loopy.codegen import SeenFunction
                 func_name = ("loopy_pow_"
-                        f"{base_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")
+                        f"{tgt_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")
 
                 self.codegen_state.seen_functions.add(
                         SeenFunction(
                             "int_pow", func_name,
-                            (base_dtype, exponent_dtype),
+                            (tgt_dtype, exponent_dtype),
                             (tgt_dtype, )))
-                return var("loopy_pow_"
-                        f"{base_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")(
-                                self.rec(expr.base), self.rec(expr.exponent))
+                return var(func_name)(self.rec(expr.base), self.rec(expr.exponent))
             else:
                 return self.rec(var("pow")(expr.base, expr.exponent), type_context)
 

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -717,9 +717,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                 elif is_zero(expr.exponent - 2):
                     return self.rec(expr.base*expr.base, type_context)
 
-            if exponent_dtype.numpy_dtype.kind == "u":
-                # FIXME: need to add this to the seen functions
-
+            if exponent_dtype.is_integral():
                 from loopy.codegen import SeenFunction
                 func_name = ("loopy_pow_"
                         f"{base_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")
@@ -741,7 +739,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                         tgt_dtype,
                         var("pow")(self.rec(expr.base, type_context,
                                             loopy_f64_dtype),
-                                   self.rec(expr.base, type_context,
+                                   self.rec(expr.exponent, type_context,
                                             loopy_f64_dtype)))
 
         if not self.allow_complex:

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -325,7 +325,8 @@ class ExpressionToCExpressionMapper(IdentityMapper):
             self.codegen_state.seen_functions.add(
                     SeenFunction(
                         name, f"{name}_{suffix}",
-                        (result_dtype, result_dtype)))
+                        (result_dtype, result_dtype),
+                        (result_dtype,)))
 
         if den_nonneg:
             if num_nonneg:
@@ -538,7 +539,8 @@ class ExpressionToCExpressionMapper(IdentityMapper):
         self.codegen_state.seen_functions.add(
                 SeenFunction(identifier,
                     mangle_result.target_name,
-                    mangle_result.arg_dtypes or par_dtypes))
+                    mangle_result.arg_dtypes or par_dtypes,
+                    mangle_result.result_dtypes))
 
         return var(mangle_result.target_name)(*processed_parameters)
 
@@ -725,7 +727,8 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                 self.codegen_state.seen_functions.add(
                         SeenFunction(
                             "int_pow", func_name,
-                            (base_dtype, exponent_dtype)))
+                            (base_dtype, exponent_dtype),
+                            (tgt_dtype, )))
                 return var("loopy_pow_"
                         f"{base_dtype.numpy_dtype}_{exponent_dtype.numpy_dtype}")(
                                 self.rec(expr.base), self.rec(expr.exponent))

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -727,7 +727,8 @@ class ExpressionToCExpressionMapper(IdentityMapper):
                             "int_pow", func_name,
                             (tgt_dtype, exponent_dtype),
                             (tgt_dtype, )))
-                return var(func_name)(self.rec(expr.base), self.rec(expr.exponent))
+                return var(func_name)(self.rec(expr.base, type_context),
+                                      self.rec(expr.exponent, type_context))
             else:
                 return self.rec(var("pow")(expr.base, expr.exponent), type_context)
 

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -127,6 +127,18 @@ def cuda_function_mangler(kernel, name, arg_dtypes):
 
         return dtype, name
 
+    if name in ["pow"] and len(arg_dtypes) == 2:
+        dtype = np.find_common_type([], arg_dtypes)
+
+        if dtype == np.float64:
+            pass  # pow
+        elif dtype == np.float32:
+            name = name + "f"  # powf
+        else:
+            raise RuntimeError(f"{name} does not support type {dtype}")
+
+        return dtype, name
+
     if name in "atan2" and len(arg_dtypes) == 2:
         return arg_dtypes[0], name
 

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -28,7 +28,7 @@ import numpy as np
 from loopy.target.c import CFamilyTarget, CFamilyASTBuilder
 from loopy.target.c.codegen.expression import ExpressionToCExpressionMapper
 from pytools import memoize_method
-from loopy.diagnostic import LoopyError
+from loopy.diagnostic import LoopyError, LoopyTypeError
 from loopy.types import NumpyType
 from loopy.target.c import DTypeRegistryWrapper, c_math_mangler
 from loopy.kernel.data import AddressSpace, CallMangleInfo
@@ -144,7 +144,6 @@ _CL_SIMPLE_MULTI_ARG_FUNCTIONS = {
         "rsqrt": 1,
         "clamp": 3,
         "atan2": 2,
-        "pow": 2,
         }
 
 
@@ -181,6 +180,22 @@ def opencl_function_mangler(kernel, name, arg_dtypes):
                     target_name=name,
                     result_dtypes=(result_dtype,),
                     arg_dtypes=2*(result_dtype,))
+
+    if name == "pow" and len(arg_dtypes) == 2:
+        dtype = np.find_common_type(
+                [], [dtype.numpy_dtype for dtype in arg_dtypes])
+        if dtype == np.float64:
+            name = "powf64"
+        elif dtype == np.float32:
+            name = "powf32"
+        else:
+            raise LoopyTypeError(f"'pow' does not support type {dtype}.")
+
+        result_dtype = NumpyType(dtype)
+        return CallMangleInfo(
+                target_name=name,
+                result_dtypes=(result_dtype,),
+                arg_dtypes=2*(result_dtype,))
 
     if name == "dot":
         scalar_dtype, offset, field_name = arg_dtypes[0].numpy_dtype.fields["s0"]
@@ -286,6 +301,19 @@ def opencl_preamble_generator(preamble_info):
                 #define gid(N) ((%(idx_ctype)s) get_group_id(N))
                 """ % dict(idx_ctype=kernel.target.dtype_to_typename(
                     kernel.index_dtype))))
+
+    for func in preamble_info.seen_functions:
+        if func.name == "pow" and func.c_name == "powf32":
+            yield("08_clpowf32", """
+            inline float powf32(float x, float y) {
+              return pow(x, y);
+            }""")
+
+        if func.name == "pow" and func.c_name == "powf64":
+            yield("08_clpowf64", """
+            inline double powf64(double x, double y) {
+              return pow(x, y);
+            }""")
 
 # }}}
 

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -144,6 +144,7 @@ _CL_SIMPLE_MULTI_ARG_FUNCTIONS = {
         "rsqrt": 1,
         "clamp": 3,
         "atan2": 2,
+        "pow": 2,
         }
 
 

--- a/loopy/target/python.py
+++ b/loopy/target/python.py
@@ -118,7 +118,8 @@ class ExpressionToPythonMapper(StringifyMapper):
         self.codegen_state.seen_functions.add(
                 SeenFunction(identifier,
                     mangle_result.target_name,
-                    mangle_result.arg_dtypes or par_dtypes))
+                    mangle_result.arg_dtypes or par_dtypes,
+                    mangle_result.result_dtypes))
 
         return "{}({})".format(mangle_result.target_name, ", ".join(str_parameters))
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -2996,8 +2996,9 @@ def test_split_iname_within(ctx_factory):
 
 
 @pytest.mark.parametrize("base_type,exp_type", [(np.int32, np.uint32), (np.int64,
-    np.uint64), (np.int, np.float), (np.float, np.int), (np.int, np.int)])
-def test_int_pow(ctx_factory, base_type, exp_type):
+    np.uint64), (np.int, np.float), (np.float, np.int), (np.int, np.int),
+    (np.float32, np.float64), (np.float64, np.float32)])
+def test_pow(ctx_factory, base_type, exp_type):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -2997,7 +2997,7 @@ def test_split_iname_within(ctx_factory):
 
 @pytest.mark.parametrize("base_type,exp_type", [(np.int32, np.uint32), (np.int64,
     np.uint64), (np.int, np.float), (np.float, np.int), (np.int, np.int)])
-def test_int_int_pow(ctx_factory, base_type, exp_type):
+def test_int_pow(ctx_factory, base_type, exp_type):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -2995,6 +2995,49 @@ def test_split_iname_within(ctx_factory):
     lp.auto_test_vs_ref(ref_knl, ctx, knl, parameters=dict(n=5))
 
 
+@pytest.mark.parametrize("basetype,exptype", [(np.int32, np.uint32), (np.int64,
+    np.uint64), (np.int, np.float), (np.float, np.int)])
+def test_int_int_pow(ctx_factory, basetype, exptype):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+
+    def _make_random_np_array(shape, dtype):
+        from numpy.random import default_rng
+        rng = default_rng()
+        if isinstance(shape, int):
+            shape = (shape,)
+
+        dtype = np.dtype(dtype)
+        if dtype.kind in ["u", "i"]:
+            # choosing numbers so that we don't have overflow, to not trigger
+            # undefined behavior
+            low = 0 if dtype.kind == "u" else -6
+            high = 6
+            return rng.integers(low=low, high=high, size=shape, dtype=dtype)
+        elif dtype.kind == "f":
+            return rng.random(*shape).astype(dtype)
+        else:
+            raise NotImplementedError()
+
+    base = _make_random_np_array(10, basetype)
+    power = _make_random_np_array(10, exptype)
+    expected_result = base ** power
+
+    knl = lp.make_kernel(
+            "{[i]: 0<=i<n}",
+            """
+            res[i] = base[i] ** power[i]
+            """, [lp.GlobalArg("base", dtype=basetype, shape=lp.auto),
+                  lp.GlobalArg("power", dtype=exptype, shape=lp.auto),
+                  ...])
+
+    evt, (result,) = knl(queue, base=base, power=power)
+
+    assert result.dtype == expected_result.dtype
+
+    np.testing.assert_allclose(expected_result, result)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
- Uses exponentiation by squaring for int exponents. (for all base dtypes)
- Exponentiation with negative exponents is undefined behavior, but the result type is always `np.find_common_type`