### PR TITLE
Kernel callables: Pass examples

### DIFF
--- a/examples/fortran/matmul-driver.py
+++ b/examples/fortran/matmul-driver.py
@@ -11,7 +11,7 @@ def main():
     with open(fn) as inf:
         source = inf.read()
 
-    dgemm, = lp.parse_transformed_fortran(source, filename=fn)
+    dgemm = lp.parse_transformed_fortran(source, filename=fn)
 
     ctx = cl.create_some_context()
     queue = cl.CommandQueue(ctx)


### PR DESCRIPTION
`parse_fortran` returns a Program instead of a list of kernels