### PR TITLE
fix generate_integer_arg_finding_from_strides in opt case

### DIFF
--- a/loopy/target/execution.py
+++ b/loopy/target/execution.py
@@ -293,8 +293,9 @@ class ExecutionWrapperGeneratorBase:
                                 % (stride_impl_axis, impl_array_name))
                         gen("del _lpy_remdr")
                     else:
-                        gen("%s = _lpy_offset // %d"
-                                % (arg.name, base_arg.dtype.itemsize))
+                        gen("%s = %s.strides[%d] // %d"
+                                % (arg.name,  impl_array_name, stride_impl_axis,
+                                    base_arg.dtype.itemsize))
 
         gen("# }}}")
         gen("")


### PR DESCRIPTION
Fixes https://github.com/illinois-ceesd/mirgecom/issues/208 , fixes https://github.com/inducer/loopy/issues/208.

@MTCam Can you check if this fixes it for you as well?
@inducer I'm not sure if we need to increment the `DATA_MODEL_VERSION`. Also, it might be interesting to add the skip_arg_checks mode to CI.

Edit: you might need to run with `LOOPY_NO_CACHE=1`