### PR TITLE
Do not access LoopKernel.schedule

### DIFF
--- a/loopy/auto_test.py
+++ b/loopy/auto_test.py
@@ -529,7 +529,7 @@ def auto_test_vs_ref(
 
         test_knl = lp.preprocess_kernel(test_knl)
 
-    if not test_knl.schedule:
+    if not test_knl.linearization:
         test_kernels = lp.generate_loop_schedules(test_knl)
     else:
         test_kernels = [test_knl]

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -411,7 +411,7 @@ def generate_code_v2(kernel):
         from loopy.preprocess import preprocess_kernel
         kernel = preprocess_kernel(kernel)
 
-    if kernel.schedule is None:
+    if kernel.linearization is None:
         from loopy.schedule import get_one_linearized_kernel
         kernel = get_one_linearized_kernel(kernel)
 
@@ -500,7 +500,7 @@ def generate_code_v2(kernel):
                 kernel.target.host_program_name_prefix
                 + kernel.name
                 + kernel.target.host_program_name_suffix),
-            schedule_index_end=len(kernel.schedule),
+            schedule_index_end=len(kernel.linearization),
             codegen_cachemanager=CodegenOperationCacheManager.from_kernel(kernel),
             )
 

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -35,7 +35,7 @@ def synthesize_idis_for_extra_args(kernel, schedule_index):
     """
     :returns: A list of :class:`loopy.codegen.ImplementedDataInfo`
     """
-    sched_item = kernel.schedule[schedule_index]
+    sched_item = kernel.linearization[schedule_index]
 
     from loopy.codegen import ImplementedDataInfo
     from loopy.kernel.data import InameArg, AddressSpace
@@ -66,13 +66,13 @@ def synthesize_idis_for_extra_args(kernel, schedule_index):
 
 def generate_code_for_sched_index(codegen_state, sched_index):
     kernel = codegen_state.kernel
-    sched_item = kernel.schedule[sched_index]
+    sched_item = kernel.linearization[sched_index]
 
     if isinstance(sched_item, CallKernel):
         assert not codegen_state.is_generating_device_code
 
         from loopy.schedule import (gather_schedule_block, get_insn_ids_for_block_at)
-        _, past_end_i = gather_schedule_block(kernel.schedule, sched_index)
+        _, past_end_i = gather_schedule_block(kernel.linearization, sched_index)
         assert past_end_i <= codegen_state.schedule_index_end
 
         extra_args = synthesize_idis_for_extra_args(kernel, sched_index)
@@ -89,7 +89,7 @@ def generate_code_for_sched_index(codegen_state, sched_index):
                 new_codegen_state, sched_index)
 
         glob_grid, loc_grid = kernel.get_grid_sizes_for_insn_ids_as_exprs(
-                get_insn_ids_for_block_at(kernel.schedule, sched_index))
+                get_insn_ids_for_block_at(kernel.linearization, sched_index))
 
         return merge_codegen_results(codegen_state, [
             codegen_result,
@@ -176,7 +176,7 @@ def generate_code_for_sched_index(codegen_state, sched_index):
 
 def get_required_predicates(kernel, sched_index):
     result = None
-    for _, sched_item in generate_sub_sched_items(kernel.schedule, sched_index):
+    for _, sched_item in generate_sub_sched_items(kernel.linearization, sched_index):
         if isinstance(sched_item, Barrier):
             my_preds = frozenset()
         elif isinstance(sched_item, RunInstruction):
@@ -238,7 +238,7 @@ def build_loop_nest(codegen_state, schedule_index):
 
     i = schedule_index
     while i < codegen_state.schedule_index_end:
-        sched_item = kernel.schedule[i]
+        sched_item = kernel.linearization[i]
 
         if isinstance(sched_item, LeaveLoop):
             break
@@ -246,7 +246,7 @@ def build_loop_nest(codegen_state, schedule_index):
         my_sched_indices.append(i)
 
         if isinstance(sched_item, (EnterLoop, CallKernel)):
-            _, i = gather_schedule_block(kernel.schedule, i)
+            _, i = gather_schedule_block(kernel.linearization, i)
             assert i <= codegen_state.schedule_index_end, \
                     "schedule block extends beyond schedule_index_end"
 

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -121,7 +121,7 @@ def get_slab_decomposition(kernel, iname):
 def generate_unroll_loop(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
-    iname = kernel.schedule[sched_index].iname
+    iname = kernel.linearization[sched_index].iname
 
     bounds = kernel.get_iname_bounds(iname, constants_only=True)
 
@@ -163,7 +163,7 @@ def generate_unroll_loop(codegen_state, sched_index):
 def generate_vectorize_loop(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
-    iname = kernel.schedule[sched_index].iname
+    iname = kernel.linearization[sched_index].iname
 
     bounds = kernel.get_iname_bounds(iname, constants_only=True)
 
@@ -236,7 +236,7 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
                 LocalIndexTag, GroupIndexTag, VectorizeTag)
 
     from loopy.schedule import get_insn_ids_for_block_at
-    insn_ids_for_block = get_insn_ids_for_block_at(kernel.schedule, schedule_index)
+    insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization, schedule_index)
 
     if hw_inames_left is None:
         all_inames_by_insns = set()
@@ -348,7 +348,7 @@ def generate_sequential_loop_dim_code(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
     ecm = codegen_state.expression_to_code_mapper
-    loop_iname = kernel.schedule[sched_index].iname
+    loop_iname = kernel.linearization[sched_index].iname
 
     slabs = get_slab_decomposition(kernel, loop_iname)
 

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -236,7 +236,8 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
                 LocalIndexTag, GroupIndexTag, VectorizeTag)
 
     from loopy.schedule import get_insn_ids_for_block_at
-    insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization, schedule_index)
+    insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization,
+                                                   schedule_index)
 
     if hw_inames_left is None:
         all_inames_by_insns = set()

--- a/loopy/codegen/result.py
+++ b/loopy/codegen/result.py
@@ -292,7 +292,8 @@ def generate_host_or_device_program(codegen_state, schedule_index):
     from loopy.codegen.control import build_loop_nest
     if codegen_state.is_generating_device_code:
         from loopy.schedule import CallKernel
-        assert isinstance(codegen_state.kernel.linearization[schedule_index], CallKernel)
+        assert isinstance(codegen_state.kernel.linearization[schedule_index],
+                          CallKernel)
 
         from loopy.codegen.loop import set_up_hw_parallel_loops
         codegen_result = set_up_hw_parallel_loops(

--- a/loopy/codegen/result.py
+++ b/loopy/codegen/result.py
@@ -292,7 +292,7 @@ def generate_host_or_device_program(codegen_state, schedule_index):
     from loopy.codegen.control import build_loop_nest
     if codegen_state.is_generating_device_code:
         from loopy.schedule import CallKernel
-        assert isinstance(codegen_state.kernel.schedule[schedule_index], CallKernel)
+        assert isinstance(codegen_state.kernel.linearization[schedule_index], CallKernel)
 
         from loopy.codegen.loop import set_up_hw_parallel_loops
         codegen_result = set_up_hw_parallel_loops(

--- a/loopy/codegen/tools.py
+++ b/loopy/codegen/tools.py
@@ -73,7 +73,7 @@ class KernelProxyForCodegenOperationCacheManager:
         # relevant to CodegenOperationCacheManager
         return (self.inames == other.inames
                 and self.instructions == other.instructions
-                and self.schedule == other.schedule)
+                and self.schedule == other.linearization)
 
 
 class CodegenOperationCacheManager:
@@ -96,7 +96,7 @@ class CodegenOperationCacheManager:
         assert isinstance(kernel, LoopKernel)
         return CodegenOperationCacheManager(
                 KernelProxyForCodegenOperationCacheManager(kernel.instructions,
-                            kernel.schedule,
+                            kernel.linearization,
                             kernel.inames))
 
     def with_kernel(self, kernel):

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -394,11 +394,11 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                 # these should not both be present
                 raise ValueError(
                     "received both `schedule` and `linearization` args, "
-                    "'LoopKernel.schedule' is deprecated. "
+                    "'LoopKernel.linearization' is deprecated. "
                     "Use 'LoopKernel.linearization'.")
         elif schedule is not None:
             warn(
-                "'LoopKernel.schedule' is deprecated. "
+                "'LoopKernel.linearization' is deprecated. "
                 "Use 'LoopKernel.linearization'.",
                 DeprecationWarning, stacklevel=2)
             linearization = schedule
@@ -771,7 +771,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
     @property
     def schedule(self):
         warn(
-                "LoopKernel.schedule is deprecated. "
+                "LoopKernel.linearization is deprecated. "
                 "Call LoopKernel.linearization instead, "
                 "will be unsupported in 2022.",
                 DeprecationWarning, stacklevel=2)
@@ -1410,12 +1410,12 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                         "(use loopy.show_dependency_graph to visualize)")
             lines.extend(dep_lines)
 
-        if "schedule" in what and kernel.schedule is not None:
+        if "schedule" in what and kernel.linearization is not None:
             lines.extend(sep)
             if show_labels:
                 lines.append("LINEARIZATION:")
             from loopy.schedule import dump_schedule
-            lines.append(dump_schedule(kernel, kernel.schedule))
+            lines.append(dump_schedule(kernel, kernel.linearization))
 
         lines.extend(sep)
 
@@ -1541,7 +1541,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
             "domains",
             "instructions",
             "args",
-            "schedule",
+            "linearization",
             "name",
             "preambles",
             "assumptions",

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -473,7 +473,7 @@ def get_dot_dependency_graph(kernel, iname_cluster=True, use_insn_id=False):
     from loopy.kernel.creation import apply_single_writer_depencency_heuristic
     kernel = apply_single_writer_depencency_heuristic(kernel, warn_if_used=False)
 
-    if iname_cluster and not kernel.schedule:
+    if iname_cluster and not kernel.linearization:
         try:
             from loopy.schedule import get_one_linearized_kernel
             kernel = get_one_linearized_kernel(kernel)
@@ -550,7 +550,7 @@ def get_dot_dependency_graph(kernel, iname_cluster=True, use_insn_id=False):
                 EnterLoop, LeaveLoop, RunInstruction, Barrier,
                 CallKernel, ReturnFromKernel)
 
-        for sched_item in kernel.schedule:
+        for sched_item in kernel.linearization:
             if isinstance(sched_item, EnterLoop):
                 lines.append('subgraph cluster_%s { label="%s"'
                         % (sched_item.iname, sched_item.iname))
@@ -1736,7 +1736,7 @@ def get_subkernels(kernel):
     from loopy.schedule import CallKernel
 
     return tuple(sched_item.kernel_name
-            for sched_item in kernel.schedule
+            for sched_item in kernel.linearization
             if isinstance(sched_item, CallKernel))
 
 
@@ -1756,7 +1756,7 @@ def get_subkernel_to_insn_id_map(kernel):
     subkernel = None
     result = {}
 
-    for sched_item in kernel.schedule:
+    for sched_item in kernel.linearization:
         if isinstance(sched_item, CallKernel):
             subkernel = sched_item.kernel_name
             result[subkernel] = set()

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -1955,7 +1955,9 @@ def generate_loop_schedules_inner(kernel, debug_args={}):
 
     debug = ScheduleDebugger(**debug_args)
 
-    preschedule = kernel.linearization if kernel.state == KernelState.LINEARIZED else ()
+    preschedule = (kernel.linearization
+                   if kernel.state == KernelState.LINEARIZED
+                   else ())
 
     prescheduled_inames = {
             insn.iname

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -169,11 +169,11 @@ def get_insn_ids_for_block_at(schedule, start_idx):
 
 
 def find_used_inames_within(kernel, sched_index):
-    sched_item = kernel.schedule[sched_index]
+    sched_item = kernel.linearization[sched_index]
 
     if isinstance(sched_item, BeginBlockItem):
         loop_contents, _ = gather_schedule_block(
-                kernel.schedule, sched_index)
+                kernel.linearization, sched_index)
         run_insns = [subsched_item
                 for subsched_item in loop_contents
                 if isinstance(subsched_item, RunInstruction)]
@@ -1955,7 +1955,7 @@ def generate_loop_schedules_inner(kernel, debug_args={}):
 
     debug = ScheduleDebugger(**debug_args)
 
-    preschedule = kernel.schedule if kernel.state == KernelState.LINEARIZED else ()
+    preschedule = kernel.linearization if kernel.state == KernelState.LINEARIZED else ()
 
     prescheduled_inames = {
             insn.iname

--- a/loopy/schedule/device_mapping.py
+++ b/loopy/schedule/device_mapping.py
@@ -43,7 +43,7 @@ def map_schedule_onto_host_or_device(kernel):
             [CallKernel(kernel_name=device_prog_name_gen(),
                         extra_args=[],
                         extra_inames=[])] +
-            list(kernel.schedule) +
+            list(kernel.linearization) +
             [ReturnFromKernel(kernel_name=kernel.name)])
         kernel = kernel.copy(linearization=new_schedule)
     else:
@@ -54,7 +54,7 @@ def map_schedule_onto_host_or_device(kernel):
 
 
 def map_schedule_onto_host_or_device_impl(kernel, device_prog_name_gen):
-    schedule = kernel.schedule
+    schedule = kernel.linearization
     loop_bounds = get_block_boundaries(schedule)
 
     # {{{ inner mapper function

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -78,7 +78,7 @@ def add_extra_args_to_schedule(kernel):
     new_schedule = []
     from loopy.schedule import CallKernel
 
-    for sched_item in kernel.schedule:
+    for sched_item in kernel.linearization:
         if isinstance(sched_item, CallKernel):
             subkernel = sched_item.kernel_name
 

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1787,7 +1787,7 @@ def get_synchronization_map(knl, subgroup_size=None):
         else:
             return one
 
-    for sched_item in knl.schedule:
+    for sched_item in knl.linearization:
         if isinstance(sched_item, EnterLoop):
             if sched_item.iname:  # (if not empty)
                 iname_list.append(sched_item.iname)

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -618,7 +618,7 @@ class CFamilyASTBuilder(ASTBuilderBase):
         # whether this is the first device program in the schedule.
         is_first_dev_prog = codegen_state.is_generating_device_code
         for i in range(schedule_index):
-            if isinstance(kernel.schedule[i], CallKernel):
+            if isinstance(kernel.linearization[i], CallKernel):
                 is_first_dev_prog = False
                 break
         if is_first_dev_prog:
@@ -707,7 +707,7 @@ class CFamilyASTBuilder(ASTBuilderBase):
         from loopy.schedule.tools import (
                 temporaries_read_in_subkernel,
                 temporaries_written_in_subkernel)
-        subkernel = kernel.schedule[schedule_index].kernel_name
+        subkernel = kernel.linearization[schedule_index].kernel_name
         sub_knl_temps = (
                 temporaries_read_in_subkernel(kernel, subkernel) |
                 temporaries_written_in_subkernel(kernel, subkernel))

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -260,7 +260,7 @@ class CUDACASTBuilder(CFamilyASTBuilder):
         _, local_grid_size = \
                 codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                         get_insn_ids_for_block_at(
-                            codegen_state.kernel.schedule, schedule_index))
+                            codegen_state.kernel.linearization, schedule_index))
 
         from loopy.symbolic import get_dependencies
         if not get_dependencies(local_grid_size):

--- a/loopy/target/execution.py
+++ b/loopy/target/execution.py
@@ -769,7 +769,7 @@ class KernelExecutorBase:
             from loopy.type_inference import infer_unknown_types
             kernel = infer_unknown_types(kernel, expect_completion=True)
 
-        if kernel.schedule is None:
+        if kernel.linearization is None:
             from loopy.preprocess import preprocess_kernel
             kernel = preprocess_kernel(kernel)
 

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -468,7 +468,7 @@ class OpenCLCASTBuilder(CFamilyASTBuilder):
         from loopy.schedule import get_insn_ids_for_block_at
         _, local_sizes = codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                 get_insn_ids_for_block_at(
-                    codegen_state.kernel.schedule, schedule_index))
+                    codegen_state.kernel.linearization, schedule_index))
 
         from loopy.symbolic import get_dependencies
         if not get_dependencies(local_sizes):

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -71,7 +71,7 @@ def test_ispc_target(occa_mode=False):
             default_tag="l.auto")
 
     codegen_result = lp.generate_code_v2(
-                lp.get_one_scheduled_kernel(
+                lp.get_one_linearized_kernel(
                     lp.preprocess_kernel(knl)))
 
     print(codegen_result.device_code())
@@ -97,7 +97,7 @@ def test_cuda_target():
 
     print(
             lp.generate_code(
-                lp.get_one_scheduled_kernel(
+                lp.get_one_linearized_kernel(
                     lp.preprocess_kernel(knl)))[0])
 
 
@@ -140,7 +140,7 @@ def test_generate_c_snippet():
     knl = lp.prioritize_loops(knl, "I,k_outer,k_inner")
 
     knl = lp.preprocess_kernel(knl)
-    knl = lp.get_one_scheduled_kernel(knl)
+    knl = lp.get_one_linearized_kernel(knl)
     print(lp.generate_body(knl))
 
 
@@ -355,7 +355,7 @@ def test_ispc_streaming_stores():
     knl = lp.set_argument_order(knl, vars + ["n"])
 
     knl = lp.preprocess_kernel(knl)
-    knl = lp.get_one_scheduled_kernel(knl)
+    knl = lp.get_one_linearized_kernel(knl)
     assert "streaming_store(" in lp.generate_code_v2(knl).all_code()
 
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -271,7 +271,7 @@ def test_vectorize(ctx_factory):
     knl = lp.tag_inames(knl, {"i_inner": "vec"})
 
     knl = lp.preprocess_kernel(knl)
-    knl = lp.get_one_scheduled_kernel(knl)
+    knl = lp.get_one_linearized_kernel(knl)
     code, inf = lp.generate_code(knl)
 
     lp.auto_test_vs_ref(


### PR DESCRIPTION
- accessing LoopKernel.schedule warns about its deprecation
- sed commands:
  git grep -l "l\.schedule\b" | xargs sed -i \
      "s/l.scheduled/linearization/g"
  cd test/
  git grep -l "get_one_scheduled_kernel" | xargs sed -i \
      "s/get_one_scheduled/get_one_linearized/g"

Also updated LoopKernel.hash_fields