### PR TITLE
Include only read/written args while generating code for CallKernels

### DIFF
--- a/loopy/codegen/result.py
+++ b/loopy/codegen/result.py
@@ -195,6 +195,26 @@ class CodeGenerationResult(ImmutableRecord):
                 self.current_program(codegen_state).copy(
                     ast=new_ast))
 
+    def get_idis_for_subkernel(self, kernel, name):
+        """
+        Returns a :class:`list` of :class:`~loopy.codegen.ImplementedDataInfo` for
+        the subkernel named *name*.
+
+        :arg kernel: An instance of :class:`loopy.LoopKernel`.
+        """
+        from loopy.schedule.tools import get_callkernel_dependencies
+        from loopy.kernel.data import InameArg
+        subknl_deps = get_callkernel_dependencies(kernel, name)
+        return [idi
+                for idi in self.implemented_data_info
+                if (idi.name in subknl_deps
+                    or idi.arg_class is InameArg
+                    or idi.base_name in subknl_deps
+                    or idi.offset_for_name in subknl_deps
+                    or (idi.stride_for_name_and_axis is not None
+                        and idi.stride_for_name_and_axis[0] in subknl_deps))]
+
+
 # }}}
 
 

--- a/loopy/codegen/result.py
+++ b/loopy/codegen/result.py
@@ -204,13 +204,15 @@ class CodeGenerationResult(ImmutableRecord):
         """
         from loopy.schedule.tools import get_callkernel_dependencies
         from loopy.kernel.data import InameArg
+        name2idi = {idi.name: idi for idi in self.implemented_data_info}
         subknl_deps = get_callkernel_dependencies(kernel, name)
         return [idi
                 for idi in self.implemented_data_info
                 if (idi.name in subknl_deps
                     or idi.arg_class is InameArg
                     or idi.base_name in subknl_deps
-                    or idi.offset_for_name in subknl_deps
+                    or (idi.offset_for_name is not None
+                        and name2idi[idi.offset_for_name].base_name in subknl_deps)
                     or (idi.stride_for_name_and_axis is not None
                         and idi.stride_for_name_and_axis[0] in subknl_deps))]
 

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -68,6 +68,35 @@ def temporaries_written_in_subkernel(kernel, subkernel):
             for tv in kernel.id_to_insn[insn_id].write_dependency_names()
             if tv in kernel.temporary_variables)
 
+
+def args_read_in_subkernel(kernel, subkernel):
+    from loopy.kernel.tools import get_subkernel_to_insn_id_map
+    insn_ids = get_subkernel_to_insn_id_map(kernel)[subkernel]
+    return frozenset(arg
+                     for insn_id in insn_ids
+                     for arg in kernel.id_to_insn[insn_id].read_dependency_names()
+                     if arg in kernel.arg_dict)
+
+
+def args_written_in_subkernel(kernel, subkernel):
+    from loopy.kernel.tools import get_subkernel_to_insn_id_map
+    insn_ids = get_subkernel_to_insn_id_map(kernel)[subkernel]
+    return frozenset(arg
+                     for insn_id in insn_ids
+                     for arg in kernel.id_to_insn[insn_id].write_dependency_names()
+                     if arg in kernel.arg_dict)
+
+
+def get_callkernel_dependencies(kernel, subkernel):
+    """
+    Returns variable names referenced by :class:`~loopy.schedule.CallKernel`
+    named *subkernel*.
+    """
+    return (temporaries_read_in_subkernel(kernel, subkernel)
+            | temporaries_written_in_subkernel(kernel, subkernel)
+            | args_read_in_subkernel(kernel, subkernel)
+            | args_written_in_subkernel(kernel, subkernel))
+
 # }}}
 
 

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -56,9 +56,10 @@ def temporaries_read_in_subkernel(kernel, subkernel):
     insn_ids = get_subkernel_to_insn_id_map(kernel)[subkernel]
     inames = frozenset().union(*(kernel.insn_inames(insn_id)
                                  for insn_id in insn_ids))
+    domain_idxs = {kernel.get_home_domain_index(iname) for iname in inames}
     params = frozenset().union(*(
         kernel.domains[dom_idx].get_var_names(isl.dim_type.param)
-        for dom_idx in kernel.get_leaf_domain_indices(inames)))
+        for dom_idx in domain_idxs))
 
     return (frozenset(tv
                       for insn_id in insn_ids
@@ -81,9 +82,10 @@ def args_read_in_subkernel(kernel, subkernel):
     insn_ids = get_subkernel_to_insn_id_map(kernel)[subkernel]
     inames = frozenset().union(*(kernel.insn_inames(insn_id)
                                  for insn_id in insn_ids))
+    domain_idxs = {kernel.get_home_domain_index(iname) for iname in inames}
     params = frozenset().union(*(
         kernel.domains[dom_idx].get_var_names(isl.dim_type.param)
-        for dom_idx in kernel.get_leaf_domain_indices(inames)))
+        for dom_idx in domain_idxs))
 
     return (frozenset(arg
                       for insn_id in insn_ids

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -853,6 +853,11 @@ class CFamilyASTBuilder(ASTBuilderBase):
 
     def get_function_declaration(self, codegen_state, codegen_result,
             schedule_index):
+        from loopy.schedule.tools import get_callkernel_dependencies
+        kernel = codegen_state.kernel
+        subkernel = codegen_state.kernel.schedule[schedule_index].kernel_name
+        subknl_deps = get_callkernel_dependencies(kernel, subkernel)
+
         from cgen import FunctionDeclaration, Value
 
         name = codegen_result.current_program(codegen_state).name
@@ -866,8 +871,9 @@ class CFamilyASTBuilder(ASTBuilderBase):
         return FunctionDeclarationWrapper(
                 FunctionDeclaration(
                     name,
-                    [self.idi_to_cgen_declarator(codegen_state.kernel, idi)
-                        for idi in codegen_state.implemented_data_info]))
+                    [self.idi_to_cgen_declarator(kernel, idi)
+                     for idi in codegen_state.implemented_data_info
+                     if idi.name in subknl_deps]))
 
     def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
         return None

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -853,10 +853,8 @@ class CFamilyASTBuilder(ASTBuilderBase):
 
     def get_function_declaration(self, codegen_state, codegen_result,
             schedule_index):
-        from loopy.schedule.tools import get_callkernel_dependencies
         kernel = codegen_state.kernel
         subkernel = codegen_state.kernel.schedule[schedule_index].kernel_name
-        subknl_deps = get_callkernel_dependencies(kernel, subkernel)
 
         from cgen import FunctionDeclaration, Value
 
@@ -872,8 +870,9 @@ class CFamilyASTBuilder(ASTBuilderBase):
                 FunctionDeclaration(
                     name,
                     [self.idi_to_cgen_declarator(kernel, idi)
-                     for idi in codegen_state.implemented_data_info
-                     if idi.name in subknl_deps]))
+                     for idi in codegen_result.get_idis_for_subkernel(kernel,
+                                                                      subkernel)]
+                ))
 
     def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
         return None

--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -442,11 +442,11 @@ class CKernelExecutor(KernelExecutorBase):
     @memoize_method
     def program_info(self, entrypoint, arg_to_dtype_set=frozenset(),
             all_kwargs=None):
-        from loopy.schedule.tools import get_callkernel_dependencies
         program = self.get_typed_and_scheduled_translation_unit(
                 entrypoint, arg_to_dtype_set)
 
         from loopy.codegen import generate_code_v2
+        from loopy.schedule.tools import get_callkernel_dependencies
         codegen_result = generate_code_v2(program)
 
         dev_code = codegen_result.device_code()

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -766,6 +766,7 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
         return code_lines
 
     def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
+        from loopy.schedule.tools import get_callkernel_dependencies
         ecm = self.get_expression_to_code_mapper(codegen_state)
 
         if not gsize:
@@ -773,7 +774,10 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
         if not lsize:
             lsize = (1,)
 
-        all_args = codegen_state.implemented_data_info + extra_args
+        all_args = [arg
+                    for arg in codegen_state.implemented_data_info + extra_args
+                    if arg.name in get_callkernel_dependencies(codegen_state.kernel,
+                                                               name)]
 
         value_arg_code, arg_idx_to_cl_arg_idx, cl_arg_count = \
             generate_value_arg_setup(

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -768,6 +768,8 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
     def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
         from loopy.schedule.tools import get_callkernel_dependencies
         from loopy.kernel.data import InameArg
+        name2idi = {idi.name: idi for idi in (codegen_state.implemented_data_info
+                                              + extra_args)}
         subknl_deps = get_callkernel_dependencies(codegen_state.kernel, name)
         ecm = self.get_expression_to_code_mapper(codegen_state)
 
@@ -781,6 +783,9 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
                     if (arg.name in subknl_deps
                         or arg.arg_class is InameArg
                         or arg.base_name in subknl_deps
+                        or (arg.offset_for_name is not None
+                            and (name2idi[arg.offset_for_name].base_name
+                                 in subknl_deps))
                         or arg.offset_for_name in subknl_deps
                         or (arg.stride_for_name_and_axis is not None
                             and arg.stride_for_name_and_axis[0] in subknl_deps))]

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -767,6 +767,8 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
 
     def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
         from loopy.schedule.tools import get_callkernel_dependencies
+        from loopy.kernel.data import InameArg
+        subknl_deps = get_callkernel_dependencies(codegen_state.kernel, name)
         ecm = self.get_expression_to_code_mapper(codegen_state)
 
         if not gsize:
@@ -775,9 +777,13 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
             lsize = (1,)
 
         all_args = [arg
-                    for arg in codegen_state.implemented_data_info + extra_args
-                    if arg.name in get_callkernel_dependencies(codegen_state.kernel,
-                                                               name)]
+                    for arg in (codegen_state.implemented_data_info + extra_args)
+                    if (arg.name in subknl_deps
+                        or arg.arg_class is InameArg
+                        or arg.base_name in subknl_deps
+                        or arg.offset_for_name in subknl_deps
+                        or (arg.stride_for_name_and_axis is not None
+                            and arg.stride_for_name_and_axis[0] in subknl_deps))]
 
         value_arg_code, arg_idx_to_cl_arg_idx, cl_arg_count = \
             generate_value_arg_setup(


### PR DESCRIPTION
```python
knl = lp.make_kernel(
    "{[i, j]: 0<=i,j<10}",
    """
    x[i] = 2*i
    ... gbarrier
    y[j] = 2*x[j]
    """, seq_dependencies=True)
```

now generates:

```c
__kernel void __attribute__ ((reqd_work_group_size(1, 1, 1))) loopy_kernel(__global int *__restrict__ x)
{
  for (int i = 0; i <= 9; ++i)
    x[i] = 2 * i;
}

__kernel void __attribute__ ((reqd_work_group_size(1, 1, 1))) loopy_kernel_0(__global int *__restrict__ x, __global int *__restrict__ y)
{
  for (int j = 0; j <= 9; ++j)
    y[j] = 2 * x[j];
}
```