### PR TITLE
Bool support opencl target

### DIFF
--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -51,8 +51,9 @@ class DTypeRegistryWrapperWithInt8ForBool(DTypeRegistryWrapper):
     def dtype_to_ctype(self, dtype):
         from loopy.types import NumpyType
         if isinstance(dtype, NumpyType) and dtype.dtype == np.bool8:
-            return super().dtype_to_ctype(NumpyType(np.int8, dtype.target))
-        return super().dtype_to_ctype(dtype)
+            return self.wrapped_registry.dtype_to_ctype(
+                    NumpyType(np.int8, dtype.target))
+        return self.wrapped_registry.dtype_to_ctype(dtype)
 
 
 class DTypeRegistryWrapperWithAtomics(DTypeRegistryWrapper):
@@ -60,11 +61,10 @@ class DTypeRegistryWrapperWithAtomics(DTypeRegistryWrapper):
         if dtype is not None:
             from loopy.types import AtomicNumpyType, NumpyType
             if isinstance(dtype, AtomicNumpyType):
-                return super(self.wrapped_registry.get_or_register_dtype(
-                        names, NumpyType(dtype.dtype)))
+                return self.wrapped_registry.get_or_register_dtype(
+                        names, NumpyType(dtype.dtype))
 
-        return super().get_or_register_dtype(
-                names, dtype)
+        return self.wrapped_registry.get_or_register_dtype(names, dtype)
 
 
 class DTypeRegistryWrapperWithCL1Atomics(DTypeRegistryWrapperWithAtomics):
@@ -74,8 +74,7 @@ class DTypeRegistryWrapperWithCL1Atomics(DTypeRegistryWrapperWithAtomics):
         if isinstance(dtype, AtomicNumpyType):
             return "volatile " + self.wrapped_registry.dtype_to_ctype(dtype)
         else:
-            return super().dtype_to_ctype(
-                    dtype)
+            return self.wrapped_registry.dtype_to_ctype(dtype)
 
 # }}}
 

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -478,12 +478,13 @@ class PyOpenCLTarget(OpenCLTarget):
     host_program_name_suffix = ""
 
     def __init__(self, device=None, pyopencl_module_name="_lpy_cl",
-            atomics_flavor=None):
+                 atomics_flavor=None, use_int8_for_bool=True):
         # This ensures the dtype registry is populated.
         import pyopencl.tools  # noqa
 
         super().__init__(
-                atomics_flavor=atomics_flavor)
+            atomics_flavor=atomics_flavor,
+            use_int8_for_bool=use_int8_for_bool)
 
         import pyopencl.version
         if pyopencl.version.VERSION < (2021, 1):
@@ -579,11 +580,18 @@ class PyOpenCLTarget(OpenCLTarget):
         else:
             result = TYPE_REGISTRY
 
-        from loopy.target.opencl import DTypeRegistryWrapperWithCL1Atomics
+        from loopy.target.opencl import (DTypeRegistryWrapperWithCL1Atomics,
+                                         DTypeRegistryWrapperWithInt8ForBool)
+
         if self.atomics_flavor == "cl1":
-            return DTypeRegistryWrapperWithCL1Atomics(result)
+            result = DTypeRegistryWrapperWithCL1Atomics(result)
         else:
             raise NotImplementedError("atomics flavor: %s" % self.atomics_flavor)
+
+        if self.use_int8_for_bool:
+            result = DTypeRegistryWrapperWithInt8ForBool(result)
+
+        return result
 
     def is_vector_dtype(self, dtype):
         try:

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -529,12 +529,14 @@ class PyOpenCLTarget(OpenCLTarget):
         return {
                 "device_id": dev_id,
                 "atomics_flavor": self.atomics_flavor,
+                "use_int8_for_bool": self.use_int8_for_bool,
                 "fortran_abi": self.fortran_abi,
                 "pyopencl_module_name": self.pyopencl_module_name,
                 }
 
     def __setstate__(self, state):
         self.atomics_flavor = state["atomics_flavor"]
+        self.use_int8_for_bool = state["use_int8_for_bool"]
         self.fortran_abi = state["fortran_abi"]
         self.pyopencl_module_name = state["pyopencl_module_name"]
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -408,6 +408,20 @@ def test_pyopencl_execution_numpy_handling(ctx_factory):
     assert x[0] == 5.
 
 
+def test_opencl_support_for_bool(ctx_factory):
+    knl = lp.make_kernel(
+        "{[i]: 0<=i<10}",
+        """
+        y[i] = i%2
+        """,
+        [lp.GlobalArg("y", dtype=np.bool8, shape=lp.auto)])
+
+    evt, (out, ) = knl(cl.CommandQueue(ctx_factory()))
+    out = out.get()
+
+    np.testing.assert_equal(out, np.tile(np.array([0, 1], dtype=np.bool8), 5))
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Apparently loopy did not support bool types for OpenCL targets. The provided regression with this PR fails on `main`.