### PR TITLE
Add update_for_Map to LoopyKeyBuilder

### DIFF
--- a/loopy/tools.py
+++ b/loopy/tools.py
@@ -102,6 +102,8 @@ class LoopyKeyBuilder(KeyBuilderBase):
         getattr(prn, "print_"+key._base_name)(key)
         key_hash.update(prn.get_str().encode("utf8"))
 
+    update_for_Map = update_for_BasicSet  # noqa
+
     def update_for_type(self, key_hash, key):
         try:
             method = getattr(self, "update_for_type_"+key.__name__)


### PR DESCRIPTION
Add `update_for_Map` to `LoopyKeyBuilder`. This will be needed, e.g., once kernel instructions contain the new dependency maps. Merging this as a separate PR will eliminate an entire file from the (upcoming) dependency-checking PR diff, plus it could be useful independently.

This change was previously part of this PR: [Check new dependencies against SIO](https://github.com/inducer/loopy/pull/264)

