### PR TITLE
Fix performance of LoopKernel.all_inames

### DIFF
--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -797,7 +797,7 @@ class LoopKernel(ImmutableRecordWithoutPickling):
         """
         Returns a :class:`frozenset` of the names of all the inames in the kernel.
         """
-        return _get_inames_from_domains(self.domains)
+        return frozenset(self.inames.keys())
 
     @memoize_method
     def all_params(self):


### PR DESCRIPTION
I don't know why this was not used.

cc @kaushikcfd 