### PR TITLE
Actual support for user-defined iname tags, IndexTag -> InameTag

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -343,7 +343,7 @@ def set_options(kernel, *args, **kwargs):
         arg, = args
 
         from loopy.options import make_options
-        new_opt.update(make_options(arg))
+        new_opt._update(make_options(arg))
 
     return kernel.copy(options=new_opt)
 

--- a/loopy/codegen/bounds.py
+++ b/loopy/codegen/bounds.py
@@ -75,10 +75,10 @@ def get_usable_inames_for_conditional(kernel, sched_index, op_cache_manager):
     #  - local indices may not be used in conditionals that cross barriers.
     #  - ILP indices and vector lane indices are not available in loop
     #    bounds, they only get defined at the innermost level of nesting.
-    from loopy.kernel.data import VectorizeTag, LocalIndexTagBase, IlpBaseTag
+    from loopy.kernel.data import VectorizeTag, LocalInameTagBase, IlpBaseTag
     usable_parallel_inames_in_subkernel = frozenset(iname
             for iname in parallel_inames_in_subkernel
-            if (not (kernel.iname_tags_of_type(iname, LocalIndexTagBase)
+            if (not (kernel.iname_tags_of_type(iname, LocalInameTagBase)
                          and crosses_barrier)
                 and not kernel.iname_tags_of_type(iname, VectorizeTag)
                 and not kernel.iname_tags_of_type(iname, IlpBaseTag)))

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -106,7 +106,12 @@ def generate_code_for_sched_index(codegen_state, sched_index):
             return codegen_result
 
     elif isinstance(sched_item, EnterLoop):
-        tags = kernel.iname_tags(sched_item.iname)
+        from loopy.kernel.data import (UnrolledIlpTag, UnrollTag,
+                ForceSequentialTag, LoopedIlpTag, VectorizeTag,
+                InameImplementationTag,
+                InOrderSequentialSequentialTag, filter_iname_tags_by_type)
+
+        tags = kernel.iname_tags_of_type(sched_item.iname, InameImplementationTag)
         tags = tuple(tag for tag in tags if tag)
 
         from loopy.codegen.loop import (
@@ -114,9 +119,6 @@ def generate_code_for_sched_index(codegen_state, sched_index):
                 generate_vectorize_loop,
                 generate_sequential_loop_dim_code)
 
-        from loopy.kernel.data import (UnrolledIlpTag, UnrollTag,
-                ForceSequentialTag, LoopedIlpTag, VectorizeTag,
-                InOrderSequentialSequentialTag, filter_iname_tags_by_type)
         if filter_iname_tags_by_type(tags, (UnrollTag, UnrolledIlpTag)):
             func = generate_unroll_loop
         elif filter_iname_tags_by_type(tags, VectorizeTag):

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -232,8 +232,8 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
         hw_inames_left=None):
     kernel = codegen_state.kernel
 
-    from loopy.kernel.data import (UniqueTag, HardwareConcurrentTag,
-                LocalIndexTag, GroupIndexTag, VectorizeTag)
+    from loopy.kernel.data import (UniqueInameTag, HardwareConcurrentTag,
+                LocalInameTag, GroupInameTag, VectorizeTag)
 
     from loopy.schedule import get_insn_ids_for_block_at
     insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization,
@@ -259,18 +259,18 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
 
     from loopy.symbolic import GroupHardwareAxisIndex, LocalHardwareAxisIndex
 
-    tag, = kernel.iname_tags_of_type(iname, UniqueTag, max_num=1, min_num=1)
+    tag, = kernel.iname_tags_of_type(iname, UniqueInameTag, max_num=1, min_num=1)
 
-    if isinstance(tag, GroupIndexTag):
+    if isinstance(tag, GroupInameTag):
         hw_axis_expr = GroupHardwareAxisIndex(tag.axis)
-    elif isinstance(tag, LocalIndexTag):
+    elif isinstance(tag, LocalInameTag):
         hw_axis_expr = LocalHardwareAxisIndex(tag.axis)
     else:
         raise RuntimeError("unexpected hw tag type")
 
     other_inames_with_same_tag = [
         other_iname for other_iname in kernel.all_inames()
-        if (kernel.iname_tags_of_type(other_iname, UniqueTag)
+        if (kernel.iname_tags_of_type(other_iname, UniqueInameTag)
             and other_iname != iname
             and any(_tag.key == tag.key
                     for _tag in kernel.iname_tags(other_iname)
@@ -278,9 +278,9 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
 
     # {{{ 'implement' hardware axis boundaries
 
-    if isinstance(tag, LocalIndexTag):
+    if isinstance(tag, LocalInameTag):
         hw_axis_size = local_size[tag.axis]
-    elif isinstance(tag, GroupIndexTag):
+    elif isinstance(tag, GroupInameTag):
         hw_axis_size = global_size[tag.axis]
     else:
         raise RuntimeError("unknown hardware parallel tag")

--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -233,7 +233,7 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
     kernel = codegen_state.kernel
 
     from loopy.kernel.data import (UniqueInameTag, HardwareConcurrentTag,
-                LocalInameTag, GroupInameTag, VectorizeTag)
+                LocalInameTag, GroupInameTag, VectorizeTag, InameImplementationTag)
 
     from loopy.schedule import get_insn_ids_for_block_at
     insn_ids_for_block = get_insn_ids_for_block_at(kernel.linearization,
@@ -273,8 +273,8 @@ def set_up_hw_parallel_loops(codegen_state, schedule_index, next_func,
         if (kernel.iname_tags_of_type(other_iname, UniqueInameTag)
             and other_iname != iname
             and any(_tag.key == tag.key
-                    for _tag in kernel.iname_tags(other_iname)
-                    if _tag))]
+                    for _tag in kernel.iname_tags_of_type(
+                        other_iname, InameImplementationTag)))]
 
     # {{{ 'implement' hardware axis boundaries
 

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -733,7 +733,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
         *min_num*.
 
         :arg tags: An iterable of tags.
-        :arg tag_type_or_types: a subclass of :class:`loopy.kernel.data.IndexTag`.
+        :arg tag_type_or_types: a subclass of :class:`loopy.kernel.data.InameTag`.
         :arg max_num: the maximum number of tags expected to be found.
         :arg min_num: the minimum number of tags expected to be found.
         """
@@ -1079,25 +1079,25 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
         # }}}
 
         from loopy.kernel.data import (
-                GroupIndexTag, LocalIndexTag,
-                AutoLocalIndexTagBase)
+                GroupInameTag, LocalInameTag,
+                AutoLocalInameTagBase)
 
         for iname in all_inames_by_insns:
             tags = self.iname_tags_of_type(
                     iname,
-                    (AutoLocalIndexTagBase, GroupIndexTag, LocalIndexTag), max_num=1)
+                    (AutoLocalInameTagBase, GroupInameTag, LocalInameTag), max_num=1)
 
             if not tags:
                 continue
 
             tag, = tags
 
-            if isinstance(tag, AutoLocalIndexTagBase) and not ignore_auto:
+            if isinstance(tag, AutoLocalInameTagBase) and not ignore_auto:
                 raise RuntimeError("cannot find grid sizes if automatic "
                         "local index tags are present")
-            elif isinstance(tag, GroupIndexTag):
+            elif isinstance(tag, GroupInameTag):
                 tgt_dict = global_sizes
-            elif isinstance(tag, LocalIndexTag):
+            elif isinstance(tag, LocalInameTag):
                 tgt_dict = local_sizes
             else:
                 continue
@@ -1111,7 +1111,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
             try:
                 # insist block size is constant
                 size_as_aff = static_max_of_pw_aff(size,
-                        constants_only=isinstance(tag, LocalIndexTag),
+                        constants_only=isinstance(tag, LocalInameTag),
                         context=self.assumptions)
                 size = isl.PwAff.from_aff(size_as_aff)
             except StaticValueFindingError:

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -720,10 +720,10 @@ def get_auto_axis_iname_ranking_by_stride(kernel, insn):
 
     # {{{ figure out automatic-axis inames
 
-    from loopy.kernel.data import AutoLocalIndexTagBase
+    from loopy.kernel.data import AutoLocalInameTagBase
     auto_axis_inames = {
         iname for iname in insn.within_inames
-        if kernel.iname_tags_of_type(iname, AutoLocalIndexTagBase)}
+        if kernel.iname_tags_of_type(iname, AutoLocalInameTagBase)}
 
     # }}}
 
@@ -798,7 +798,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
     # TODO: do the tag removal rigorously, might be easier after switching
     # to set() from tuple()
 
-    from loopy.kernel.data import (AutoLocalIndexTagBase, LocalIndexTag,
+    from loopy.kernel.data import (AutoLocalInameTagBase, LocalInameTag,
                                    filter_iname_tags_by_type)
 
     # Realize that at this point in time, axis lengths are already
@@ -827,7 +827,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
             new_inames[iname] = kernel.inames[iname].copy(
                     tags=frozenset(tag
                         for tag in kernel.inames[iname].tags
-                        if not isinstance(tag, AutoLocalIndexTagBase)))
+                        if not isinstance(tag, AutoLocalInameTagBase)))
             return assign_automatic_axes(
                     kernel.copy(inames=new_inames),
                     callables_table,
@@ -868,7 +868,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
         if axis is None:
             new_tag = None
         else:
-            new_tag = LocalIndexTag(axis)
+            new_tag = LocalInameTag(axis)
             if desired_length > local_size[axis]:
                 from loopy import untag_inames
                 from loopy.transform.iname import split_iname
@@ -878,14 +878,14 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
 
                 return assign_automatic_axes(
                         split_iname(
-                            untag_inames(kernel, iname, AutoLocalIndexTagBase),
+                            untag_inames(kernel, iname, AutoLocalInameTagBase),
                             iname, inner_length=local_size[axis],
                             outer_tag=None, inner_tag=new_tag,
                             do_tagged_check=False),
                         callables_table=callables_table,
                         axis=recursion_axis, local_size=local_size)
 
-        if not kernel.iname_tags_of_type(iname, AutoLocalIndexTagBase):
+        if not kernel.iname_tags_of_type(iname, AutoLocalInameTagBase):
             raise LoopyError("trying to reassign '%s'" % iname)
 
         if new_tag:
@@ -894,7 +894,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
             new_tag_set = frozenset()
         new_tags = (
                 frozenset(tag for tag in kernel.inames[iname].tags
-                    if not isinstance(tag, AutoLocalIndexTagBase))
+                    if not isinstance(tag, AutoLocalInameTagBase))
                 | new_tag_set)
         new_inames = kernel.inames.copy()
         new_inames[iname] = kernel.inames[iname].copy(tags=new_tags)
@@ -916,7 +916,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
 
         auto_axis_inames = [
             iname for iname in insn.within_inames
-            if kernel.iname_tags_of_type(iname, AutoLocalIndexTagBase)]
+            if kernel.iname_tags_of_type(iname, AutoLocalInameTagBase)]
 
         if not auto_axis_inames:
             continue
@@ -924,7 +924,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
         assigned_local_axes = set()
 
         for iname in insn.within_inames:
-            tags = kernel.iname_tags_of_type(iname, LocalIndexTag, max_num=1)
+            tags = kernel.iname_tags_of_type(iname, LocalInameTag, max_num=1)
             if tags:
                 tag, = tags
                 assigned_local_axes.add(tag.axis)
@@ -938,7 +938,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
                     for iname in iname_ranking:
                         prev_tags = kernel.iname_tags(iname)
                         if filter_iname_tags_by_type(
-                                prev_tags, AutoLocalIndexTagBase):
+                                prev_tags, AutoLocalInameTagBase):
                             return assign_axis(axis, iname, axis)
 
         else:

--- a/loopy/options.py
+++ b/loopy/options.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 from pytools import ImmutableRecord
 import re
 import os
+from warnings import warn
 
 
 ALLOW_TERMINAL_COLORS = True
@@ -45,7 +46,6 @@ def _apply_legacy_map(lmap, kwargs):
         else:
             if lmap_value is None:
                 # ignore this
-                from warnings import warn
                 warn("option '%s' is deprecated and was ignored" % name,
                         DeprecationWarning)
                 continue
@@ -55,6 +55,9 @@ def _apply_legacy_map(lmap, kwargs):
                 raise TypeError("may not pass a value for both '%s' and '%s'"
                         % (name, new_name))
 
+            warn(f"Loopy option '{name}' is deprecated. '{new_name}' should be "
+                    "used instead. The old option will stop working in 2022.",
+                    DeprecationWarning)
             if translator is not None:
                 val = translator(val)
 

--- a/loopy/options.py
+++ b/loopy/options.py
@@ -273,7 +273,8 @@ class Options(ImmutableRecord):
 
     # }}}
 
-    def update(self, other):
+    # only used internally on new copies of Options
+    def _update(self, other):
         for f in self.__class__.fields:
             setattr(self, f, getattr(self, f) or getattr(other, f))
 

--- a/loopy/preprocess.py
+++ b/loopy/preprocess.py
@@ -190,7 +190,7 @@ def find_temporary_address_space(kernel):
     logger.debug("%s: find temporary address space" % kernel.name)
 
     new_temp_vars = {}
-    from loopy.kernel.data import (LocalIndexTagBase, GroupIndexTag,
+    from loopy.kernel.data import (LocalInameTagBase, GroupInameTag,
             AddressSpace)
     import loopy as lp
 
@@ -238,16 +238,16 @@ def find_temporary_address_space(kernel):
             #   than are reflected in the assignee indices.
 
             locparallel_compute_inames = _get_compute_inames_tagged(
-                    kernel, insn, LocalIndexTagBase)
+                    kernel, insn, LocalInameTagBase)
 
             locparallel_assignee_inames = _get_assignee_inames_tagged(
-                    kernel, insn, LocalIndexTagBase, tv_names)
+                    kernel, insn, LocalInameTagBase, tv_names)
 
             grpparallel_compute_inames = _get_compute_inames_tagged(
-                    kernel, insn, GroupIndexTag)
+                    kernel, insn, GroupInameTag)
 
             grpparallel_assignee_inames = _get_assignee_inames_tagged(
-                    kernel, insn, GroupIndexTag, temp_var.name)
+                    kernel, insn, GroupInameTag, temp_var.name)
 
             assert locparallel_assignee_inames <= locparallel_compute_inames
             assert grpparallel_assignee_inames <= grpparallel_compute_inames
@@ -321,7 +321,7 @@ def _classify_reduction_inames(kernel, inames):
     nonlocal_par = []
 
     from loopy.kernel.data import (
-            LocalIndexTagBase, UnrolledIlpTag, UnrollTag,
+            LocalInameTagBase, UnrolledIlpTag, UnrollTag,
             ConcurrentTag, filter_iname_tags_by_type)
 
     for iname in inames:
@@ -332,7 +332,7 @@ def _classify_reduction_inames(kernel, inames):
             # them as sequential.
             sequential.append(iname)
 
-        elif filter_iname_tags_by_type(iname_tags, LocalIndexTagBase):
+        elif filter_iname_tags_by_type(iname_tags, LocalInameTagBase):
             local_par.append(iname)
 
         elif filter_iname_tags_by_type(iname_tags, ConcurrentTag):
@@ -1202,9 +1202,9 @@ def realize_reduction_for_single_kernel(kernel, callables_table,
 
         outer_insn_inames = insn.within_inames
 
-        from loopy.kernel.data import LocalIndexTagBase
+        from loopy.kernel.data import LocalInameTagBase
         outer_local_inames = tuple(oiname for oiname in outer_insn_inames
-                if kernel.iname_tags_of_type(oiname, LocalIndexTagBase))
+                if kernel.iname_tags_of_type(oiname, LocalInameTagBase))
 
         from pymbolic import var
         outer_local_iname_vars = tuple(
@@ -1569,9 +1569,9 @@ def realize_reduction_for_single_kernel(kernel, callables_table,
 
         outer_insn_inames = insn.within_inames
 
-        from loopy.kernel.data import LocalIndexTagBase
+        from loopy.kernel.data import LocalInameTagBase
         outer_local_inames = tuple(oiname for oiname in outer_insn_inames
-                if kernel.iname_tags_of_type(oiname, LocalIndexTagBase)
+                if kernel.iname_tags_of_type(oiname, LocalInameTagBase)
                 and oiname != sweep_iname)
 
         from pymbolic import var
@@ -2394,9 +2394,9 @@ def _preprocess_single_kernel(kernel, callables_table, device=None):
 
     # {{{ check that there are no l.auto-tagged inames
 
-    from loopy.kernel.data import AutoLocalIndexTagBase
+    from loopy.kernel.data import AutoLocalInameTagBase
     for name, iname in kernel.inames.items():
-        if (filter_iname_tags_by_type(iname.tags, AutoLocalIndexTagBase)
+        if (filter_iname_tags_by_type(iname.tags, AutoLocalInameTagBase)
                  and name in kernel.all_inames()):
             raise LoopyError("kernel with automatically-assigned "
                     "local axes passed to preprocessing")

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1127,16 +1127,16 @@ def _get_lid_and_gid_strides(knl, array, index):
     from loopy.symbolic import get_dependencies
     my_inames = get_dependencies(index) & knl.all_inames()
 
-    from loopy.kernel.data import (LocalIndexTag, GroupIndexTag,
+    from loopy.kernel.data import (LocalInameTag, GroupInameTag,
                                    filter_iname_tags_by_type)
     lid_to_iname = {}
     gid_to_iname = {}
     for iname in my_inames:
-        tags = knl.iname_tags_of_type(iname, (GroupIndexTag, LocalIndexTag))
+        tags = knl.iname_tags_of_type(iname, (GroupInameTag, LocalInameTag))
         if tags:
             tag, = filter_iname_tags_by_type(
-                tags, (GroupIndexTag, LocalIndexTag), 1)
-            if isinstance(tag, LocalIndexTag):
+                tags, (GroupInameTag, LocalInameTag), 1)
+            if isinstance(tag, LocalInameTag):
                 lid_to_iname[tag.axis] = iname
             else:
                 gid_to_iname[tag.axis] = iname
@@ -1547,15 +1547,15 @@ def get_unused_hw_axes_factor(knl, callables_table, insn, disregard_local_axes):
     g_used = set()
     l_used = set()
 
-    from loopy.kernel.data import LocalIndexTag, GroupIndexTag
+    from loopy.kernel.data import LocalInameTag, GroupInameTag
     for iname in insn.within_inames:
         tags = knl.iname_tags_of_type(iname,
-                              (LocalIndexTag, GroupIndexTag), max_num=1)
+                              (LocalInameTag, GroupInameTag), max_num=1)
         if tags:
             tag, = tags
-            if isinstance(tag, LocalIndexTag):
+            if isinstance(tag, LocalInameTag):
                 l_used.add(tag.axis)
-            elif isinstance(tag, GroupIndexTag):
+            elif isinstance(tag, GroupInameTag):
                 g_used.add(tag.axis)
 
     def mult_grid_factor(used_axes, size):
@@ -1597,10 +1597,10 @@ def count_insn_runs(knl, callables_table, insn, count_redundant_work,
     insn_inames = insn.within_inames
 
     if disregard_local_axes:
-        from loopy.kernel.data import LocalIndexTag
+        from loopy.kernel.data import LocalInameTag
         insn_inames = frozenset(
                 [iname for iname in insn_inames
-                    if not knl.iname_tags_of_type(iname, LocalIndexTag)])
+                    if not knl.iname_tags_of_type(iname, LocalInameTag)])
 
     c = count_inames_domain(knl, insn_inames)
 

--- a/loopy/target/ispc.py
+++ b/loopy/target/ispc.py
@@ -426,15 +426,15 @@ class ISPCASTBuilder(CFamilyASTBuilder):
 
             new_terms = []
 
-            from loopy.kernel.data import LocalIndexTag, filter_iname_tags_by_type
+            from loopy.kernel.data import LocalInameTag, filter_iname_tags_by_type
             from loopy.symbolic import get_dependencies
 
             saw_l0 = False
             for term in terms:
                 if (isinstance(term, Variable)
-                            and kernel.iname_tags_of_type(term.name, LocalIndexTag)):
+                            and kernel.iname_tags_of_type(term.name, LocalInameTag)):
                     tag, = kernel.iname_tags_of_type(
-                        term.name, LocalIndexTag, min_num=1, max_num=1)
+                        term.name, LocalInameTag, min_num=1, max_num=1)
                     if tag.axis == 0:
                         if saw_l0:
                             raise LoopyError(
@@ -446,9 +446,9 @@ class ISPCASTBuilder(CFamilyASTBuilder):
                     for dep in get_dependencies(term):
                         if dep in kernel.all_inames() and (
                                 filter_iname_tags_by_type(kernel.inames[dep].tags,
-                                    LocalIndexTag)):
+                                    LocalInameTag)):
                             tag, = filter_iname_tags_by_type(
-                                kernel.inames[dep].tags, LocalIndexTag, 1)
+                                kernel.inames[dep].tags, LocalInameTag, 1)
                             if tag.axis == 0:
                                 raise LoopyError(
                                     "streaming store must have stride 1 in "
@@ -465,7 +465,7 @@ class ISPCASTBuilder(CFamilyASTBuilder):
                         "data type")
 
             rhs_has_programindex = any(
-                isinstance(tag, LocalIndexTag) and tag.axis == 0
+                isinstance(tag, LocalInameTag) and tag.axis == 0
                 for tag in kernel.iname_tags(dep)
                 for dep in get_dependencies(insn.expression))
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -240,7 +240,13 @@ def _split_iname_backend(kernel, iname_to_split,
 
     # }}}
 
-    existing_tags = kernel.iname_tags(iname_to_split)
+    # Split inames do not inherit tags from their 'parent' inames.
+    # FIXME: They *should* receive a tag that indicates that they descend from
+    # an iname tagged in a certain way.
+    from loopy.kernel.data import InameImplementationTag
+    existing_tags = [tag
+            for tag in kernel.iname_tags(iname_to_split)
+            if isinstance(tag, InameImplementationTag)]
     from loopy.kernel.data import ForceSequentialTag, filter_iname_tags_by_type
     if (do_tagged_check and existing_tags
             and not filter_iname_tags_by_type(existing_tags, ForceSequentialTag)):
@@ -365,6 +371,8 @@ def split_iname(kernel, split_iname, inner_length,
         *inner_iname*.
     :arg within: a stack match as understood by
         :func:`loopy.match.parse_match`.
+
+    Split inames do not inherit tags from their 'parent' inames.
     """
     assert isinstance(kernel, LoopKernel)
 
@@ -397,6 +405,8 @@ def chunk_iname(kernel, split_iname, num_chunks,
 
     :arg within: a stack match as understood by
         :func:`loopy.match.parse_stack_match`.
+
+    Split inames do not inherit tags from their 'parent' inames.
 
     .. versionadded:: 2016.2
     """

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -658,7 +658,8 @@ def untag_inames(kernel, iname_to_untag, tag_type):
     Remove tags on *iname_to_untag* which matches *tag_type*.
 
     :arg iname_to_untag: iname as string.
-    :arg tag_type: a subclass of :class:`loopy.kernel.data.IndexTag`.
+    :arg tag_type: a subclass of :class:`pytools.tag.Tag`, for example a
+        subclass of :class:`loopy.kernel.data.InameImplementationTag`.
 
     .. versionadded:: 2018.1
     """
@@ -682,10 +683,11 @@ def tag_inames(kernel, iname_to_tag, force=False,
     """Tag an iname
 
     :arg iname_to_tag: a list of tuples ``(iname, new_tag)``. *new_tag* is given
-        as an instance of a subclass of :class:`loopy.kernel.data.IndexTag` or an
-        iterable of which, or as a string as shown in :ref:`iname-tags`. May also
-        be a dictionary for backwards compatibility. *iname* may also be a wildcard
-        using ``*`` and ``?``.
+        as an instance of a subclass of :class:`pytools.tag.Tag`, for example a
+        subclass of :class:`loopy.kernel.data.InameImplementationTag`.
+        May also be iterable of which, or as a string as shown in
+        :ref:`iname-tags`. May also be a dictionary for backwards
+        compatibility. *iname* may also be a wildcard using ``*`` and ``?``.
 
     .. versionchanged:: 2016.3
 
@@ -1619,17 +1621,17 @@ def find_unused_axis_tag(kernel, kind, insn_match=None):
         :func:`loopy.match.parse_match`.
     :arg kind: may be "l" or "g", or the corresponding tag class name
 
-    :returns: an :class:`loopy.kernel.data.GroupIndexTag` or
-        :class:`loopy.kernel.data.LocalIndexTag` that is not being used within
+    :returns: an :class:`loopy.kernel.data.GroupInameTag` or
+        :class:`loopy.kernel.data.LocalInameTag` that is not being used within
         the instructions matched by *insn_match*.
     """
     used_axes = set()
 
-    from loopy.kernel.data import GroupIndexTag, LocalIndexTag
+    from loopy.kernel.data import GroupInameTag, LocalInameTag
 
     if isinstance(kind, str):
         found = False
-        for cls in [GroupIndexTag, LocalIndexTag]:
+        for cls in [GroupInameTag, LocalInameTag]:
             if kind == cls.print_name:
                 kind = cls
                 found = True
@@ -1789,8 +1791,8 @@ def add_inames_to_insn(kernel, inames, insn_match):
     :arg insn_match: An instruction match as understood by
         :func:`loopy.match.parse_match`.
 
-    :returns: an :class:`loopy.kernel.data.GroupIndexTag` or
-        :class:`loopy.kernel.data.LocalIndexTag` that is not being used within
+    :returns: an :class:`loopy.kernel.data.GroupInameTag` or
+        :class:`loopy.kernel.data.LocalInameTag` that is not being used within
         the instructions matched by *insn_match*.
 
     .. versionadded:: 2016.3
@@ -1824,8 +1826,8 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
     """
     Returns a kernel with inames added to each instruction
     corresponding to any hardware-parallel iname tags
-    (:class:`loopy.kernel.data.GroupIndexTag`,
-    :class:`loopy.kernel.data.LocalIndexTag`) unused
+    (:class:`loopy.kernel.data.GroupInameTag`,
+    :class:`loopy.kernel.data.LocalInameTag`) unused
     in the instruction but used elsewhere in the kernel.
 
     Current limitations:
@@ -1837,22 +1839,22 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
     :arg within: An instruction match as understood by
         :func:`loopy.match.parse_match`.
     """
-    from loopy.kernel.data import (LocalIndexTag, GroupIndexTag,
-            AutoFitLocalIndexTag)
+    from loopy.kernel.data import (LocalInameTag, GroupInameTag,
+            AutoFitLocalInameTag)
 
     n_local_axes = max([tag.axis
         for iname in kernel.inames.values()
         for tag in iname.tags
-        if isinstance(tag, LocalIndexTag)],
+        if isinstance(tag, LocalInameTag)],
         default=-1) + 1
 
     n_group_axes = max([tag.axis
         for iname in kernel.inames.values()
         for tag in iname.tags
-        if isinstance(tag, GroupIndexTag)],
+        if isinstance(tag, GroupInameTag)],
         default=-1) + 1
 
-    contains_auto_local_tag = any([isinstance(tag, AutoFitLocalIndexTag)
+    contains_auto_local_tag = any([isinstance(tag, AutoFitLocalInameTag)
         for iname in kernel.inames.values()
         for tag in iname.tags])
 
@@ -1870,7 +1872,7 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
     group_axes_to_inames = []
 
     for i in range(n_local_axes):
-        ith_local_axes_tag = LocalIndexTag(i)
+        ith_local_axes_tag = LocalInameTag(i)
         inames = [name
                 for name, iname in kernel.inames.items()
                 if ith_local_axes_tag in iname.tags]
@@ -1880,7 +1882,7 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
         local_axes_to_inames.append(inames[0] if len(inames) == 1 else None)
 
     for i in range(n_group_axes):
-        ith_group_axes_tag = GroupIndexTag(i)
+        ith_group_axes_tag = GroupInameTag(i)
         inames = [name
                 for name, iname in kernel.inames.items()
                 if ith_group_axes_tag in iname.tags]
@@ -1901,9 +1903,9 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
             within_tags = frozenset().union(*(kernel.inames[iname].tags
                 for iname in insn.within_inames))
             missing_local_axes = [i for i in range(n_local_axes)
-                    if LocalIndexTag(i) not in within_tags]
+                    if LocalInameTag(i) not in within_tags]
             missing_group_axes = [i for i in range(n_group_axes)
-                    if GroupIndexTag(i) not in within_tags]
+                    if GroupInameTag(i) not in within_tags]
 
             for axis in missing_local_axes:
                 iname = local_axes_to_inames[axis]

--- a/loopy/transform/precompute.py
+++ b/loopy/transform/precompute.py
@@ -1052,9 +1052,9 @@ def precompute_for_single_kernel(kernel, callables_table, subst_use,
     from loopy.transform.iname import tag_inames
     kernel = tag_inames(kernel, new_iname_to_tag)
 
-    from loopy.kernel.data import AutoFitLocalIndexTag, filter_iname_tags_by_type
+    from loopy.kernel.data import AutoFitLocalInameTag, filter_iname_tags_by_type
 
-    if filter_iname_tags_by_type(new_iname_to_tag.values(), AutoFitLocalIndexTag):
+    if filter_iname_tags_by_type(new_iname_to_tag.values(), AutoFitLocalInameTag):
         from loopy.kernel.tools import assign_automatic_axes
         kernel = assign_automatic_axes(kernel, callables_table)
 

--- a/loopy/transform/save.py
+++ b/loopy/transform/save.py
@@ -400,14 +400,14 @@ class TemporarySaver:
                 if not tags:
                     continue
 
-                from loopy.kernel.data import (GroupIndexTag, LocalIndexTag,
+                from loopy.kernel.data import (GroupInameTag, LocalInameTag,
                         ConcurrentTag, filter_iname_tags_by_type)
 
-                if filter_iname_tags_by_type(tags, GroupIndexTag):
-                    tag, = filter_iname_tags_by_type(tags, GroupIndexTag, 1)
+                if filter_iname_tags_by_type(tags, GroupInameTag):
+                    tag, = filter_iname_tags_by_type(tags, GroupInameTag, 1)
                     my_group_tags.append(tag)
-                elif filter_iname_tags_by_type(tags, LocalIndexTag):
-                    tag, = filter_iname_tags_by_type(tags, LocalIndexTag, 1)
+                elif filter_iname_tags_by_type(tags, LocalInameTag):
+                    tag, = filter_iname_tags_by_type(tags, LocalInameTag, 1)
                     my_local_tags.append(tag)
                 elif filter_iname_tags_by_type(tags, ConcurrentTag):
                     raise LoopyError(
@@ -673,8 +673,8 @@ class TemporarySaver:
             if orig_temporary.address_space == AddressSpace.LOCAL:
                 # If the temporary has local scope, then loads / stores can
                 # be done in parallel.
-                from loopy.kernel.data import AutoFitLocalIndexTag
-                iname_to_tags[new_iname] = frozenset([AutoFitLocalIndexTag()])
+                from loopy.kernel.data import AutoFitLocalInameTag
+                iname_to_tags[new_iname] = frozenset([AutoFitLocalInameTag()])
 
             dim_inames.append(new_iname)
 


### PR DESCRIPTION
This PR makes the ability for users to apply their own tags to inames actually useful. 6441d83 and 3407391 are the two important bits.  In addition, this PR deprecates everything called `IndexTag` (for 2022) in favor of `InameTag` (d164bf3).

3a747fd  and 7b7c44f contain drive-by fixes.

@kaushikcfd, if you like, I can pick this apart into multiple PRs, but I figure reviewing commit-by-commit is maybe not too bad, and I hope these changes will be largely uncontroversial. I'm aware that the rename might cause some conflict with what you're currenty working on, but it's hopefully easy to mop up.