### PR TITLE
Bugfix: corrects the arg passed to subst_into_pwaff

### DIFF
--- a/loopy/kernel/function_interface.py
+++ b/loopy/kernel/function_interface.py
@@ -888,7 +888,7 @@ class CallableKernel(InKernelCallable):
         gsize, lsize = self.subkernel.get_grid_size_upper_bounds(callables_table,
                                                                  return_dict=True)
 
-        subst_dict = {i: val
+        subst_dict = {pos_to_kw[i]: val
                       for i, val in arg_id_to_arg.items()
                       if isinstance(self.subkernel.arg_dict[pos_to_kw[i]],
                                     ValueArg)}


### PR DESCRIPTION
The provided test fails on `main` with the error:
```
  File "/home/kgk2/projects/pytato_multiprogram/src/loopy/loopy/isl_helpers.py", line 645, in get_param_subst_domain                                  
    new_subst_dict[new_name] = subst_dict[old_name]                                                                                                   
KeyError: 'n'
```