### PR TITLE
Simplifications around Targets

### DIFF
--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -708,10 +708,9 @@ def generate_code_v2(program):
     # {{{ cache retrieval
 
     from loopy import CACHING_ENABLED
-    from loopy.preprocess import prepare_for_caching
 
     if CACHING_ENABLED:
-        input_program = prepare_for_caching(program)
+        input_program = program
         try:
             result = code_gen_cache[input_program]
             logger.debug(f"TranslationUnit with entrypoints {program.entrypoints}:"

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2481,9 +2481,6 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
     from loopy.kernel.tools import infer_args_are_input_output
     knl = infer_args_are_input_output(knl)
 
-    from loopy.preprocess import prepare_for_caching
-    knl = prepare_for_caching(knl)
-
     creation_plog.done()
 
     from loopy.translation_unit import make_program

--- a/loopy/target/execution.py
+++ b/loopy/target/execution.py
@@ -779,11 +779,7 @@ class KernelExecutorBase:
     def get_typed_and_scheduled_translation_unit(self, entrypoint, arg_to_dtype_set):
         from loopy import CACHING_ENABLED
 
-        from loopy.preprocess import prepare_for_caching
-        # prepare_for_caching() gets run by preprocess, but the kernel at this
-        # stage is not guaranteed to be preprocessed.
-        cacheable_program = prepare_for_caching(self.program)
-        cache_key = (type(self).__name__, cacheable_program, arg_to_dtype_set)
+        cache_key = (type(self).__name__, self.program, arg_to_dtype_set)
 
         if CACHING_ENABLED:
             try:

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -29,171 +29,12 @@ from loopy.target.opencl import (OpenCLTarget, OpenCLCASTBuilder,
         ExpressionToOpenCLCExpressionMapper)
 from loopy.target.python import PythonASTBuilderBase
 from loopy.types import NumpyType
-from loopy.diagnostic import LoopyError, warn_with_kernel, LoopyTypeError
+from loopy.diagnostic import LoopyError, LoopyTypeError
 from warnings import warn
 from loopy.kernel.function_interface import ScalarCallable
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-# {{{ temp storage adjust for bank conflict
-
-def adjust_local_temp_var_storage(kernel, device):
-    import pyopencl as cl
-    import pyopencl.characterize as cl_char
-
-    logger.debug("%s: adjust temp var storage" % kernel.name)
-
-    new_temp_vars = {}
-
-    from loopy.kernel.data import AddressSpace
-
-    lmem_size = cl_char.usable_local_mem_size(device)
-    for temp_var in kernel.temporary_variables.values():
-        if temp_var.address_space != AddressSpace.LOCAL:
-            new_temp_vars[temp_var.name] = \
-                    temp_var.copy(storage_shape=temp_var.shape)
-            continue
-
-        if not temp_var.shape:
-            # scalar, no need to mess with storage shape
-            new_temp_vars[temp_var.name] = temp_var
-            continue
-
-        other_loctemp_nbytes = [
-                tv.nbytes
-                for tv in kernel.temporary_variables.values()
-                if tv.address_space == AddressSpace.LOCAL
-                and tv.name != temp_var.name]
-
-        storage_shape = temp_var.storage_shape
-
-        if storage_shape is None:
-            storage_shape = temp_var.shape
-
-        storage_shape = list(storage_shape)
-
-        # sizes of all dims except the last one, which we may change
-        # below to avoid bank conflicts
-        from pytools import product
-
-        if device.local_mem_type == cl.device_local_mem_type.GLOBAL:
-            # FIXME: could try to avoid cache associativity disasters
-            new_storage_shape = storage_shape
-
-        elif device.local_mem_type == cl.device_local_mem_type.LOCAL:
-            min_mult = cl_char.local_memory_bank_count(device)
-            good_incr = None
-            new_storage_shape = storage_shape
-            min_why_not = None
-
-            for increment in range(storage_shape[-1]//2):
-
-                test_storage_shape = storage_shape[:]
-                test_storage_shape[-1] = test_storage_shape[-1] + increment
-                new_mult, why_not = cl_char.why_not_local_access_conflict_free(
-                        device, temp_var.dtype.itemsize,
-                        temp_var.shape, test_storage_shape)
-
-                # will choose smallest increment 'automatically'
-                if new_mult < min_mult:
-                    new_lmem_use = (sum(other_loctemp_nbytes)
-                            + temp_var.dtype.itemsize*product(test_storage_shape))
-                    if new_lmem_use < lmem_size:
-                        new_storage_shape = test_storage_shape
-                        min_mult = new_mult
-                        min_why_not = why_not
-                        good_incr = increment
-
-            if min_mult != 1:
-                from warnings import warn
-                from loopy.diagnostic import LoopyAdvisory
-                warn("could not find a conflict-free mem layout "
-                        "for local variable '%s' "
-                        "(currently: %dx conflict, increment: %s, reason: %s)"
-                        % (temp_var.name, min_mult, good_incr, min_why_not),
-                        LoopyAdvisory)
-        else:
-            from warnings import warn
-            warn("unknown type of local memory")
-
-            new_storage_shape = storage_shape
-
-        new_temp_vars[temp_var.name] = temp_var.copy(
-                storage_shape=tuple(new_storage_shape))
-
-    return kernel.copy(temporary_variables=new_temp_vars)
-
-# }}}
-
-
-# {{{ check sizes against device properties
-
-def check_sizes(kernel, callables_table, device):
-    import loopy as lp
-
-    from loopy.diagnostic import LoopyAdvisory, LoopyError
-
-    if device is None:
-        warn_with_kernel(kernel, "no_device_in_pre_codegen_checks",
-                "No device parameter was passed to the PyOpenCLTarget. "
-                "Perhaps you want to pass a device to benefit from "
-                "additional checking.", LoopyAdvisory)
-        return
-
-    parameters = {}
-    for arg in kernel.args:
-        if isinstance(arg, lp.ValueArg) and arg.approximately is not None:
-            parameters[arg.name] = arg.approximately
-
-    glens, llens = (
-            kernel.get_grid_size_upper_bounds_as_exprs(callables_table))
-
-    if (max(len(glens), len(llens))
-            > device.max_work_item_dimensions):
-        raise LoopyError("too many work item dimensions")
-
-    from pymbolic import evaluate
-    from pymbolic.mapper.evaluator import UnknownVariableError
-    try:
-        glens = evaluate(glens, parameters)
-        llens = evaluate(llens, parameters)
-    except UnknownVariableError as name:
-        from warnings import warn
-        warn("could not check axis bounds because no value "
-                "for variable '%s' was passed to check_kernels()"
-                % name, LoopyAdvisory)
-    else:
-        for i in range(len(llens)):
-            if llens[i] > device.max_work_item_sizes[i]:
-                raise LoopyError("group axis %d too big" % i)
-
-        from pytools import product
-        if product(llens) > device.max_work_group_size:
-            raise LoopyError("work group too big")
-
-    local_mem_use = kernel.local_mem_use()
-
-    from pyopencl.characterize import usable_local_mem_size
-    import numbers
-    if isinstance(local_mem_use, numbers.Integral):
-        if local_mem_use > usable_local_mem_size(device):
-            raise LoopyError("using too much local memory")
-    else:
-        warn_with_kernel(kernel, "non_constant_local_mem",
-                "The amount of local memory used by the kernel "
-                "is not a constant. This will likely cause problems.")
-
-    from loopy.kernel.data import ConstantArg
-    const_arg_count = sum(
-            1 for arg in kernel.args
-            if isinstance(arg, ConstantArg))
-
-    if const_arg_count > device.max_constant_args:
-        raise LoopyError("too many constant arguments")
-
-# }}}
 
 
 # {{{ pyopencl function scopers
@@ -535,79 +376,23 @@ class PyOpenCLTarget(OpenCLTarget):
                     "generates invoker code that requires PyOpenCL 2021.2 "
                     "or newer.")
 
-        self.device = device
+        if device is not None:
+            warn("Passing device is deprecated, it will stop working in 2022.",
+                    DeprecationWarning, stacklevel=2)
+
         self.pyopencl_module_name = pyopencl_module_name
+
+    @property
+    def device(self):
+        warn("PyOpenCLTarget.device is deprecated, it will stop working in 2022.",
+                DeprecationWarning, stacklevel=2)
+        return None
 
     # NB: Not including 'device', as that is handled specially here.
     hash_fields = OpenCLTarget.hash_fields + (
             "pyopencl_module_name",)
     comparison_fields = OpenCLTarget.comparison_fields + (
             "pyopencl_module_name",)
-
-    def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
-
-        if (self.device is None) != (other.device is None):
-            return False
-
-        if self.device is not None:
-            assert other.device is not None
-            return (self.device.hashable_model_and_version_identifier
-                    == other.device.hashable_model_and_version_identifier)
-        else:
-            assert other.device is None
-            return True
-
-    def update_persistent_hash(self, key_hash, key_builder):
-        super().update_persistent_hash(key_hash, key_builder)
-        key_builder.rec(key_hash, getattr(
-            self.device, "hashable_model_and_version_identifier", None))
-
-    def __getstate__(self):
-        dev_id = None
-        if self.device is not None:
-            dev_id = self.device.hashable_model_and_version_identifier
-
-        return {
-                "device_id": dev_id,
-                "atomics_flavor": self.atomics_flavor,
-                "use_int8_for_bool": self.use_int8_for_bool,
-                "fortran_abi": self.fortran_abi,
-                "pyopencl_module_name": self.pyopencl_module_name,
-                }
-
-    def __setstate__(self, state):
-        self.atomics_flavor = state["atomics_flavor"]
-        self.use_int8_for_bool = state["use_int8_for_bool"]
-        self.fortran_abi = state["fortran_abi"]
-        self.pyopencl_module_name = state["pyopencl_module_name"]
-
-        dev_id = state["device_id"]
-        if dev_id is None:
-            self.device = None
-        else:
-            import pyopencl as cl
-            matches = [
-                dev
-                for plat in cl.get_platforms()
-                for dev in plat.get_devices()
-                if dev.hashable_model_and_version_identifier == dev_id]
-
-            if matches:
-                self.device = matches[0]
-            else:
-                raise LoopyError(
-                        "cannot unpickle device '%s': not found"
-                        % dev_id)
-
-    def preprocess(self, kernel):
-        if self.device is not None:
-            kernel = adjust_local_temp_var_storage(kernel, self.device)
-        return kernel
-
-    def pre_codegen_entrypoint_check(self, kernel, callables_table):
-        check_sizes(kernel, callables_table, self.device)
 
     def get_host_ast_builder(self):
         return PyOpenCLPythonASTBuilder(self)
@@ -676,7 +461,10 @@ class PyOpenCLTarget(OpenCLTarget):
                 entrypoint=kwargs.pop("entrypoint"))
 
     def with_device(self, device):
-        return type(self)(device)
+        from warnings import warn
+        warn("PyOpenCLTarget.with_device is deprecated, it will "
+                "stop working in 2022.", DeprecationWarning, stacklevel=2)
+        return self
 
 # }}}
 
@@ -688,44 +476,6 @@ def generate_value_arg_setup(kernel, devices, implemented_data_info):
 
     import loopy as lp
     from loopy.kernel.array import ArrayBase
-
-    # {{{ arg counting bug handling
-
-    # For example:
-    # https://github.com/pocl/pocl/issues/197
-    # (but Apple CPU has a similar bug)
-
-    work_around_arg_count_bug = False
-    warn_about_arg_count_bug = False
-
-    try:
-        from pyopencl.characterize import has_struct_arg_count_bug
-
-    except ImportError:
-        count_bug_per_dev = [False]*len(devices)
-
-    else:
-        count_bug_per_dev = [
-                has_struct_arg_count_bug(dev)
-                if dev is not None else False
-                for dev in devices]
-
-    if any(dev is None for dev in devices):
-        warn("{knl_name}: device not supplied to PyOpenCLTarget--"
-                "workarounds for broken OpenCL implementations "
-                "(such as those relating to complex numbers) "
-                "may not be enabled when needed. To avoid this, "
-                "pass target=lp.PyOpenCLTarget(dev) when creating "
-                "the kernel."
-                .format(knl_name=kernel.name))
-
-    if any(count_bug_per_dev):
-        if all(count_bug_per_dev):
-            work_around_arg_count_bug = True
-        else:
-            warn_about_arg_count_bug = True
-
-    # }}}
 
     cl_arg_idx = 0
     arg_idx_to_cl_arg_idx = {}
@@ -778,13 +528,6 @@ def generate_value_arg_setup(kernel, devices, implemented_data_info):
 
             dtype = idi.dtype
 
-            if warn_about_arg_count_bug:
-                warn("{knl_name}: arguments include complex numbers, and "
-                        "some (but not all) of the target devices mishandle "
-                        "struct kernel arguments (hence the workaround is "
-                        "disabled".format(
-                            knl_name=kernel.name))
-
             if dtype.numpy_dtype == np.complex64:
                 arg_char = "f"
             elif dtype.numpy_dtype == np.complex128:
@@ -792,20 +535,11 @@ def generate_value_arg_setup(kernel, devices, implemented_data_info):
             else:
                 raise TypeError("unexpected complex type: %s" % dtype)
 
-            if (work_around_arg_count_bug
-                    and dtype.numpy_dtype == np.complex128
-                    and fp_arg_count + 2 <= 8):
-                add_buf_arg(cl_arg_idx, arg_char, f"{idi.name}.real")
-                cl_arg_idx += 1
-
-                add_buf_arg(cl_arg_idx, arg_char, f"{idi.name}.imag")
-                cl_arg_idx += 1
-            else:
-                buf_indices_and_args.append(cl_arg_idx)
-                buf_indices_and_args.append(
-                    f"_lpy_pack('{arg_char}{arg_char}', "
-                    f"{idi.name}.real, {idi.name}.imag)")
-                cl_arg_idx += 1
+            buf_indices_and_args.append(cl_arg_idx)
+            buf_indices_and_args.append(
+                f"_lpy_pack('{arg_char}{arg_char}', "
+                f"{idi.name}.real, {idi.name}.imag)")
+            cl_arg_idx += 1
 
             fp_arg_count += 2
 

--- a/loopy/target/pyopencl_execution.py
+++ b/loopy/target/pyopencl_execution.py
@@ -269,11 +269,6 @@ class PyOpenCLKernelExecutor(KernelExecutorBase):
 
         self.context = context
 
-        from loopy.target.pyopencl import PyOpenCLTarget
-        if isinstance(program.target, PyOpenCLTarget):
-            self.program = program.copy(target=(
-                program.target.with_device(context.devices[0])))
-
     def get_invoker_uncached(self, program, entrypoint, codegen_result):
         generator = PyOpenCLExecutionWrapperGenerator()
         return generator(program, entrypoint, codegen_result)

--- a/loopy/transform/buffer.py
+++ b/loopy/transform/buffer.py
@@ -252,9 +252,7 @@ def buffer_array_for_single_kernel(kernel, callables_table, var_name,
 
     from loopy import CACHING_ENABLED
 
-    from loopy.preprocess import prepare_for_caching
-    key_kernel = prepare_for_caching(kernel)
-    cache_key = (key_kernel, var_name,
+    cache_key = (kernel, var_name,
             tuple(buffer_inames),
             PymbolicExpressionHashWrapper(init_expression),
             PymbolicExpressionHashWrapper(store_expression), within,
@@ -546,9 +544,7 @@ def buffer_array_for_single_kernel(kernel, callables_table, var_name,
     kernel = assign_automatic_axes(kernel, callables_table)
 
     if CACHING_ENABLED:
-        from loopy.preprocess import prepare_for_caching
-        buffer_array_cache.store_if_not_present(
-                cache_key, prepare_for_caching(kernel))
+        buffer_array_cache.store_if_not_present(cache_key, kernel)
 
     return kernel
 

--- a/loopy/transform/data.py
+++ b/loopy/transform/data.py
@@ -839,4 +839,94 @@ def reduction_arg_to_subst_rule(
 # }}}
 
 
+# {{{ add_padding_to_avoid_bank_conflicts
+
+# experimental not exported/documented for now
+def add_padding_to_avoid_bank_conflicts(kernel, device):
+    import pyopencl as cl
+    import pyopencl.characterize as cl_char
+
+    new_temp_vars = {}
+
+    from loopy.kernel.data import AddressSpace
+
+    lmem_size = cl_char.usable_local_mem_size(device)
+    for temp_var in kernel.temporary_variables.values():
+        if temp_var.address_space != AddressSpace.LOCAL:
+            new_temp_vars[temp_var.name] = \
+                    temp_var.copy(storage_shape=temp_var.shape)
+            continue
+
+        if not temp_var.shape:
+            # scalar, no need to mess with storage shape
+            new_temp_vars[temp_var.name] = temp_var
+            continue
+
+        other_loctemp_nbytes = [
+                tv.nbytes
+                for tv in kernel.temporary_variables.values()
+                if tv.address_space == AddressSpace.LOCAL
+                and tv.name != temp_var.name]
+
+        storage_shape = temp_var.storage_shape
+
+        if storage_shape is None:
+            storage_shape = temp_var.shape
+
+        storage_shape = list(storage_shape)
+
+        # sizes of all dims except the last one, which we may change
+        # below to avoid bank conflicts
+        from pytools import product
+
+        if device.local_mem_type == cl.device_local_mem_type.GLOBAL:
+            # FIXME: could try to avoid cache associativity disasters
+            new_storage_shape = storage_shape
+
+        elif device.local_mem_type == cl.device_local_mem_type.LOCAL:
+            min_mult = cl_char.local_memory_bank_count(device)
+            good_incr = None
+            new_storage_shape = storage_shape
+            min_why_not = None
+
+            for increment in range(storage_shape[-1]//2):
+
+                test_storage_shape = storage_shape[:]
+                test_storage_shape[-1] = test_storage_shape[-1] + increment
+                new_mult, why_not = cl_char.why_not_local_access_conflict_free(
+                        device, temp_var.dtype.itemsize,
+                        temp_var.shape, test_storage_shape)
+
+                # will choose smallest increment 'automatically'
+                if new_mult < min_mult:
+                    new_lmem_use = (sum(other_loctemp_nbytes)
+                            + temp_var.dtype.itemsize*product(test_storage_shape))
+                    if new_lmem_use < lmem_size:
+                        new_storage_shape = test_storage_shape
+                        min_mult = new_mult
+                        min_why_not = why_not
+                        good_incr = increment
+
+            if min_mult != 1:
+                from warnings import warn
+                from loopy.diagnostic import LoopyAdvisory
+                warn("could not find a conflict-free mem layout "
+                        "for local variable '%s' "
+                        "(currently: %dx conflict, increment: %s, reason: %s)"
+                        % (temp_var.name, min_mult, good_incr, min_why_not),
+                        LoopyAdvisory)
+        else:
+            from warnings import warn
+            warn("unknown type of local memory")
+
+            new_storage_shape = storage_shape
+
+        new_temp_vars[temp_var.name] = temp_var.copy(
+                storage_shape=tuple(new_storage_shape))
+
+    return kernel.copy(temporary_variables=new_temp_vars)
+
+# }}}
+
+
 # vim: foldmethod=marker

--- a/loopy/transform/data.py
+++ b/loopy/transform/data.py
@@ -842,6 +842,7 @@ def reduction_arg_to_subst_rule(
 # {{{ add_padding_to_avoid_bank_conflicts
 
 # experimental not exported/documented for now
+@for_each_kernel
 def add_padding_to_avoid_bank_conflicts(kernel, device):
     import pyopencl as cl
     import pyopencl.characterize as cl_char

--- a/loopy/types.py
+++ b/loopy/types.py
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from warnings import warn
 import numpy as np
 
 from loopy.diagnostic import LoopyError
@@ -42,7 +43,16 @@ class LoopyType:
     Abstract class for dtypes of variables encountered in a
     :class:`loopy.LoopKernel`.
     """
+    def target(self):
+        warn("LoopyType.target is deprecated and will go away in 2022.",
+                DeprecationWarning, stacklevel=2)
+
+        return None
+
     def with_target(self, target):
+        warn("LoopyType.with_target is deprecated and will go away in 2022.",
+                DeprecationWarning, stacklevel=2)
+
         return self
 
     def is_integral(self):
@@ -77,22 +87,6 @@ class AtomicType(LoopyType):
 # {{{ numpy-based dtype
 
 class NumpyType(LoopyType):
-    """This object works around several issues with pickling :class:`numpy.dtype`
-    objects. It does so by serving as a picklable wrapper around the original
-    dtype.
-
-    The issues are the following
-
-    - :class:`numpy.dtype` objects for custom types in :mod:`loopy` are usually
-      registered in the target's dtype registry. This registration may
-      have been lost after unpickling. This container restores it implicitly,
-      as part of unpickling.
-
-    - There is a`numpy bug <https://github.com/numpy/numpy/issues/4317>`_
-      that prevents unpickled dtypes from hashing properly. This is solved
-      by retrieving the 'canonical' type from the dtype registry.
-    """
-
     def __init__(self, dtype, target=None):
         assert not isinstance(dtype, NumpyType)
 
@@ -102,7 +96,10 @@ class NumpyType(LoopyType):
         if dtype == object:
             raise TypeError("loopy does not directly support object arrays")
 
-        self.target = target
+        if target is not None:
+            warn("Passing target is deprecated and will stop working in 2022.",
+                    DeprecationWarning, stacklevel=2)
+
         self.dtype = np.dtype(dtype)
 
     def __hash__(self):
@@ -118,31 +115,6 @@ class NumpyType(LoopyType):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    def __getstate__(self):
-        if self.target is None:
-            raise RuntimeError("unable to pickle dtype: target not known")
-
-        c_name = self.target.dtype_to_typename(NumpyType(self.dtype))
-        return (self.target, c_name, self.dtype)
-
-    def __setstate__(self, state):
-        target, name, dtype = state
-        self.target = target
-
-        if dtype == np.bool8:
-            # Bools are mapped to chars because OpenCL doesn't have them, so
-            # get_or_register_dtype will complain about duplicate registration.
-            # FIXME Tehcnically, this is OpenCL-specific.
-            self.dtype = np.dtype(dtype)
-        else:
-            self.dtype = self.target.get_or_register_dtype([name], NumpyType(dtype))
-
-    def with_target(self, target):
-        return type(self)(self.dtype, target)
-
-    def assert_has_target(self):
-        assert self.target is not None
 
     def is_integral(self):
         return self.dtype.kind in "iu"
@@ -200,7 +172,7 @@ class AtomicNumpyType(NumpyType, AtomicType):
 # }}}
 
 
-# {{{
+# {{{ opaque type
 
 class OpaqueType(LoopyType):
     """An opaque data type is truly opaque - it has no allocations, no
@@ -211,7 +183,6 @@ class OpaqueType(LoopyType):
     def __init__(self, name):
         assert isinstance(name, str)
         self.name = name
-        self.target = None
 
     def is_integral(self):
         return False
@@ -268,7 +239,7 @@ def to_loopy_type(dtype, allow_auto=False, allow_none=False, for_atomic=False,
     if isinstance(dtype, LoopyType):
         if for_atomic:
             if isinstance(dtype, NumpyType):
-                return AtomicNumpyType(dtype.dtype, target=target)
+                return AtomicNumpyType(dtype.dtype)
             elif not isinstance(dtype, AtomicType):
                 raise LoopyError("do not know how to convert '%s' to an atomic type"
                         % dtype)
@@ -277,9 +248,9 @@ def to_loopy_type(dtype, allow_auto=False, allow_none=False, for_atomic=False,
 
     elif numpy_dtype is not None:
         if for_atomic:
-            return AtomicNumpyType(numpy_dtype, target=target)
+            return AtomicNumpyType(numpy_dtype)
         else:
-            return NumpyType(numpy_dtype, target=target)
+            return NumpyType(numpy_dtype)
 
     else:
         raise TypeError("dtype must be a LoopyType, or convertible to one, "

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(name="loopy",
           "genpy>=2016.1.2",
 
           # https://github.com/inducer/loopy/pull/419
-          "numpy>=1.8",
+          "numpy>=1.19",
 
           "cgen>=2016.1",
           "islpy>=2019.1",

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,10 @@ setup(name="loopy",
           "pytools>=2021.2.4",
           "pymbolic>=2019.2",
           "genpy>=2016.1.2",
+
+          # https://github.com/inducer/loopy/pull/419
+          "numpy>=1.8",
+
           "cgen>=2016.1",
           "islpy>=2019.1",
           "codepy>=2017.1",

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -149,6 +149,8 @@ def test_transpose(ctx_factory):
     knl = lp.add_prefetch(knl, "a", ["i_inner", "j_inner"],
             default_tag="l.auto")
 
+    from loopy.transform.data import add_padding_to_avoid_bank_conflicts
+    knl = add_padding_to_avoid_bank_conflicts(knl, ctx.devices[0])
     lp.auto_test_vs_ref(seq_knl, ctx, knl,
             op_count=[dtype.itemsize*n**2*2/1e9], op_label=["GByte"],
             parameters={})


### PR DESCRIPTION
- Drop target from types
- Drop prepare_for_caching
- Drop device from PyOpenCLTarget

Closes #411.

Draft because we still need to figure out when numpy fixed the bug described in https://github.com/inducer/loopy/issues/411#issuecomment-860253458 and add that as a dependency. @isuruf, could you investigate?

Draft because:
- [x] `add_padding_to_avoid_bank_conflicts` should be tested somewhere.

cc @isuruf 