### PR TITLE
Do not set DEFAULT_TARGET in loopy.__init__

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -578,10 +578,10 @@ def _set_up_default_target():
         import pyopencl  # noqa
     except ImportError:
         from loopy.target.opencl import OpenCLTarget
-        target = OpenCLTarget()
+        target = OpenCLTarget
     else:
         from loopy.target.pyopencl import PyOpenCLTarget
-        target = PyOpenCLTarget()
+        target = PyOpenCLTarget
 
     set_default_target(target)
 

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -553,10 +553,11 @@ class _AccessCheckMapper(WalkMapper):
 
     @memoize_method
     def _get_access_range(self, domain, subscript):
-        from loopy.symbolic import (get_access_map, UnableToDetermineAccessRange)
+        from loopy.symbolic import (get_access_map,
+                                    UnableToDetermineAccessRangeError)
         try:
             return get_access_map(domain, subscript).range()
-        except UnableToDetermineAccessRange:
+        except UnableToDetermineAccessRangeError:
             return None
 
     def map_subscript(self, expr, domain, insn_id):

--- a/loopy/cli.py
+++ b/loopy/cli.py
@@ -71,22 +71,22 @@ def main():
 
     if args.target == "opencl":
         from loopy.target.opencl import OpenCLTarget
-        target = OpenCLTarget()
+        target = OpenCLTarget
     elif args.target == "ispc":
         from loopy.target.ispc import ISPCTarget
-        target = ISPCTarget()
+        target = ISPCTarget
     elif args.target == "ispc-occa":
         from loopy.target.ispc import ISPCTarget
-        target = ISPCTarget(occa_mode=True)
+        target = lambda: ISPCTarget(occa_mode=True)  # noqa: E731
     elif args.target == "c":
         from loopy.target.c import CTarget
-        target = CTarget()
+        target = CTarget
     elif args.target == "c-fortran":
         from loopy.target.c import CTarget
-        target = CTarget(fortran_abi=True)
+        target = lambda: CTarget(fortran_abi=True)  # noqa: E731
     elif args.target == "cuda":
         from loopy.target.cuda import CudaTarget
-        target = CudaTarget()
+        target = CudaTarget
     else:
         raise ValueError("unknown target: %s" % target)
 

--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -135,7 +135,7 @@ class ImplementedDataInfo(ImmutableRecord):
 
 # {{{ code generation state
 
-class Unvectorizable(Exception):
+class UnvectorizableError(Exception):
     pass
 
 
@@ -375,7 +375,7 @@ class CodeGenerationState:
         """If *self* is in a vectorizing state (:attr:`vectorization_info` is
         not None), tries to call func (which must be a callable accepting a
         single :class:`CodeGenerationState` argument). If this fails with
-        :exc:`Unvectorizable`, it unrolls the vectorized loop instead.
+        :exc:`UnvectorizableError`, it unrolls the vectorized loop instead.
 
         *func* should return a :class:`GeneratedCode` instance.
 
@@ -387,7 +387,7 @@ class CodeGenerationState:
 
         try:
             return func(self)
-        except Unvectorizable as e:
+        except UnvectorizableError as e:
             warn(self.kernel, "vectorize_failed",
                     "Vectorization of '%s' failed because '%s'"
                     % (what, e))

--- a/loopy/codegen/instruction.py
+++ b/loopy/codegen/instruction.py
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 import islpy as isl
 dim_type = isl.dim_type
-from loopy.codegen import Unvectorizable
+from loopy.codegen import UnvectorizableError
 from loopy.codegen.result import CodeGenerationResult
 from pymbolic.mapper.stringifier import PREC_NONE
 from pytools import memoize_on_first_arg
@@ -115,7 +115,7 @@ def generate_assignment_instruction_code(codegen_state, insn):
 
     if codegen_state.vectorization_info:
         if insn.atomicity:
-            raise Unvectorizable("atomic operation")
+            raise UnvectorizableError("atomic operation")
 
         vinfo = codegen_state.vectorization_info
         vcheck = VectorizabilityChecker(
@@ -124,7 +124,7 @@ def generate_assignment_instruction_code(codegen_state, insn):
         rhs_is_vector = vcheck(insn.expression)
 
         if not lhs_is_vector and rhs_is_vector:
-            raise Unvectorizable(
+            raise UnvectorizableError(
                     "LHS is scalar, RHS is vector, cannot assign")
 
         is_vector = lhs_is_vector
@@ -166,7 +166,7 @@ def generate_assignment_instruction_code(codegen_state, insn):
 
     if kernel.options.trace_assignments or kernel.options.trace_assignment_values:
         if codegen_state.vectorization_info and is_vector:
-            raise Unvectorizable("tracing does not support vectorization")
+            raise UnvectorizableError("tracing does not support vectorization")
 
         from pymbolic.mapper.stringifier import PREC_NONE
         lhs_code = codegen_state.expression_to_code_mapper(insn.assignee, PREC_NONE)
@@ -234,7 +234,7 @@ def generate_call_code(codegen_state, insn):
 
     if codegen_state.vectorization_info:
         if insn.atomicity:
-            raise Unvectorizable("atomic operation")
+            raise UnvectorizableError("atomic operation")
 
     # }}}
 
@@ -255,7 +255,7 @@ def generate_c_instruction_code(codegen_state, insn):
     kernel = codegen_state.kernel
 
     if codegen_state.vectorization_info is not None:
-        raise Unvectorizable("C instructions cannot be vectorized")
+        raise UnvectorizableError("C instructions cannot be vectorized")
 
     body = []
 
@@ -285,7 +285,7 @@ def generate_c_instruction_code(codegen_state, insn):
 
 def generate_nop_instruction_code(codegen_state, insn):
     if codegen_state.vectorization_info is not None:
-        raise Unvectorizable("C instructions cannot be vectorized")
+        raise UnvectorizableError("C instructions cannot be vectorized")
     return codegen_state.ast_builder.emit_comment(
         "no-op (insn=%s)" % (insn.id))
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2236,7 +2236,7 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
 
     if target is None:
         from loopy import _DEFAULT_TARGET
-        target = _DEFAULT_TARGET
+        target = _DEFAULT_TARGET()
 
     if flags is not None:
         if options is not None:

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -536,7 +536,7 @@ class ScheduleDebugger:
         self.start_time = time()
 
 
-class ScheduleDebugInput(Exception):
+class ScheduleDebugInputError(Exception):
     pass
 
 # }}}
@@ -1407,7 +1407,7 @@ def generate_loop_schedules_internal(
                 "or enter a number to examine schedules of a "
                 "different length:")
         if inp:
-            raise ScheduleDebugInput(inp)
+            raise ScheduleDebugInputError(inp)
 
     if (
             not sched_state.active_inames
@@ -2055,7 +2055,7 @@ def generate_loop_schedules_inner(kernel, callables_table, debug_args=None):
                             sched_state, debug=debug, **schedule_gen_kwargs):
                         pass
 
-                except ScheduleDebugInput as e:
+                except ScheduleDebugInputError as e:
                     debug.debug_length = int(str(e))
                     continue
 

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -2263,7 +2263,7 @@ class PrimeAdder(IdentityMapper):
 
 # {{{ get access range
 
-class UnableToDetermineAccessRange(Exception):
+class UnableToDetermineAccessRangeError(Exception):
     pass
 
 
@@ -2341,7 +2341,7 @@ def get_access_map(domain, subscript, assumptions=None, shape=None,
 
             if shape_aff is None:
                 # failed to convert shape[idim] to aff
-                raise UnableToDetermineAccessRange(
+                raise UnableToDetermineAccessRangeError(
                         "unable to determine access range of subscript: [%s] "
                         "(encountered %s: %s)"
                         % (", ".join(str(si) for si in subscript),
@@ -2432,7 +2432,7 @@ class BatchedAccessMapMapper(WalkMapper):
                     domain, subscript, self.kernel.assumptions,
                     shape=descriptor.shape if self._overestimate else None,
                     allowed_constant_names=self.kernel.get_unwritten_value_args())
-        except UnableToDetermineAccessRange:
+        except UnableToDetermineAccessRangeError:
             self.bad_subscripts[arg_name].append(expr)
             return
 


### PR DESCRIPTION
1. No substantial benefit by avoiding initialization.
2. If pyopencl < 2021.2 is present in the environment, user is forced to upgrade pyopencl even if they just want to use the CTarget.

Reported by @ReubenHill on firedrake slack.


The 3 later commits are intended to placate [N818](https://github.com/PyCQA/pep8-naming#error-codes).