### PR TITLE
Acually deprecate `LoopKernel.schedule`

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -1005,19 +1005,19 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
         local_axes = set()
 
         i = 0
-        loop_end_i = past_end_i = len(kernel.schedule)
+        loop_end_i = past_end_i = len(kernel.linearization)
     else:
-        assert isinstance(kernel.schedule[sched_index], CallKernel)
-        _, past_end_i = gather_schedule_block(kernel.schedule, sched_index)
+        assert isinstance(kernel.linearization[sched_index], CallKernel)
+        _, past_end_i = gather_schedule_block(kernel.linearization, sched_index)
         group_size, local_size = kernel.get_grid_sizes_for_insn_ids_as_exprs(
-                get_insn_ids_for_block_at(kernel.schedule, sched_index),
+                get_insn_ids_for_block_at(kernel.linearization, sched_index),
                 callables_table, return_dict=True)
 
         group_axes = set(group_size.keys())
         local_axes = set(local_size.keys())
 
         i = sched_index + 1
-        assert isinstance(kernel.schedule[past_end_i - 1], ReturnFromKernel)
+        assert isinstance(kernel.linearization[past_end_i - 1], ReturnFromKernel)
         loop_end_i = past_end_i - 1
 
     # alternative: just disregard length-1 dimensions?
@@ -1026,7 +1026,7 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
                         GroupIndexTag)
 
     while i < loop_end_i:
-        sched_item = kernel.schedule[i]
+        sched_item = kernel.linearization[i]
         if isinstance(sched_item, CallKernel):
             i = _check_for_unused_hw_axes_in_kernel_chunk(kernel,
                     callables_table, i)
@@ -1101,7 +1101,7 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
 
 
 def check_for_unused_hw_axes_in_insns(kernel, callables_table):
-    if kernel.schedule:
+    if kernel.linearization:
         _check_for_unused_hw_axes_in_kernel_chunk(kernel,
                 callables_table)
 
@@ -1195,7 +1195,7 @@ def check_that_all_insns_are_scheduled(kernel):
     from loopy.schedule import sched_item_to_insn_id
     scheduled_insns = {
         insn_id
-        for sched_item in kernel.schedule
+        for sched_item in kernel.linearization
         for insn_id in sched_item_to_insn_id(sched_item)}
 
     assert scheduled_insns <= all_schedulable_insns

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -539,7 +539,7 @@ def generate_code_for_a_single_kernel(kernel, callables_table, target,
                 target.host_program_name_prefix
                 + kernel.name
                 + kernel.target.host_program_name_suffix),
-            schedule_index_end=len(kernel.schedule),
+            schedule_index_end=len(kernel.linearization),
             callables_table=callables_table,
             is_entrypoint=is_entrypoint,
             codegen_cachemanager=CodegenOperationCacheManager.from_kernel(kernel),
@@ -743,7 +743,7 @@ def generate_code_v2(program):
         if isinstance(clbl, CallableKernel):
             from loopy.schedule import get_one_linearized_kernel
             knl = clbl.subkernel
-            if knl.schedule is None:
+            if knl.linearization is None:
                 knl = get_one_linearized_kernel(
                             knl, program.callables_table)
             new_callables[name] = clbl.copy(subkernel=knl)

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -121,7 +121,7 @@ def get_slab_decomposition(kernel, iname):
 def generate_unroll_loop(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
-    iname = kernel.schedule[sched_index].iname
+    iname = kernel.linearization[sched_index].iname
 
     bounds = kernel.get_iname_bounds(iname, constants_only=True)
 
@@ -163,7 +163,7 @@ def generate_unroll_loop(codegen_state, sched_index):
 def generate_vectorize_loop(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
-    iname = kernel.schedule[sched_index].iname
+    iname = kernel.linearization[sched_index].iname
 
     bounds = kernel.get_iname_bounds(iname, constants_only=True)
 
@@ -236,7 +236,8 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
                 LocalIndexTag, GroupIndexTag, VectorizeTag)
 
     from loopy.schedule import get_insn_ids_for_block_at
-    insn_ids_for_block = get_insn_ids_for_block_at(kernel.schedule, schedule_index)
+    insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization,
+                                                   schedule_index)
 
     if hw_inames_left is None:
         all_inames_by_insns = set()
@@ -348,7 +349,7 @@ def generate_sequential_loop_dim_code(codegen_state, sched_index):
     kernel = codegen_state.kernel
 
     ecm = codegen_state.expression_to_code_mapper
-    loop_iname = kernel.schedule[sched_index].iname
+    loop_iname = kernel.linearization[sched_index].iname
 
     slabs = get_slab_decomposition(kernel, loop_iname)
 

--- a/loopy/codegen/result.py
+++ b/loopy/codegen/result.py
@@ -292,7 +292,8 @@ def generate_host_or_device_program(codegen_state, schedule_index):
     from loopy.codegen.control import build_loop_nest
     if codegen_state.is_generating_device_code:
         from loopy.schedule import CallKernel
-        assert isinstance(codegen_state.kernel.schedule[schedule_index], CallKernel)
+        assert isinstance(codegen_state.kernel.linearization[schedule_index],
+                          CallKernel)
 
         from loopy.codegen.loop import set_up_hw_parallel_loops
         codegen_result = set_up_hw_parallel_loops(

--- a/loopy/codegen/tools.py
+++ b/loopy/codegen/tools.py
@@ -96,7 +96,7 @@ class CodegenOperationCacheManager:
         assert isinstance(kernel, LoopKernel)
         return CodegenOperationCacheManager(
                 KernelProxyForCodegenOperationCacheManager(kernel.instructions,
-                            kernel.schedule,
+                            kernel.linearization,
                             kernel.inames))
 
     def with_kernel(self, kernel):

--- a/loopy/codegen/tools.py
+++ b/loopy/codegen/tools.py
@@ -47,7 +47,7 @@ class KernelProxyForCodegenOperationCacheManager:
     :class:`CodegenOperationCacheManager`.
     """
     instructions: List[InstructionBase]
-    schedule: List[ScheduleItem]
+    linearization: List[ScheduleItem]
     inames: Dict[str, Iname]
 
     @property
@@ -73,7 +73,7 @@ class KernelProxyForCodegenOperationCacheManager:
         # relevant to CodegenOperationCacheManager
         return (self.inames == other.inames
                 and self.instructions == other.instructions
-                and self.schedule == other.schedule)
+                and self.linearization == other.linearization)
 
 
 class CodegenOperationCacheManager:
@@ -121,12 +121,12 @@ class CodegenOperationCacheManager:
         """
         active_inames = []
 
-        for i in range(len(self.kernel_proxy.schedule)):
+        for i in range(len(self.kernel_proxy.linearization)):
             if i == 0:
                 active_inames.append(frozenset())
                 continue
 
-            sched_item = self.kernel_proxy.schedule[i-1]
+            sched_item = self.kernel_proxy.linearization[i-1]
             if isinstance(sched_item, EnterLoop):
                 active_inames.append(active_inames[i-1]
                         | frozenset([sched_item.iname]))
@@ -149,12 +149,12 @@ class CodegenOperationCacheManager:
         """
         callkernel_index = []
 
-        for i in range(len(self.kernel_proxy.schedule)):
+        for i in range(len(self.kernel_proxy.linearization)):
             if i == 0:
                 callkernel_index.append(None)
                 continue
 
-            sched_item = self.kernel_proxy.schedule[i-1]
+            sched_item = self.kernel_proxy.linearization[i-1]
 
             if isinstance(sched_item, CallKernel):
                 callkernel_index.append(i-1)
@@ -175,13 +175,14 @@ class CodegenOperationCacheManager:
         """
         has_barrier_within = []
 
-        for sched_idx, sched_item in enumerate(self.kernel_proxy.schedule):
+        for sched_idx, sched_item in enumerate(self.kernel_proxy.linearization):
             if isinstance(sched_item, BeginBlockItem):
                 # TODO: calls to "gather_schedule_block" can be amortized
-                _, endblock_index = gather_schedule_block(self.kernel_proxy.schedule,
-                        sched_idx)
+                _, endblock_index = gather_schedule_block(self.kernel_proxy
+                                                          .linearization,
+                                                          sched_idx)
                 has_barrier_within.append(any(
-                        isinstance(self.kernel_proxy.schedule[i], Barrier)
+                        isinstance(self.kernel_proxy.linearization[i], Barrier)
                         for i in range(sched_idx+1, endblock_index)))
             elif isinstance(sched_item, Barrier):
                 has_barrier_within.append(True)
@@ -196,20 +197,22 @@ class CodegenOperationCacheManager:
         Cached variant of :func:`loopy.schedule.get_insn_ids_for_block_at`.
         """
         from loopy.schedule import get_insn_ids_for_block_at
-        return get_insn_ids_for_block_at(self.kernel_proxy.schedule, sched_index)
+        return get_insn_ids_for_block_at(self.kernel_proxy.linearization,
+                                         sched_index)
 
     @memoize_method
     def get_parallel_inames_in_a_callkernel(self, callkernel_index):
         """
         Returns a :class:`frozenset` of parallel inames in a callkernel
 
-        :arg callkernel_index: Index of the :class:`loopy.schedule.CallKernel` in
-            the :attr:`CodegenOperationCacheManager.kernel_proxy`'s schedule, whose
-            parallel inames are to be found.
+        :arg callkernel_index: Index of the :class:`loopy.schedule.CallKernel`
+            in the :attr:`CodegenOperationCacheManager.kernel_proxy`'s
+            schedule, whose parallel inames are to be found.
         """
 
         from loopy.kernel.data import ConcurrentTag
-        assert isinstance(self.kernel_proxy.schedule[callkernel_index], CallKernel)
+        assert isinstance(self.kernel_proxy.linearization[callkernel_index],
+                          CallKernel)
         insn_ids_in_subkernel = self.get_insn_ids_for_block_at(callkernel_index)
 
         inames_in_subkernel = {iname

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -384,11 +384,11 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                 # these should not both be present
                 raise ValueError(
                     "received both `schedule` and `linearization` args, "
-                    "'LoopKernel.schedule' is deprecated. "
+                    "'LoopKernel.linearization' is deprecated. "
                     "Use 'LoopKernel.linearization'.")
         elif schedule is not None:
             warn(
-                "'LoopKernel.schedule' is deprecated. "
+                "'LoopKernel.linearization' is deprecated. "
                 "Use 'LoopKernel.linearization'.",
                 DeprecationWarning, stacklevel=2)
             linearization = schedule
@@ -730,7 +730,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
     @property
     def schedule(self):
         warn(
-                "LoopKernel.schedule is deprecated. "
+                "LoopKernel.linearization is deprecated. "
                 "Call LoopKernel.linearization instead, "
                 "will be unsupported in 2022.",
                 DeprecationWarning, stacklevel=2)
@@ -1440,12 +1440,12 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                         "(use loopy.show_dependency_graph to visualize)")
             lines.extend(dep_lines)
 
-        if "schedule" in what and kernel.schedule is not None:
+        if "schedule" in what and kernel.linearization is not None:
             lines.extend(sep)
             if show_labels:
                 lines.append("LINEARIZATION:")
             from loopy.schedule import dump_schedule
-            lines.append(dump_schedule(kernel, kernel.schedule))
+            lines.append(dump_schedule(kernel, kernel.linearization))
 
         lines.extend(sep)
 

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -376,9 +376,6 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                 ]:
             raise ValueError("invalid value for 'state'")
 
-        # `linearization` is replacing `schedule`, but we're not changing
-        # this under the hood yet, so for now, store it inside `schedule`
-        # and raise deprecation warning anyway
         if linearization is not None:
             if schedule is not None:
                 # these should not both be present
@@ -1337,7 +1334,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
             "rules",
             "instructions",
             "Dependencies",
-            "schedule",
+            "linearization",
             }
 
         first_letter_to_what = {
@@ -1440,7 +1437,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
                         "(use loopy.show_dependency_graph to visualize)")
             lines.extend(dep_lines)
 
-        if "schedule" in what and kernel.linearization is not None:
+        if "linearization" in what and kernel.linearization is not None:
             lines.extend(sep)
             if show_labels:
                 lines.append("LINEARIZATION:")
@@ -1568,7 +1565,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
             "domains",
             "instructions",
             "args",
-            "schedule",
+            "linearization",
             "name",
             "preambles",
             "assumptions",

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -509,7 +509,7 @@ def get_dot_dependency_graph(kernel, callables_table, iname_cluster=True,
     from loopy.kernel.creation import apply_single_writer_depencency_heuristic
     kernel = apply_single_writer_depencency_heuristic(kernel, warn_if_used=False)
 
-    if iname_cluster and not kernel.schedule:
+    if iname_cluster and not kernel.linearization:
         try:
             from loopy.schedule import get_one_linearized_kernel
             kernel = get_one_linearized_kernel(kernel, callables_table)
@@ -586,7 +586,7 @@ def get_dot_dependency_graph(kernel, callables_table, iname_cluster=True,
                 EnterLoop, LeaveLoop, RunInstruction, Barrier,
                 CallKernel, ReturnFromKernel)
 
-        for sched_item in kernel.schedule:
+        for sched_item in kernel.linearization:
             if isinstance(sched_item, EnterLoop):
                 lines.append('subgraph cluster_%s { label="%s"'
                         % (sched_item.iname, sched_item.iname))
@@ -1776,7 +1776,7 @@ def get_subkernels(kernel):
     from loopy.schedule import CallKernel
 
     return tuple(sched_item.kernel_name
-            for sched_item in kernel.schedule
+            for sched_item in kernel.linearization
             if isinstance(sched_item, CallKernel))
 
 
@@ -1796,7 +1796,7 @@ def get_subkernel_to_insn_id_map(kernel):
     subkernel = None
     result = {}
 
-    for sched_item in kernel.schedule:
+    for sched_item in kernel.linearization:
         if isinstance(sched_item, CallKernel):
             subkernel = sched_item.kernel_name
             result[subkernel] = set()

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -169,11 +169,11 @@ def get_insn_ids_for_block_at(schedule, start_idx):
 
 
 def find_used_inames_within(kernel, sched_index):
-    sched_item = kernel.schedule[sched_index]
+    sched_item = kernel.linearization[sched_index]
 
     if isinstance(sched_item, BeginBlockItem):
         loop_contents, _ = gather_schedule_block(
-                kernel.schedule, sched_index)
+                kernel.linearization, sched_index)
         run_insns = [subsched_item
                 for subsched_item in loop_contents
                 if isinstance(subsched_item, RunInstruction)]
@@ -1959,7 +1959,9 @@ def generate_loop_schedules_inner(kernel, callables_table, debug_args={}):
 
     debug = ScheduleDebugger(**debug_args)
 
-    preschedule = kernel.schedule if kernel.state == KernelState.LINEARIZED else ()
+    preschedule = (kernel.linearization
+                   if kernel.state == KernelState.LINEARIZED
+                   else ())
 
     prescheduled_inames = {
             insn.iname

--- a/loopy/schedule/device_mapping.py
+++ b/loopy/schedule/device_mapping.py
@@ -43,7 +43,7 @@ def map_schedule_onto_host_or_device(kernel):
             [CallKernel(kernel_name=device_prog_name_gen(),
                         extra_args=[],
                         extra_inames=[])] +
-            list(kernel.schedule) +
+            list(kernel.linearization) +
             [ReturnFromKernel(kernel_name=kernel.name)])
         kernel = kernel.copy(linearization=new_schedule)
     else:
@@ -54,7 +54,7 @@ def map_schedule_onto_host_or_device(kernel):
 
 
 def map_schedule_onto_host_or_device_impl(kernel, device_prog_name_gen):
-    schedule = kernel.schedule
+    schedule = kernel.linearization
     loop_bounds = get_block_boundaries(schedule)
 
     # {{{ inner mapper function

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -78,7 +78,7 @@ def add_extra_args_to_schedule(kernel):
     new_schedule = []
     from loopy.schedule import CallKernel
 
-    for sched_item in kernel.schedule:
+    for sched_item in kernel.linearization:
         if isinstance(sched_item, CallKernel):
             subkernel = sched_item.kernel_name
 

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -2043,7 +2043,7 @@ def _get_synchronization_map_for_single_kernel(knl, callables_table,
 
     iname_list = []
 
-    for sched_item in knl.schedule:
+    for sched_item in knl.linearization:
         if isinstance(sched_item, EnterLoop):
             if sched_item.iname:  # (if not empty)
                 iname_list.append(sched_item.iname)

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -699,7 +699,7 @@ class CFamilyASTBuilder(ASTBuilderBase):
         # whether this is the first device program in the schedule.
         is_first_dev_prog = codegen_state.is_generating_device_code
         for i in range(schedule_index):
-            if isinstance(kernel.schedule[i], CallKernel):
+            if isinstance(kernel.linearization[i], CallKernel):
                 is_first_dev_prog = False
                 break
         if is_first_dev_prog:
@@ -792,7 +792,7 @@ class CFamilyASTBuilder(ASTBuilderBase):
         from loopy.schedule.tools import (
                 temporaries_read_in_subkernel,
                 temporaries_written_in_subkernel)
-        subkernel = kernel.schedule[schedule_index].kernel_name
+        subkernel = kernel.linearization[schedule_index].kernel_name
         sub_knl_temps = (
                 temporaries_read_in_subkernel(kernel, subkernel)
                 | temporaries_written_in_subkernel(kernel, subkernel))

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -338,7 +338,7 @@ class CUDACASTBuilder(CFamilyASTBuilder):
         _, local_grid_size = \
                 codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                         get_insn_ids_for_block_at(
-                            codegen_state.kernel.schedule, schedule_index),
+                            codegen_state.kernel.linearization, schedule_index),
                         codegen_state.callables_table)
 
         from loopy.symbolic import get_dependencies

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -619,7 +619,7 @@ class OpenCLCASTBuilder(CFamilyASTBuilder):
         from loopy.schedule import get_insn_ids_for_block_at
         _, local_sizes = codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                 get_insn_ids_for_block_at(
-                    codegen_state.kernel.schedule, schedule_index),
+                    codegen_state.kernel.linearization, schedule_index),
                 codegen_state.callables_table)
 
         from loopy.symbolic import get_dependencies

--- a/loopy/transform/save.py
+++ b/loopy/transform/save.py
@@ -61,12 +61,12 @@ class LivenessAnalysis:
 
     def __init__(self, kernel):
         self.kernel = kernel
-        self.schedule = kernel.schedule
+        self.schedule = kernel.linearization
 
     @memoize_method
     def get_successor_relation(self):
         successors = {}
-        block_bounds = get_block_boundaries(self.kernel.schedule)
+        block_bounds = get_block_boundaries(self.kernel.linearization)
 
         for idx, (item, next_item) in enumerate(zip(
                 reversed(self.schedule),
@@ -314,7 +314,7 @@ class TemporarySaver:
     def subkernel_to_slice_indices(self):
         result = {}
 
-        for sched_item_idx, sched_item in enumerate(self.kernel.schedule):
+        for sched_item_idx, sched_item in enumerate(self.kernel.linearization):
             if isinstance(sched_item, CallKernel):
                 start_idx = sched_item_idx
             elif isinstance(sched_item, ReturnFromKernel):
@@ -329,7 +329,7 @@ class TemporarySaver:
         within_subkernel = False
         result = {}
 
-        for sched_item_idx, sched_item in enumerate(self.kernel.schedule):
+        for sched_item_idx, sched_item in enumerate(self.kernel.linearization):
             if isinstance(sched_item, CallKernel):
                 within_subkernel = True
                 result[sched_item.kernel_name] = frozenset(current_outer_inames)
@@ -354,14 +354,14 @@ class TemporarySaver:
 
         try:
             pre_barrier = next(item for item in
-                self.kernel.schedule[subkernel_start::-1]
+                self.kernel.linearization[subkernel_start::-1]
                 if is_global_barrier(item)).originating_insn_id
         except StopIteration:
             pre_barrier = None
 
         try:
             post_barrier = next(item for item in
-                self.kernel.schedule[subkernel_end:]
+                self.kernel.linearization[subkernel_end:]
                 if is_global_barrier(item)).originating_insn_id
         except StopIteration:
             post_barrier = None
@@ -749,13 +749,13 @@ def save_and_reload_temporaries(program, entrypoint=None):
 
     knl = program[entrypoint]
 
-    if not knl.schedule:
+    if not knl.linearization:
         program = lp.preprocess_program(program)
         from loopy.schedule import get_one_linearized_kernel
         knl = get_one_linearized_kernel(program[entrypoint],
                 program.callables_table)
 
-    assert knl.schedule is not None
+    assert knl.linearization is not None
 
     liveness = LivenessAnalysis(knl)
     saver = TemporarySaver(knl, program.callables_table)
@@ -763,7 +763,7 @@ def save_and_reload_temporaries(program, entrypoint=None):
     from loopy.schedule.tools import (
         temporaries_read_in_subkernel, temporaries_written_in_subkernel)
 
-    for sched_idx, sched_item in enumerate(knl.schedule):
+    for sched_idx, sched_item in enumerate(knl.linearization):
 
         if isinstance(sched_item, CallKernel):
             # Any written temporary that is live-out needs to be read into
@@ -784,7 +784,7 @@ def save_and_reload_temporaries(program, entrypoint=None):
                 saver.reload(temporary, sched_item.kernel_name)
 
         elif isinstance(sched_item, ReturnFromKernel):
-            if sched_idx == len(knl.schedule) - 1:
+            if sched_idx == len(knl.linearization) - 1:
                 # Kernel exit: nothing live
                 interesting_temporaries = set()
             else:

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1107,7 +1107,7 @@ def save_and_reload_temporaries_test(queue, prog, out_expect, debug=False):
 
     from loopy.transform.save import save_and_reload_temporaries
     prog = save_and_reload_temporaries(prog)
-    prog = prog.with_kernel(lp.get_one_scheduled_kernel(prog["loopy_kernel"],
+    prog = prog.with_kernel(lp.get_one_linearized_kernel(prog["loopy_kernel"],
         prog.callables_table))
 
     if debug:
@@ -2071,7 +2071,7 @@ def test_unscheduled_insn_detection():
         "...")
 
     prog = lp.preprocess_kernel(prog)
-    knl = lp.get_one_scheduled_kernel(prog["loopy_kernel"], prog.callables_table)
+    knl = lp.get_one_linearized_kernel(prog["loopy_kernel"], prog.callables_table)
     prog = prog.with_kernel(knl)
     insn1, = lp.find_instructions(prog, "id:insn1")
     insns = prog["loopy_kernel"].instructions[:]
@@ -2240,7 +2240,7 @@ def test_barrier_insertion_near_top_of_loop():
     prog = lp.set_temporary_scope(prog, "a", "local")
     prog = lp.set_temporary_scope(prog, "b", "local")
     prog = lp.preprocess_kernel(prog)
-    knl = lp.get_one_scheduled_kernel(prog["loopy_kernel"], prog.callables_table)
+    knl = lp.get_one_linearized_kernel(prog["loopy_kernel"], prog.callables_table)
 
     print(knl)
 
@@ -2268,7 +2268,7 @@ def test_barrier_insertion_near_bottom_of_loop():
     prog = lp.set_temporary_scope(prog, "a", "local")
     prog = lp.set_temporary_scope(prog, "b", "local")
     prog = lp.preprocess_kernel(prog)
-    knl = lp.get_one_scheduled_kernel(prog["loopy_kernel"], prog.callables_table)
+    knl = lp.get_one_linearized_kernel(prog["loopy_kernel"], prog.callables_table)
 
     print(knl)
 
@@ -2626,7 +2626,7 @@ def test_no_barriers_for_nonoverlapping_access(second_index, expect_barrier):
     prog = lp.tag_inames(prog, "i:l.0")
     prog = lp.preprocess_kernel(prog)
 
-    knl = lp.get_one_scheduled_kernel(prog["loopy_kernel"],
+    knl = lp.get_one_linearized_kernel(prog["loopy_kernel"],
             prog.callables_table)
 
     assert barrier_between(knl, "first", "second") == expect_barrier

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -2199,7 +2199,7 @@ def barrier_between(knl, id1, id2, ignore_barriers_in_levels=()):
     seen_barrier = False
     loop_level = 0
 
-    for sched_item in knl.schedule:
+    for sched_item in knl.linearization:
         if isinstance(sched_item, RunInstruction):
             if sched_item.insn_id == id1:
                 watch_for_barrier = True


### PR DESCRIPTION
Resurrects #393.