### PR TITLE
Add wrap_in_typecast_lazy

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -1059,8 +1059,8 @@ class CFamilyASTBuilder(ASTBuilderBase):
             return ExpressionStatement(
                     CExpression(self.get_c_expression_to_code_mapper(), result))
 
-        result = ecm.wrap_in_typecast(
-                mangle_result.result_dtypes[0],
+        result = ecm.wrap_in_typecast_lazy(
+                lambda: mangle_result.result_dtypes[0],
                 assignee_var_descriptors[0].dtype,
                 result)
 

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -101,12 +101,20 @@ class ExpressionToCExpressionMapper(IdentityMapper):
     def wrap_in_typecast(self, actual_type, needed_dtype, s):
         return s
 
+    def wrap_in_typecast_lazy(self, actual_type_func, needed_dtype, s):
+        """This is similar to *wrap_in_typecast*, but takes a function for
+        the actual type argument instead of a type. This can be helpful
+        when actual type argument is expensive to calculate and is not
+        needed in some cases.
+        """
+        return s
+
     def rec(self, expr, type_context=None, needed_dtype=None):
         if needed_dtype is None:
             return RecursiveMapper.rec(self, expr, type_context)
 
-        return self.wrap_in_typecast(
-                self.infer_type(expr), needed_dtype,
+        return self.wrap_in_typecast_lazy(
+                lambda : self.infer_type(expr), needed_dtype,
                 RecursiveMapper.rec(self, expr, type_context))
 
     def __call__(self, expr, prec=None, type_context=None, needed_dtype=None):

--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -114,7 +114,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
             return RecursiveMapper.rec(self, expr, type_context)
 
         return self.wrap_in_typecast_lazy(
-                lambda : self.infer_type(expr), needed_dtype,
+                lambda: self.infer_type(expr), needed_dtype,
                 RecursiveMapper.rec(self, expr, type_context))
 
     def __call__(self, expr, prec=None, type_context=None, needed_dtype=None):

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -287,6 +287,12 @@ class ExpressionToPyOpenCLCExpressionMapper(ExpressionToOpenCLCExpressionMapper)
         else:
             raise RuntimeError
 
+    def wrap_in_typecast_lazy(self, actual_type_func, needed_dtype, s):
+        if needed_dtype.is_complex():
+            return self.wrap_in_typecase(self, actual_type_func(), needed_dtype, s)
+        else:
+            return s
+
     def wrap_in_typecast(self, actual_type, needed_dtype, s):
         if (actual_type.is_complex() and needed_dtype.is_complex()
                 and actual_type != needed_dtype):

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -289,7 +289,7 @@ class ExpressionToPyOpenCLCExpressionMapper(ExpressionToOpenCLCExpressionMapper)
 
     def wrap_in_typecast_lazy(self, actual_type_func, needed_dtype, s):
         if needed_dtype.is_complex():
-            return self.wrap_in_typecase(self, actual_type_func(), needed_dtype, s)
+            return self.wrap_in_typecast(self, actual_type_func(), needed_dtype, s)
         else:
             return s
 

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -289,7 +289,7 @@ class ExpressionToPyOpenCLCExpressionMapper(ExpressionToOpenCLCExpressionMapper)
 
     def wrap_in_typecast_lazy(self, actual_type_func, needed_dtype, s):
         if needed_dtype.is_complex():
-            return self.wrap_in_typecast(self, actual_type_func(), needed_dtype, s)
+            return self.wrap_in_typecast(actual_type_func(), needed_dtype, s)
         else:
             return s
 


### PR DESCRIPTION
`self.infer_type(expr)` is expensive and is not necessary in kernels without complex numbers