### PR TITLE
[callables] Adds an early exit criterion for a translation unit's type-inference

### DIFF
--- a/loopy/type_inference.py
+++ b/loopy/type_inference.py
@@ -1000,6 +1000,16 @@ def infer_unknown_types(program, expect_completion=False):
 
     program = resolve_callables(program)
 
+    # {{{ early-exit criterion
+
+    if all(clbl.is_type_specialized()
+           for clbl in program.callables_table.values()):
+        # all the callables including the kernels have inferred their types
+        # => no need for type inference
+        return program
+
+    # }}}
+
     clbl_inf_ctx = make_clbl_inf_ctx(program.callables_table,
             program.entrypoints)
 


### PR DESCRIPTION
Targets #222 

Passes the "Benchmarks CI": https://gitlab.tiker.net/inducer/loopy/-/jobs/276524