### PR TITLE
Do not carry over _cached_written_variables with copy, add test that it doesn't survive transformations

### DIFF
--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -1618,6 +1618,11 @@ class LoopKernel(ImmutableRecordWithoutPickling):
                         "LoopKernel.copy")
 
             kwargs["inames"] = None
+
+        # Avoid carrying over an invalid cache when other parts of the kernel
+        # are modified.
+        kwargs["_cached_written_variables"] = None
+
         return super().copy(**kwargs)
 
 # }}}

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3094,6 +3094,20 @@ def test_scalar_temporary(ctx_factory):
     np.testing.assert_allclose(4*x_in, out.get())
 
 
+def test_cached_written_variables_doesnt_carry_over_invalidly():
+    knl = lp.make_kernel(
+            "{:}",
+            """
+            a[i] = 2*i {id=write_a}
+            b[i] = 2*i {id=write_b}
+            """)
+    from pickle import dumps, loads
+    knl2 = loads(dumps(knl))
+
+    knl2 = lp.remove_instructions(knl2, {"write_b"})
+    assert "b" not in knl2.get_written_variables()
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
cc @jdsteve2 