### PR TITLE
Accept list of reduction inames in reduction nodes

### DIFF
--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -1147,9 +1147,9 @@ class FunctionToPrimitiveMapper(IdentityMapper):
         if isinstance(inames, p.Variable):
             inames = (inames,)
 
-        if not isinstance(inames, (tuple)):
+        if not isinstance(inames, (tuple, list)):
             raise TypeError("iname argument to reduce() must be a symbol "
-                    "or a tuple of symbols")
+                    "or a list/tuple of symbols")
 
         processed_inames = []
         for iname in inames:

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -409,7 +409,7 @@ def test_arg_guessing_with_reduction(ctx_factory):
             "{[i,j]: 0<=i,j<n }",
             """
                 a = 1.5 + simul_reduce(sum, (i,j), i*j)
-                d = 1.5 + simul_reduce(sum, (i,j), b[i,j])
+                d = 1.5 + simul_reduce(sum, [i,j], b[i,j])
                 b[i, j] = i*j
                 c[i+j, j] = b[j,i]
                 """,


### PR DESCRIPTION
Necessary because while printing out a reduce(..) we print out the reduction inames to be a list.