### PR TITLE
[callables] Test kernel call with non 1-step slice

### DIFF
--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -89,8 +89,7 @@ def make_slab(space, iname, start, stop, step=1):
 
         Not to be confused with the access map of the slice
         ``[start:stop:step]``. This routine simply creates a basic set as
-        advertised above. One could however mimic the access pattern of the
-        corresponding ``slice`` by accessing into an array as ``step * iname``.
+        advertised above.
     """
     zero = isl.Aff.zero_on_domain(space)
 

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -83,6 +83,14 @@ def make_slab(space, iname, start, stop, step=1):
 
     :arg step:
         An instance of :class:`int`.
+
+
+    .. note::
+
+        Not to be confused with the access map of the slice
+        ``[start:stop:step]``. This routine simply creates a basic set as
+        advertised above. One could however mimic the access pattern of the
+        corresponding ``slice`` by accessing into an array as ``step * iname``.
     """
     zero = isl.Aff.zero_on_domain(space)
 

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -60,36 +60,34 @@ def dump_space(ls):
 
 # {{{ make_slab
 
-def make_slab(space, iname, start, stop, step=1):
+def make_slab(space, iname, start, stop, iname_multiplier=1):
     """
     Returns an instance of :class:`islpy._isl.BasicSet`, which satisfies the
-    constraint ``start <= step*iname < stop``.
+    constraint ``start <= iname_multiplier*iname < stop``.
 
     :arg space: An instance of :class:`islpy._isl.Space`.
 
     :arg iname:
+
         Either an instance of :class:`str` as a name of the ``iname`` or a
         tuple of ``(iname_dt, iname_dx)`` indicating the *iname* in the space.
 
     :arg start:
+
         An instance of :class:`int`  or an instance of
         :class:`islpy._isl.Aff` indicating the lower bound of
-        ``step*iname``(inclusive).
+        ``iname_multiplier*iname``(inclusive).
 
     :arg stop:
+
         An instance of :class:`int`  or an instance of
         :class:`islpy._isl.Aff` indicating the upper bound of
-        ``step*iname``.
+        ``iname_multiplier*iname``.
 
-    :arg step:
-        An instance of :class:`int`.
+    :arg iname_multiplier:
 
-
-    .. note::
-
-        Not to be confused with the access map of the slice
-        ``[start:stop:step]``. This routine simply creates a basic set as
-        advertised above.
+        A strictly positive :class:`int` denoting *iname*'s coefficient in the
+        above inequality expression.
     """
     zero = isl.Aff.zero_on_domain(space)
 
@@ -119,25 +117,16 @@ def make_slab(space, iname, start, stop, step=1):
 
     iname_aff = zero.add_coefficient_val(iname_dt, iname_idx, 1)
 
-    if step > 0:
+    if iname_multiplier > 0:
         result = (isl.BasicSet.universe(space)
-                # start <= step*iname
+                # start <= iname_multiplier*iname
                 .add_constraint(isl.Constraint.inequality_from_aff(
-                    step*iname_aff - start))
-                # step*iname < stop
+                    iname_multiplier*iname_aff - start))
+                # iname_multiplier*iname < stop
                 .add_constraint(isl.Constraint.inequality_from_aff(
-                    stop-1 - step*iname_aff)))
-    elif step < 0:
-        result = (isl.BasicSet.universe(space)
-                # start >= (-step)*iname
-                .add_constraint(isl.Constraint.inequality_from_aff(
-                    step*iname_aff + start))
-                # (-step)*iname > stop
-                .add_constraint(isl.Constraint.inequality_from_aff(
-                    -stop-1 - step*iname_aff)))
+                    stop-1 - iname_multiplier*iname_aff)))
     else:
-        # step = 0
-        raise LoopyError("0 step not allowed in make_slab.")
+        raise LoopyError("iname_multiplier must be strictly positive")
 
     return result
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -1924,6 +1924,9 @@ def normalize_slice_params(slice, dimension_length):
 
     # }}}
 
+    if not isinstance(step, int):
+        raise NotImplementedError("Only integral step sizes supported for now")
+
     return start, stop, step
 
 
@@ -2063,7 +2066,12 @@ class SliceToInameReplacer(IdentityMapper):
 
             from loopy.isl_helpers import make_slab
             for iname, (start, stop, step) in sar_bounds.items():
-                iname_set = iname_set & make_slab(space, iname, start, stop, step)
+                if step > 0:
+                    iname_set = iname_set & make_slab(space, iname, 0,
+                                                      stop-start, step)
+                else:
+                    iname_set = iname_set & make_slab(space, iname, start-stop,
+                                                      -1, step)
 
             subarray_ref_domains.append(iname_set)
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -1899,6 +1899,8 @@ def normalize_slice_params(slice, dimension_length):
     :arg dimension_length: Length of the axis being sliced.
     """
     from pymbolic.primitives import Slice
+    from numbers import Integral
+
     assert isinstance(slice, Slice)
     start, stop, step = slice.start, slice.stop, slice.step
 
@@ -1924,8 +1926,9 @@ def normalize_slice_params(slice, dimension_length):
 
     # }}}
 
-    if not isinstance(step, int):
-        raise NotImplementedError("Only integral step sizes supported for now")
+    if not isinstance(step, Integral):
+        raise LoopyError("Non-integral step sizes lead to non-affine domains =>"
+                         " not supported")
 
     return start, stop, step
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2073,8 +2073,8 @@ class SliceToInameReplacer(IdentityMapper):
                     iname_set = iname_set & make_slab(space, iname, 0,
                                                       stop-start, step)
                 else:
-                    iname_set = iname_set & make_slab(space, iname, start-stop,
-                                                      -1, step)
+                    iname_set = iname_set & make_slab(space, iname, 0,
+                                                      start-stop, -step)
 
             subarray_ref_domains.append(iname_set)
 

--- a/test/test_callables.py
+++ b/test/test_callables.py
@@ -855,39 +855,47 @@ def test_kc_with_floor_div_in_expr(ctx_factory, inline):
     lp.auto_test_vs_ref(knl, ctx, knl)
 
 
+@pytest.mark.parametrize("start", [5, 6, 7])
 @pytest.mark.parametrize("inline", [True, False])
-def test_non1_step_slices(ctx_factory, inline):
+def test_non1_step_slices(ctx_factory, start, inline):
     # See https://github.com/inducer/loopy/pull/222#discussion_r645905188
 
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
 
     callee = lp.make_function(
-            "{[i]: 0<=i<12}",
+            "{[i]: 0<=i<n}",
             """
             y[i] = i**2
-            """, name="squared_arange")
+            """,
+            [lp.ValueArg("n"), ...],
+            name="squared_arange")
 
     t_unit = lp.make_kernel(
             "{[i_init, j_init]: 0<=i_init, j_init<40}",
-            """
+            f"""
             X[i_init] = 42
-            X[5:40:3] = squared_arange()
+            X[{start}:40:3] = squared_arange({len(range(start, 40, 3))})
 
             Y[j_init] = 1729
-            Y[39:3:-3] = squared_arange()
+            Y[39:{start}:-3] = squared_arange({len(range(39, start, -3))})
             """,
             [lp.GlobalArg("X,Y", shape=40)],
             seq_dependencies=True)
 
     expected_out1 = 42*np.ones(40, dtype=np.int64)
-    expected_out1[5:40:3] = np.arange(12)**2
+    expected_out1[start:40:3] = np.arange(len(range(start, 40, 3)))**2
 
     expected_out2 = 1729*np.ones(40, dtype=np.int64)
-    expected_out2[39:3:-3] = np.arange(12)**2
+    expected_out2[39:start:-3] = np.arange(len(range(39, start, -3)))**2
 
     t_unit = lp.merge([t_unit, callee])
+
     t_unit = lp.set_options(t_unit, "return_dict")
+
+    # check_bounds isn't smart enough to pass assumptions from caller to callee
+    # during check_bounds
+    t_unit = lp.set_options(t_unit, enforce_array_accesses_within_bounds="no_check")
 
     if inline:
         t_unit = lp.inline_callable_kernel(t_unit, "squared_arange")


### PR DESCRIPTION
Targets #222
Turns out we were doing fine. For the test case we generate the following code. What isn't represented in the domain, we cover it up by setting the strides correctly.

```c
static void squared_arange(__global int *__restrict__ y);
__kernel void __attribute__ ((reqd_work_group_size(1, 1, 1))) loopy_kernel(__global int *__restrict__ Y)
{
  for (int i_init = 0; i_init <= 39; ++i_init)
    Y[i_init] = 1729;
  squared_arange(&(Y[0]));
}

static void squared_arange(__global int *__restrict__ y)
{
  for (int i = 0; i <= 13; ++i)
    y[3 * i] = i * i;
}

```