### PR TITLE
Decorate remove_unused_inames with for_each_kernel

### DIFF
--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1225,6 +1225,7 @@ def get_used_inames(kernel):
     return used_inames
 
 
+@for_each_kernel
 def remove_unused_inames(kernel, inames=None):
     """Delete those among *inames* that are unused, i.e. project them
     out of the domain. If these inames pose implicit restrictions on


### PR DESCRIPTION
`remove_unused_inames` doesn't like `TranslationUnit`s. I infer that it should be decorated with `for_each_kernel` - feel free to close if not (in which case, what would be the proper way to use the transformation?).