### PR TITLE
Use pyopencl Array constructor fast path in invoker

### DIFF
--- a/loopy/target/execution.py
+++ b/loopy/target/execution.py
@@ -696,7 +696,7 @@ typed_and_scheduled_cache = WriteOncePersistentDict(
 
 
 invoker_cache = WriteOncePersistentDict(
-        "loopy-invoker-cache-v1-"+DATA_MODEL_VERSION,
+        "loopy-invoker-cache-v10-"+DATA_MODEL_VERSION,
         key_builder=LoopyKeyBuilder())
 
 

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -493,9 +493,9 @@ class PyOpenCLTarget(OpenCLTarget):
             use_int8_for_bool=use_int8_for_bool)
 
         import pyopencl.version
-        if pyopencl.version.VERSION < (2021, 1):
+        if pyopencl.version.VERSION < (2021, 2):
             raise RuntimeError("The version of loopy you have installed "
-                    "generates invoker code that requires PyOpenCL 2021.1 "
+                    "generates invoker code that requires PyOpenCL 2021.2 "
                     "or newer.")
 
         self.device = device


### PR DESCRIPTION
- [x] Needs https://github.com/conda-forge/pyopencl-feedstock/pull/64

Together with https://github.com/inducer/meshmode/pull/180, this should help make the array constructor a much smaller factor in our profiles.

cc @matthiasdiener 