### PR TITLE
Fix complex abs.

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -518,7 +518,7 @@ class CMathCallable(ScalarCallable):
             if name in ["abs", "real", "imag"]:
                 dtype = real_dtype
 
-            if dtype.kind == "c" or name in ["real", "imag"]:
+            if dtype.kind == "c" or name in ["real", "imag", "abs"]:
                 if name != "conj":
                     name = "c" + name
 

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -501,6 +501,7 @@ def test_complex_support(ctx_factory, target):
             euler1_imag[i] = imag(euler1[i])
             real_times_complex[i] = in1[i]*(in2[i]*1j)
             real_plus_complex[i] = in1[i] + (in2[i]*1j)
+            abs_complex[i] = cabs(real_plus_complex[i])
             complex_div_complex[i] = (2jf + 7*in1[i])/(32jf + 37*in1[i])
             complex_div_real[i] = (2jf + 7*in1[i])/in1[i]
             real_div_complex[i] = in1[i]/(2jf + 7*in1[i])
@@ -533,6 +534,7 @@ def test_complex_support(ctx_factory, target):
     np.testing.assert_allclose(out["euler1_imag"], 0, atol=1e-10)
     np.testing.assert_allclose(out["real_times_complex"], in1*(in2*1j))
     np.testing.assert_allclose(out["real_plus_complex"], in1+(in2*1j))
+    np.testing.assert_allclose(out["abs_complex"], np.sqrt(in1**2+in2**2))
     np.testing.assert_allclose(out["complex_div_complex"], (2j+7*in1)/(32j+37*in1))
     np.testing.assert_allclose(out["complex_div_real"], (2j + 7*in1)/in1)
     np.testing.assert_allclose(out["real_div_complex"], in1/(2j + 7*in1))

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -501,7 +501,7 @@ def test_complex_support(ctx_factory, target):
             euler1_imag[i] = imag(euler1[i])
             real_times_complex[i] = in1[i]*(in2[i]*1j)
             real_plus_complex[i] = in1[i] + (in2[i]*1j)
-            abs_complex[i] = cabs(real_plus_complex[i])
+            abs_complex[i] = abs(real_plus_complex[i])
             complex_div_complex[i] = (2jf + 7*in1[i])/(32jf + 37*in1[i])
             complex_div_real[i] = (2jf + 7*in1[i])/in1[i]
             real_div_complex[i] = in1[i]/(2jf + 7*in1[i])
@@ -534,7 +534,7 @@ def test_complex_support(ctx_factory, target):
     np.testing.assert_allclose(out["euler1_imag"], 0, atol=1e-10)
     np.testing.assert_allclose(out["real_times_complex"], in1*(in2*1j))
     np.testing.assert_allclose(out["real_plus_complex"], in1+(in2*1j))
-    np.testing.assert_allclose(out["abs_complex"], np.sqrt(in1**2+in2**2))
+    np.testing.assert_allclose(out["abs_complex"], np.abs(out["real_plus_complex"]))
     np.testing.assert_allclose(out["complex_div_complex"], (2j+7*in1)/(32j+37*in1))
     np.testing.assert_allclose(out["complex_div_real"], (2j + 7*in1)/in1)
     np.testing.assert_allclose(out["real_div_complex"], in1/(2j + 7*in1))


### PR DESCRIPTION
Hi. Firedrake complex was failing tests, because `abs` instead of `cabs` was being used. This PR is fixing that.