### PR TITLE
Use a better key for compute_topological_order

### DIFF
--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -643,6 +643,13 @@ def get_insns_in_topologically_sorted_order(kernel):
         for dep in insn.depends_on:
             rev_dep_map[dep].add(insn.id)
 
+    # For breaking ties, we compare the features of an intruction
+    # so that instructions with the same set of features are lumped
+    # together. This helps in :method:`schedule_as_many_run_insns_as_possible`
+    # which bails after 5 insns that don't have the same feature.
+    #
+    # Instead of returning these features as a key, we assign an id to
+    # each set of features to avoid comparing them which can be expensive.
     insn_id_to_feature_id = {}
     insn_features = {}
     for insn in kernel.instructions:

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -647,7 +647,7 @@ def get_insns_in_topologically_sorted_order(kernel):
         # negative of insn.priority because
         # pytools.graph.compute_topological_order schedules the nodes with
         # lower 'key' first in case of a tie.
-        return (-kernel.id_to_insn[insn_id].priority, insn.id)
+        return (-kernel.id_to_insn[insn_id].priority, insn_id)
 
     ids = compute_topological_order(rev_dep_map, key=key)
     return [kernel.id_to_insn[insn_id] for insn_id in ids]


### PR DESCRIPTION
This becomes a 25% performance improvement for sumpy indirectly
because this preserves the insns in the original order that sumpy
kernel was created and that provides a good heuristic for
schedule_as_many_insns_as_possible which bails after 5 insns
that are out of order.