### PR TITLE
Fix C99 preamble generation when args are OpaqueTypes

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -93,7 +93,8 @@ def c99_preamble_generator(preamble_info):
     if any(dtype.is_integral() for dtype in preamble_info.seen_dtypes):
         yield("10_stdint", "#include <stdint.h>")
     if any(dtype.numpy_dtype == np.dtype("bool")
-           for dtype in preamble_info.seen_dtypes):
+           for dtype in preamble_info.seen_dtypes
+           if isinstance(dtype, NumpyType)):
         yield("10_stdbool", "#include <stdbool.h>")
     if any(dtype.is_complex() for dtype in preamble_info.seen_dtypes):
         yield("10_complex", "#include <complex.h>")


### PR DESCRIPTION
In Firedrake we pass Kernel args which have a dtype which is inherited from OpaqueType. On the kernel edit branch I run into an error in the preamble generation when loopy tries to access the numpy_dtype on an OpaqueType.

@kaushikcfd For reproduction of the error: I ran the Firedrake test tests/slate/test_assemble_tensors.py::test_assemble_matrix[cg1-False].