### PR TITLE
PyOpenCL executor: accept device scalars for ValueArgs

### DIFF
--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -455,7 +455,7 @@ class PyOpenCLTarget(OpenCLTarget):
     def get_kernel_executor_cache_key(self, queue, **kwargs):
         return queue.context
 
-    def preprocess_translation_unit_before_codegen(self, t_unit, epoint,
+    def preprocess_translation_unit_for_passed_args(self, t_unit, epoint,
                                                    passed_args_dict):
 
         # {{{ ValueArgs -> GlobalArgs if passed as array shapes
@@ -490,9 +490,9 @@ class PyOpenCLTarget(OpenCLTarget):
         from loopy.target.pyopencl_execution import PyOpenCLKernelExecutor
 
         epoint = kwargs.pop("entrypoint")
-        program = self.preprocess_translation_unit_before_codegen(program,
-                                                                  epoint,
-                                                                  kwargs)
+        program = self.preprocess_translation_unit_for_passed_args(program,
+                                                                   epoint,
+                                                                   kwargs)
 
         return PyOpenCLKernelExecutor(queue.context, program,
                                       entrypoint=epoint)

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -455,10 +455,47 @@ class PyOpenCLTarget(OpenCLTarget):
     def get_kernel_executor_cache_key(self, queue, **kwargs):
         return queue.context
 
+    def preprocess_translation_unit_before_codegen(self, t_unit, epoint,
+                                                   passed_args_dict):
+
+        # {{{ ValueArgs -> GlobalArgs if passed as array shapes
+
+        from loopy.kernel.data import ValueArg, GlobalArg
+        import numpy as np
+        import pyopencl.array as cla
+
+        knl = t_unit[epoint]
+        new_args = []
+
+        for arg in knl.args:
+            if isinstance(arg, ValueArg):
+                if (arg.name in passed_args_dict
+                        and isinstance(passed_args_dict[arg.name], (cla.Array,
+                                                                    np.ndarray))
+                        and passed_args_dict[arg.name].shape == ()):
+                    arg = GlobalArg(name=arg.name, dtype=arg.dtype, shape=(),
+                                    is_output=False, is_input=True)
+
+            new_args.append(arg)
+
+        knl = knl.copy(args=new_args)
+
+        t_unit = t_unit.with_kernel(knl)
+
+        # }}}
+
+        return t_unit
+
     def get_kernel_executor(self, program, queue, **kwargs):
         from loopy.target.pyopencl_execution import PyOpenCLKernelExecutor
+
+        epoint = kwargs.pop("entrypoint")
+        program = self.preprocess_translation_unit_before_codegen(program,
+                                                                  epoint,
+                                                                  kwargs)
+
         return PyOpenCLKernelExecutor(queue.context, program,
-                entrypoint=kwargs.pop("entrypoint"))
+                                      entrypoint=epoint)
 
     def with_device(self, device):
         from warnings import warn

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -500,6 +500,22 @@ def test_inf_support(ctx_factory, target, dtype):
     assert np.isneginf(out_dict["out_neginf"])
 
 
+def test_pyopencl_execution_accepts_device_scalars(ctx_factory):
+    import pyopencl.array as cla
+
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    knl = lp.make_kernel("{:}",
+                         """
+                         y = 2*x
+                         """)
+
+    evt, (out,) = knl(cq, x=cla.to_device(cq, np.asarray(21)))
+
+    np.testing.assert_allclose(out.get(), 42)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
-Closes #452.
- Closes https://github.com/inducer/meshmode/issues/237.