### PR TITLE
Exit early in split_iname if insn doesn't have iname in dependencies

### DIFF
--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -795,18 +795,8 @@ class MultiAssignmentBase(InstructionBase):
 
     @memoize_method
     def reduction_inames(self):
-        def map_reduction(expr, rec):
-            rec(expr.expr)
-            for iname in expr.inames:
-                result.add(iname)
-
-        from loopy.symbolic import ReductionCallbackMapper
-        cb_mapper = ReductionCallbackMapper(map_reduction)
-
-        result = set()
-        cb_mapper(self.expression)
-
-        return result
+        from loopy.symbolic import get_reduction_inames
+        return get_reduction_inames(self.expression)
 
 # }}}
 

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -751,10 +751,30 @@ class RuleArgument(LoopyExpressionBase):
 # }}}
 
 
+class DependencyMapperWithReductionInames(DependencyMapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reduction_inames = set()
+
+    def map_reduction(self, expr, *args, **kwargs):
+        self.reduction_inames.update(expr.inames)
+        return super().map_reduction(expr, *args, **kwargs)
+
+
 @memoize
+def _get_dependencies_and_reduction_inames(expr):
+    dep_mapper = DependencyMapperWithReductionInames(composite_leaves=False)
+    deps = frozenset(dep.name for dep in dep_mapper(expr))
+    reduction_inames = dep_mapper.reduction_inames
+    return deps, reduction_inames
+
+
 def get_dependencies(expr):
-    dep_mapper = DependencyMapper(composite_leaves=False)
-    return frozenset(dep.name for dep in dep_mapper(expr))
+    return _get_dependencies_and_reduction_inames(expr)[0]
+
+
+def get_reduction_inames(expr):
+    return _get_dependencies_and_reduction_inames(expr)[1]
 
 
 # {{{ rule-aware mappers

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -309,8 +309,8 @@ def _split_iname_backend(kernel, iname_to_split,
     from loopy.kernel.instruction import Assignment
 
     def check_insn_has_iname(kernel, insn, *args):
-        return not (isinstance(insn, Assignment) and \
-                iname_to_split not in get_dependencies(insn.assignee) and \
+        return not (isinstance(insn, Assignment) and
+                iname_to_split not in get_dependencies(insn.assignee) and
                 iname_to_split not in get_dependencies(insn.expression))
 
     kernel = ins.map_kernel(kernel, within=check_insn_has_iname)

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -305,13 +305,14 @@ def _split_iname_backend(kernel, iname_to_split,
     ins = _InameSplitter(rule_mapping_context, within,
             iname_to_split, outer_iname, inner_iname, new_loop_index)
 
-    from loopy.symbolic import get_dependencies
+    from loopy.symbolic import get_dependencies, get_reduction_inames
     from loopy.kernel.instruction import Assignment
 
     def check_insn_has_iname(kernel, insn, *args):
         return not (isinstance(insn, Assignment) and
                 iname_to_split not in get_dependencies(insn.assignee) and
-                iname_to_split not in get_dependencies(insn.expression))
+                iname_to_split not in get_dependencies(insn.expression) and
+                iname_to_split not in get_reduction_inames(insn.expression))
 
     kernel = ins.map_kernel(kernel, within=check_insn_has_iname)
     kernel = rule_mapping_context.finish_kernel(kernel)

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -306,11 +306,12 @@ def _split_iname_backend(kernel, iname_to_split,
             iname_to_split, outer_iname, inner_iname, new_loop_index)
 
     from loopy.symbolic import get_dependencies, get_reduction_inames
-    from loopy.kernel.instruction import Assignment
+    from loopy.kernel.instruction import MultiAssignmentBase
 
     def check_insn_has_iname(kernel, insn, *args):
-        return not (isinstance(insn, Assignment) and
-                iname_to_split not in get_dependencies(insn.assignee) and
+        return not (isinstance(insn, MultiAssignmentBase) and
+                all(iname_to_split not in get_dependencies(a)
+                    for a in insn.assignees) and
                 iname_to_split not in get_dependencies(insn.expression) and
                 iname_to_split not in get_reduction_inames(insn.expression))
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -305,7 +305,15 @@ def _split_iname_backend(kernel, iname_to_split,
     ins = _InameSplitter(rule_mapping_context, within,
             iname_to_split, outer_iname, inner_iname, new_loop_index)
 
-    kernel = ins.map_kernel(kernel)
+    from loopy.symbolic import get_dependencies
+    from loopy.kernel.instruction import Assignment
+
+    def check_insn_has_iname(kernel, insn, *args):
+        return not (isinstance(insn, Assignment) and \
+                iname_to_split not in get_dependencies(insn.assignee) and \
+                iname_to_split not in get_dependencies(insn.expression))
+
+    kernel = ins.map_kernel(kernel, within=check_insn_has_iname)
     kernel = rule_mapping_context.finish_kernel(kernel)
 
     for existing_tag in existing_tags:


### PR DESCRIPTION
Since get_dependencies is cached from a previous invocation,
calling get_dependencies is cheap.