### PR TITLE
Kcv3 e2 TypeCast Error

### DIFF
--- a/loopy/transform/callable.py
+++ b/loopy/transform/callable.py
@@ -632,6 +632,9 @@ class _FunctionCalledChecker(CombineMapper):
     def map_constant(self, expr):
         return False
 
+    def map_type_cast(self, expr):
+        return False
+
     def map_algebraic_leaf(self, expr):
         return False
 


### PR DESCRIPTION
This fixes a type cast error in `loopy.transform.callable._FunctionCalledChecker`. I am not entirely sure if this is the right thing to do, but it fixes the problem for us.

@kaushikcfd for reproducing the error, I ran this test in Firedrake tests/slate/test_facet_tensors_extr.py::test_horiz_facet_interior_jump[False]

Targets #222.