### PR TITLE
[callables] Use simplify_via_aff instead of distribute to simplify affine expressions

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -1264,7 +1264,7 @@ def _are_sub_array_refs_equivalent(sar1, sar2, caller):
 
     from loopy.symbolic import SubstitutionMapper
     from pymbolic.mapper.substitutor import make_subst_func
-    from pymbolic.mapper.distributor import distribute
+    from loopy.isl_helpers import simplify_via_aff
     subst_func = make_subst_func({iname1.name:  iname2
                                   for iname1, iname2 in zip(sar1.swept_inames,
                                                             sar2.swept_inames)
@@ -1275,7 +1275,7 @@ def _are_sub_array_refs_equivalent(sar1, sar2, caller):
 
     for idx1, idx2 in zip(sar1.subscript.index_tuple,
                           sar2.subscript.index_tuple):
-        if distribute(subst_mapper(idx1) - idx2) != 0:
+        if simplify_via_aff(subst_mapper(idx1) - idx2) != 0:
             return False
     return True
 

--- a/test/test_callables.py
+++ b/test/test_callables.py
@@ -792,6 +792,32 @@ def test_double_hw_axes_used_in_knl_call(inline):
         lp.generate_code_v2(knl)
 
 
+@pytest.mark.parametrize("inline", [True, False])
+def test_kc_with_floor_div_in_expr(ctx_factory, inline):
+    # See https://github.com/inducer/loopy/issues/366
+    import loopy as lp
+
+    ctx = ctx_factory()
+    callee = lp.make_function(
+            "{[i]: 0<=i<10}",
+            """
+            x[i] = 2*x[i]
+            """, name="callee_with_update")
+
+    knl = lp.make_kernel(
+            "{[i]: 0<=i<10}",
+            """
+            [i]: x[2*(i//2) + (i%2)] = callee_with_update([i]: x[i])
+            """)
+
+    knl = lp.merge([knl, callee])
+
+    if inline:
+        knl = lp.inline_callable_kernel(knl, "callee_with_update")
+
+    lp.auto_test_vs_ref(knl, ctx, knl)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Fixes #366 

- Targets #222 