### PR TITLE
Check new dependencies against SIO

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -78,7 +78,8 @@ from loopy.transform.iname import (
 
 from loopy.transform.instruction import (
         find_instructions, map_instructions,
-        set_instruction_priority, add_dependency,
+        set_instruction_priority,
+        add_dependency, add_stmt_inst_dependency,
         remove_instructions,
         replace_instruction_ids,
         tag_instructions,
@@ -121,6 +122,8 @@ from loopy.type_inference import infer_unknown_types
 from loopy.preprocess import preprocess_kernel, realize_reduction
 from loopy.schedule import (
     generate_loop_schedules, get_one_scheduled_kernel, get_one_linearized_kernel)
+from loopy.schedule.checker import (
+    check_linearization_validity)
 from loopy.statistics import (ToCountMap, CountGranularity,
         stringify_stats_mapping, Op, MemAccess, get_op_map, get_mem_access_map,
         get_synchronization_map, gather_access_footprints,
@@ -202,7 +205,8 @@ __all__ = [
         "rename_argument", "set_temporary_scope",
 
         "find_instructions", "map_instructions",
-        "set_instruction_priority", "add_dependency",
+        "set_instruction_priority",
+        "add_dependency", "add_stmt_inst_dependency",
         "remove_instructions",
         "replace_instruction_ids",
         "tag_instructions",
@@ -247,6 +251,7 @@ __all__ = [
         "preprocess_kernel", "realize_reduction",
         "generate_loop_schedules",
         "get_one_scheduled_kernel", "get_one_linearized_kernel",
+        "check_linearization_validity",
         "GeneratedProgram", "CodeGenerationResult",
         "PreambleInfo",
         "generate_code", "generate_code_v2", "generate_body",

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -117,6 +117,42 @@ def add_dependency(kernel, insn_match, depends_on):
 # }}}
 
 
+# {{{ add_stmt_inst_dependency
+
+def add_stmt_inst_dependency(
+        kernel, stmt_id, depends_on_id, new_dependency):
+    """Add the statement instance dependency *new_dependency* to statement with
+    id *stmt_id*.
+    """
+
+    if stmt_id not in kernel.id_to_insn:
+        raise LoopyError("no instructions found matching '%s',"
+                "cannot add dependency %s->%s"
+                % (stmt_id, depends_on_id, stmt_id))
+    if depends_on_id not in kernel.id_to_insn:
+        raise LoopyError("no instructions found matching '%s',"
+                "cannot add dependency %s->%s"
+                % (depends_on_id, depends_on_id, stmt_id))
+
+    matched = [False]
+
+    def _add_dep(stmt):
+        new_deps_dict = stmt.dependencies  # dict mapping depends-on ids to dep maps
+        matched[0] = True
+        new_deps_dict.setdefault(depends_on_id, []).append(new_dependency)
+        return stmt.copy(dependencies=new_deps_dict)
+
+    result = map_instructions(kernel, "id:%s" % (stmt_id), _add_dep)
+
+    if not matched[0]:  # Is this possible, given check above?
+        raise LoopyError("no instructions found matching '%s' "
+                "(to which dependencies would be added)" % stmt_id)
+
+    return result
+
+# }}}
+
+
 # {{{ remove_instructions
 
 def remove_instructions(kernel, insn_ids):


### PR DESCRIPTION
(PR currently just for comparison. This will eventually be merged into [new-dependency-and-nest-constraint-semantics-development](https://github.com/inducer/loopy/tree/new-dependency-and-nest-constraint-semantics-development) after `statement-instance-order-and-lex-order-map` is merged.)

- Add dependencies to loopy statements
- Check kernel dependencies against SIO

[Previous (upstream) MR in chain](https://github.com/inducer/loopy/pull/169)