### PR TITLE
[callables] Account for callables_table within cache_key before linearization

### DIFF
--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -2148,7 +2148,9 @@ def get_one_scheduled_kernel(kernel, callables_table):
 def get_one_linearized_kernel(kernel, callables_table):
     from loopy import CACHING_ENABLED
 
-    sched_cache_key = kernel
+    # must include *callables_table* within the cache key as the preschedule
+    # checks depend on it.
+    sched_cache_key = (kernel, callables_table)
     from_cache = False
 
     if CACHING_ENABLED:

--- a/test/test_callables.py
+++ b/test/test_callables.py
@@ -802,26 +802,26 @@ def test_unused_hw_axes_in_callee(ctx_factory, inline):
 def test_double_hw_axes_used_in_knl_call(inline):
     from loopy.diagnostic import LoopyError
 
-    thrice = lp.make_function(
+    twice = lp.make_function(
             "{[i]: 0<=i<10}",
             """
             y[i] = 2*x[i]
-            """, name="thrice")
+            """, name="twice")
 
     knl = lp.make_kernel(
             "{[i]: 0<=i<10}",
             """
-            y[:, i] = thrice(x[:, i])
+            y[:, i] = twice(x[:, i])
             """, [lp.GlobalArg("x", shape=(10, 10), dtype=float),
                 lp.GlobalArg("y", shape=(10, 10))],
             name="outer")
 
-    thrice = lp.tag_inames(thrice, {"i": "l.0"})
+    twice = lp.tag_inames(twice, {"i": "l.0"})
     knl = lp.tag_inames(knl, {"i": "l.0"})
-    knl = lp.merge([knl, thrice])
+    knl = lp.merge([knl, twice])
 
     if inline:
-        knl = lp.inline_callable_kernel(knl, "thrice")
+        knl = lp.inline_callable_kernel(knl, "twice")
 
     with pytest.raises(LoopyError):
         lp.generate_code_v2(knl)


### PR DESCRIPTION
- Target #222 

Also gets rid of false advertising of calling a kernel as `thrice`, when it really was a `twice` kernel.