### PR TITLE
Tagging and fixes

### DIFF
--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -339,7 +339,7 @@ class LoopKernel(ImmutableRecordWithoutPickling, Taggable):
         assert assumptions.is_params()
 
         from loopy.types import to_loopy_type
-        index_dtype = to_loopy_type(index_dtype, target=target)
+        index_dtype = to_loopy_type(index_dtype)
         if not index_dtype.is_integral():
             raise TypeError("index_dtype must be an integer")
         if np.iinfo(index_dtype.numpy_dtype).min >= 0:

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -872,6 +872,9 @@ class ArrayBase(ImmutableRecord, Taggable):
             warn("dim_names is not a tuple when calling ArrayBase constructor",
                     DeprecationWarning, stacklevel=2)
 
+        if tags is None:
+            tags = frozenset()
+
         if target is not None:
             warn("Passing target is deprecated and will stop working in 2022.",
                     DeprecationWarning, stacklevel=2)

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -902,6 +902,9 @@ class ArrayBase(ImmutableRecord, Taggable):
                 and isee(self.offset, other.offset)
                 and self.dim_names == other.dim_names
                 and self.order == other.order
+                and self.alignment == other.alignment
+                and self.for_atomic == other.for_atomic
+                and self.tags == other.tags
                 )
 
     def target(self):
@@ -975,13 +978,16 @@ class ArrayBase(ImmutableRecord, Taggable):
         :class:`pytools.persistent_dict.PersistentDict`.
         """
 
-        key_builder.rec(key_hash, type(self).__name__.encode("utf-8"))
+        key_builder.rec(key_hash, type(self).__name__)
         key_builder.rec(key_hash, self.name)
         key_builder.rec(key_hash, self.dtype)
         self.update_persistent_hash_for_shape(key_hash, key_builder, self.shape)
         key_builder.rec(key_hash, self.dim_tags)
         key_builder.rec(key_hash, self.offset)
         key_builder.rec(key_hash, self.dim_names)
+        key_builder.rec(key_hash, self.order)
+        key_builder.rec(key_hash, self.alignment)
+        key_builder.rec(key_hash, self.tags)
 
     def num_target_axes(self):
         target_axes = set()

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -738,7 +738,7 @@ class ArrayBase(ImmutableRecord, Taggable):
 
         from loopy.types import to_loopy_type
         dtype = to_loopy_type(dtype, allow_auto=True, allow_none=True,
-                for_atomic=for_atomic, target=target)
+                for_atomic=for_atomic)
 
         if dtype is lp.auto:
             from warnings import warn

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 """
 
 import re
+from warnings import warn
 
 from pytools import ImmutableRecord, memoize_method
 from pytools.tag import Taggable
@@ -569,7 +570,6 @@ def _pymbolic_parse_if_necessary(x):
 def _parse_shape_or_strides(x):
     import loopy as lp
     if x == "auto":
-        from warnings import warn
         warn("use of 'auto' as a shape or stride won't work "
                 "any more--use loopy.auto instead",
                 stacklevel=3)
@@ -741,7 +741,6 @@ class ArrayBase(ImmutableRecord, Taggable):
                 for_atomic=for_atomic)
 
         if dtype is lp.auto:
-            from warnings import warn
             warn("Argument/temporary data type for '%s' should be None if "
                     "unspecified, not auto. This usage will be disallowed in 2018."
                     % name,
@@ -870,8 +869,11 @@ class ArrayBase(ImmutableRecord, Taggable):
             kwargs["strides"] = strides
 
         if dim_names is not None and not isinstance(dim_names, tuple):
-            from warnings import warn
             warn("dim_names is not a tuple when calling ArrayBase constructor",
+                    DeprecationWarning, stacklevel=2)
+
+        if target is not None:
+            warn("Passing target is deprecated and will stop working in 2022.",
                     DeprecationWarning, stacklevel=2)
 
         ImmutableRecord.__init__(self,
@@ -884,7 +886,6 @@ class ArrayBase(ImmutableRecord, Taggable):
                 order=order,
                 alignment=alignment,
                 for_atomic=for_atomic,
-                target=target,
                 tags=tags,
                 **kwargs)
 
@@ -902,6 +903,12 @@ class ArrayBase(ImmutableRecord, Taggable):
                 and self.dim_names == other.dim_names
                 and self.order == other.order
                 )
+
+    def target(self):
+        warn("Array.target is deprecated and will go away in 2022.",
+                DeprecationWarning, stacklevel=2)
+
+        return None
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -518,6 +518,9 @@ class ValueArg(KernelArgument, Taggable):
             application.
         """
 
+        if tags is None:
+            tags = frozenset()
+
         KernelArgument.__init__(self, name=name,
                 dtype=dtype,
                 approximately=approximately,

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -100,7 +100,7 @@ def _add_dtypes(kernel, dtype_dict):
     for arg in kernel.args:
         new_dtype = dtype_dict.pop(arg.name, None)
         if new_dtype is not None:
-            new_dtype = to_loopy_type(new_dtype, target=kernel.target)
+            new_dtype = to_loopy_type(new_dtype)
             if arg.dtype is not None and arg.dtype != new_dtype:
                 raise RuntimeError(
                         "argument '%s' already has a different dtype "

--- a/loopy/types.py
+++ b/loopy/types.py
@@ -212,6 +212,10 @@ class OpaqueType(LoopyType):
 
 def to_loopy_type(dtype, allow_auto=False, allow_none=False, for_atomic=False,
         target=None):
+    if target is not None:
+        warn("Passing target is deprecated and will stop working in 2022.",
+                DeprecationWarning, stacklevel=2)
+
     from loopy.kernel.data import auto
     if dtype is None:
         if allow_none:
@@ -232,9 +236,6 @@ def to_loopy_type(dtype, allow_auto=False, allow_none=False, for_atomic=False,
             numpy_dtype = np.dtype(dtype)
         except Exception:
             pass
-
-    if numpy_dtype is None and target is not None and isinstance(dtype, str):
-        numpy_dtype = target.get_dtype_registry().get_or_register_dtype(dtype)
 
     if isinstance(dtype, LoopyType):
         if for_atomic:


### PR DESCRIPTION
Various fixes and simplifications. Best read commit-by-commit. I don't imagine any of this is controversial, hence I'm not tagging anyone for review, but maybe you're reading this anyway. :)

The original impetus for this was wanting to actually use argument tagging, and discovering it to be awkwardly broken without 
9ef80b3, and then discovering key conflicts. The rest were incidental fixes following from #419.