### PR TITLE
Make simplify_via_aff deterministic

### DIFF
--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -428,7 +428,7 @@ def boxify(cache_manager, domain, box_inames, context):
 
 def simplify_via_aff(expr):
     from loopy.symbolic import aff_from_expr, aff_to_expr, get_dependencies
-    deps = get_dependencies(expr)
+    deps = sorted(get_dependencies(expr))
     return aff_to_expr(aff_from_expr(
         isl.Space.create_from_names(isl.DEFAULT_CONTEXT, list(deps)),
         expr))

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -87,6 +87,16 @@ def test_subst_into_pwaff():
     assert result == expected
 
 
+def test_simplify_via_aff_reproducibility():
+    # See https://github.com/inducer/loopy/pull/349
+    from loopy.symbolic import parse
+    from loopy.isl_helpers import simplify_via_aff
+
+    expr = parse("i+i_0")
+
+    assert simplify_via_aff(expr) == expr
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
On main, the following fails intermittently:

```python
from loopy.symbolic import parse
from loopy.isl_helpers import simplify_via_aff

expr = parse("i+i_0")

assert simplify_via_aff(expr) == expr
```