### PR TITLE
Pycuda Loopy Support

### DIFF
--- a/examples/python/pycuda-loopy.py
+++ b/examples/python/pycuda-loopy.py
@@ -1,18 +1,15 @@
 import numpy as np
 import loopy as lp
-import pyopencl as cl
 from loopy.version import LOOPY_USE_LANGUAGE_VERSION_2018_2
+
+import pycuda as cuda
+
+a = np.arange(15, dtype=np.float32)
+
 knl = lp.make_kernel(
-    "{[i]: 0<=i<n}",
-    """
-    y[i] = a[i] + 2*b[i] + 3*c[n-1-i]
-    """)
-a = b = c = np.arange(15)
-knl = lp.add_dtypes(knl, {"a,b,c": np.int64})
-# print(knl)
-print(lp.generate_code_v2(knl).device_code())
+        "{ [i]: 0<=i<n }",
+        "out[i] = 2*a[i]")
+
+knl = lp.split_iname(knl, "i", 128, outer_tag="g.0", inner_tag="l.0")
 cuda_knl = knl.copy(target=lp.CudaTarget())
-print(lp.generate_code_v2(cuda_knl).device_code())
-cuda_knl(a=a, b=b, c=c)
-lp.generate_code_v2(cuda_knl).host_code()
-print(lp.generate_code_v2(knl).host_code())
+evt, (out,) = cuda_knl(a=a)

--- a/examples/python/pycuda-loopy.py
+++ b/examples/python/pycuda-loopy.py
@@ -1,0 +1,18 @@
+import numpy as np
+import loopy as lp
+import pyopencl as cl
+from loopy.version import LOOPY_USE_LANGUAGE_VERSION_2018_2
+knl = lp.make_kernel(
+    "{[i]: 0<=i<n}",
+    """
+    y[i] = a[i] + 2*b[i] + 3*c[n-1-i]
+    """)
+a = b = c = np.arange(15)
+knl = lp.add_dtypes(knl, {"a,b,c": np.int64})
+# print(knl)
+print(lp.generate_code_v2(knl).device_code())
+cuda_knl = knl.copy(target=lp.CudaTarget())
+print(lp.generate_code_v2(cuda_knl).device_code())
+cuda_knl(a=a, b=b, c=c)
+lp.generate_code_v2(cuda_knl).host_code()
+print(lp.generate_code_v2(knl).host_code())

--- a/loopy/target/pycuda.py
+++ b/loopy/target/pycuda.py
@@ -383,18 +383,10 @@ class PyCUDATarget(CUDATarget):
     def get_dtype_registry(self):
         from pycuda.compyte.dtypes import TYPE_REGISTRY
         result = TYPE_REGISTRY
-# TODO: CUDA EQUIVALENTS FOR THIS STUFF ???vvv ================================================================================================================
-        from loopy.target.opencl import (
-                DTypeRegistryWrapperWithCL1Atomics,
-                DTypeRegistryWrapperWithInt8ForBool)
-
-        result = DTypeRegistryWrapperWithInt8ForBool(result)
-        if self.atomics_flavor == "cl1":
-            result = DTypeRegistryWrapperWithCL1Atomics(result)
-        else:
-            raise NotImplementedError("atomics flavor: %s" % self.atomics_flavor)
 
         return result
+
+#TODO: rewrite following for cuda
 
     def is_vector_dtype(self, dtype):
         try:
@@ -418,7 +410,7 @@ class PyCUDATarget(CUDATarget):
         return NumpyType(
                 vec_types[base.numpy_dtype, count],
                 target=self)
-# ===============================================================================================================================================================
+
     def alignment_requirement(self, type_decl):
         import struct
 

--- a/loopy/target/pycuda.py
+++ b/loopy/target/pycuda.py
@@ -1,0 +1,816 @@
+"""CUDA target integrated with PyCUDA."""
+
+import numpy as np
+import pymbolic.primitives as p
+
+from loopy.target.cuda import (CUDATarget, CUDACASTBuilder,
+        ExpressionToCudaCExpressionMapper)
+from loopy.target.python import PythonASTBuilderBase
+from loopy.types import NumpyType
+from loopy.diagnostic import LoopyError, LoopyTypeError
+from warnings import warn
+from loopy.kernel.function_interface import ScalarCallable
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+# {{{ pycuda function scopers
+
+class PyCUDACallable(ScalarCallable):
+    """
+    Records information about the callables which are not covered by
+    :class:`loopy.target.cuda.CUDACallable`
+    """
+    def with_types(self, arg_id_to_dtype, callables_table):
+
+        name = self.name
+
+        for id in arg_id_to_dtype:
+            # since all the below functions are single arg.
+            if not -1 <= id <= 0:
+                raise LoopyError("%s can only take one argument." % name)
+
+        if 0 not in arg_id_to_dtype or arg_id_to_dtype[0] is None:
+            # the types provided aren't mature enough to specialize the
+            # callable
+            return (
+                    self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                    callables_table)
+
+        dtype = arg_id_to_dtype[0]
+
+        if name in ["real", "imag", "abs"]:
+            if dtype.is_complex():
+                if dtype.numpy_dtype == np.complex64:
+                    tpname = "cfloat"
+                elif dtype.numpy_dtype == np.complex128:
+                    tpname = "cdouble"
+                else:
+                    raise LoopyTypeError("unexpected complex type '%s'" % dtype)
+
+                return (
+                        self.copy(name_in_target=f"{tpname}_{name}",
+                            arg_id_to_dtype={0: dtype, -1: NumpyType(
+                                np.dtype(dtype.numpy_dtype.type(0).real))}),
+                        callables_table)
+
+        if name in ["sqrt", "exp", "log",
+                "sin", "cos", "tan",
+                "sinh", "cosh", "tanh",
+                "conj", "abs"]:
+            if dtype.is_complex():
+                # function parameters are complex.
+                if dtype.numpy_dtype == np.complex64:
+                    tpname = "cfloat"
+                elif dtype.numpy_dtype == np.complex128:
+                    tpname = "cdouble"
+                else:
+                    raise LoopyTypeError("unexpected complex type '%s'" % dtype)
+
+                return (
+                        self.copy(name_in_target=f"{tpname}_{name}",
+                            arg_id_to_dtype={0: dtype, -1: dtype}),
+                        callables_table)
+            else:
+                # function calls for floating-point parameters.
+                numpy_dtype = dtype.numpy_dtype
+                if numpy_dtype.kind in ("u", "i"):
+                    dtype = NumpyType(np.float32)
+                if name == "abs":
+                    name = "fabs"
+                return (
+                        self.copy(name_in_target=name,
+                            arg_id_to_dtype={0: dtype, -1: dtype}),
+                        callables_table)
+
+        return (
+                self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                callables_table)
+
+
+def get_pycuda_callables():
+    pycuda_ids = ["sqrt", "exp", "log", "sin", "cos", "tan", "sinh", "cosh",
+            "tanh", "conj", "real", "imag", "abs"]
+    return {id_: PyCUDACallable(name=id_) for id_ in pycuda_ids}
+
+# }}}
+
+
+# {{{ preamble generator
+
+def pycuda_preamble_generator(preamble_info):
+    has_double = False
+    has_complex = False
+
+    from loopy.types import NumpyType
+    for dtype in preamble_info.seen_dtypes:
+        if (isinstance(dtype, NumpyType)
+                and dtype.dtype in [np.float64, np.complex128]):
+            has_double = True
+        if dtype.involves_complex():
+            has_complex = True
+
+    if has_complex:
+        if has_double:
+            yield ("10_include_complex_header", """
+                #define PYCUDA_DEFINE_CDOUBLE
+
+                #include <pycuda-complex.h>
+                """)
+        else:
+            yield ("10_include_complex_header", """
+                #include <pycuda-complex.h>
+                """)
+
+# }}}
+
+
+# {{{ expression mapper
+
+class ExpressionToPyCUDACExpressionMapper(ExpressionToCUDACExpressionMapper):
+    def complex_type_name(self, dtype):
+        from loopy.types import NumpyType
+        if not isinstance(dtype, NumpyType):
+            raise LoopyError("'%s' is not a complex type" % dtype)
+
+        if dtype.dtype == np.complex64:
+            return "cfloat"
+        if dtype.dtype == np.complex128:
+            return "cdouble"
+        else:
+            raise RuntimeError
+
+    def wrap_in_typecast_lazy(self, actual_type_func, needed_dtype, s):
+        if needed_dtype.is_complex():
+            return self.wrap_in_typecast(actual_type_func(), needed_dtype, s)
+        else:
+            return super().wrap_in_typecast_lazy(actual_type_func,
+                                                 needed_dtype, s)
+
+    def wrap_in_typecast(self, actual_type, needed_dtype, s):
+        if (actual_type.is_complex() and needed_dtype.is_complex()
+                and actual_type != needed_dtype):
+            return p.Variable("%s_cast" % self.complex_type_name(needed_dtype))(s)
+        elif not actual_type.is_complex() and needed_dtype.is_complex():
+            return p.Variable("%s_fromreal" % self.complex_type_name(needed_dtype))(
+                    s)
+        else:
+            return super().wrap_in_typecast_lazy(actual_type,
+                                                 needed_dtype, s)
+
+    def map_sum(self, expr, type_context):
+        # I've added 'type_context == "i"' because of the following
+        # idiotic corner case: Code generation for subscripts comes
+        # through here, and it may involve variables that we know
+        # nothing about (offsets and such). If we fall into the allow_complex
+        # branch, we'll try to do type inference on these variables,
+        # and stuff breaks. This band-aid works around that. -AK
+        if not self.allow_complex or type_context == "i":
+            return super().map_sum(expr, type_context)
+
+        tgt_dtype = self.infer_type(expr)
+        is_complex = tgt_dtype.is_complex()
+
+        if not is_complex:
+            return super().map_sum(expr, type_context)
+        else:
+            tgt_name = self.complex_type_name(tgt_dtype)
+
+            reals = []
+            complexes = []
+            for child in expr.children:
+                if self.infer_type(child).is_complex():
+                    complexes.append(child)
+                else:
+                    reals.append(child)
+
+            real_sum = p.flattened_sum([self.rec(r, type_context) for r in reals])
+
+            c_applied = [self.rec(c, type_context, tgt_dtype) for c in complexes]
+
+            def binary_tree_add(start, end):
+                if start + 1 == end:
+                    return c_applied[start]
+                mid = (start + end)//2
+                lsum = binary_tree_add(start, mid)
+                rsum = binary_tree_add(mid, end)
+                return p.Variable("%s_add" % tgt_name)(lsum, rsum)
+
+            complex_sum = binary_tree_add(0, len(c_applied))
+
+            if real_sum:
+                return p.Variable("%s_radd" % tgt_name)(real_sum, complex_sum)
+            else:
+                return complex_sum
+
+    def map_product(self, expr, type_context):
+        # I've added 'type_context == "i"' because of the following
+        # idiotic corner case: Code generation for subscripts comes
+        # through here, and it may involve variables that we know
+        # nothing about (offsets and such). If we fall into the allow_complex
+        # branch, we'll try to do type inference on these variables,
+        # and stuff breaks. This band-aid works around that. -AK
+        if not self.allow_complex or type_context == "i":
+            return super().map_product(expr, type_context)
+
+        tgt_dtype = self.infer_type(expr)
+        is_complex = tgt_dtype.is_complex()
+
+        if not is_complex:
+            return super().map_product(expr, type_context)
+        else:
+            tgt_name = self.complex_type_name(tgt_dtype)
+
+            reals = []
+            complexes = []
+            for child in expr.children:
+                if self.infer_type(child).is_complex():
+                    complexes.append(child)
+                else:
+                    reals.append(child)
+
+            real_prd = p.flattened_product(
+                    [self.rec(r, type_context) for r in reals])
+
+            c_applied = [self.rec(c, type_context, tgt_dtype) for c in complexes]
+
+            def binary_tree_mul(start, end):
+                if start + 1 == end:
+                    return c_applied[start]
+                mid = (start + end)//2
+                lsum = binary_tree_mul(start, mid)
+                rsum = binary_tree_mul(mid, end)
+                return p.Variable("%s_mul" % tgt_name)(lsum, rsum)
+
+            complex_prd = binary_tree_mul(0, len(complexes))
+
+            if real_prd:
+                return p.Variable("%s_rmul" % tgt_name)(real_prd, complex_prd)
+            else:
+                return complex_prd
+
+    def map_quotient(self, expr, type_context):
+        n_dtype = self.infer_type(expr.numerator).numpy_dtype
+        d_dtype = self.infer_type(expr.denominator).numpy_dtype
+        tgt_dtype = self.infer_type(expr)
+        n_complex = "c" == n_dtype.kind
+        d_complex = "c" == d_dtype.kind
+
+        if not self.allow_complex or (not (n_complex or d_complex)):
+            return super().map_quotient(expr, type_context)
+
+        if n_complex and not d_complex:
+            return p.Variable("%s_divider" % self.complex_type_name(tgt_dtype))(
+                    self.rec(expr.numerator, type_context, tgt_dtype),
+                    self.rec(expr.denominator, type_context))
+        elif not n_complex and d_complex:
+            return p.Variable("%s_rdivide" % self.complex_type_name(tgt_dtype))(
+                    self.rec(expr.numerator, type_context),
+                    self.rec(expr.denominator, type_context, tgt_dtype))
+        else:
+            return p.Variable("%s_divide" % self.complex_type_name(tgt_dtype))(
+                    self.rec(expr.numerator, type_context, tgt_dtype),
+                    self.rec(expr.denominator, type_context, tgt_dtype))
+
+    def map_constant(self, expr, type_context):
+        if isinstance(expr, (complex, np.complexfloating)):
+            try:
+                dtype = expr.dtype
+            except AttributeError:
+                # (COMPLEX_GUESS_LOGIC) This made it through type 'guessing' in
+                # type inference, and it was concluded there (search for
+                # COMPLEX_GUESS_LOGIC in loopy.type_inference), that no
+                # accuracy was lost by using single precision.
+                cast_type = "cfloat"
+            else:
+                if dtype == np.complex128:
+                    cast_type = "cdouble"
+                elif dtype == np.complex64:
+                    cast_type = "cfloat"
+                else:
+                    raise RuntimeError("unsupported complex type in expression "
+                            "generation: %s" % type(expr))
+
+            return p.Variable("%s_new" % cast_type)(expr.real, expr.imag)
+
+        return super().map_constant(expr, type_context)
+
+    def map_power(self, expr, type_context):
+        tgt_dtype = self.infer_type(expr)
+        base_dtype = self.infer_type(expr.base)
+        exponent_dtype = self.infer_type(expr.exponent)
+
+        if not self.allow_complex or (not tgt_dtype.is_complex()):
+            return super().map_power(expr, type_context)
+
+        if expr.exponent in [2, 3, 4]:
+            value = expr.base
+            for _i in range(expr.exponent-1):
+                value = value * expr.base
+            return self.rec(value, type_context)
+        else:
+            b_complex = base_dtype.is_complex()
+            e_complex = exponent_dtype.is_complex()
+
+            if b_complex and not e_complex:
+                return p.Variable("%s_powr" % self.complex_type_name(tgt_dtype))(
+                        self.rec(expr.base, type_context, tgt_dtype),
+                        self.rec(expr.exponent, type_context))
+            else:
+                return p.Variable("%s_pow" % self.complex_type_name(tgt_dtype))(
+                        self.rec(expr.base, type_context, tgt_dtype),
+                        self.rec(expr.exponent, type_context, tgt_dtype))
+
+# }}}
+
+
+# {{{ target
+
+class PyCUDATarget(CUDATarget):
+    """A code generation target that takes special advantage of :mod:`pycuda`
+    features such as run-time knowledge of the target device (to generate
+    warnings) and support for complex numbers.
+    """
+
+    # FIXME make prefixes conform to naming rules
+    # (see Reference: Loopy’s Model of a Kernel)
+
+    host_program_name_prefix = "_lpy_host_"
+    host_program_name_suffix = ""
+
+    def __init__(self, device=None, pycuda_module_name="_lpy_cuda",
+                 atomics_flavor=None, use_int8_for_bool=True):
+        # This ensures the dtype registry is populated.
+        import pycuda.tools  # noqa
+
+        super().__init__(
+            atomics_flavor=atomics_flavor,
+            use_int8_for_bool=use_int8_for_bool)
+
+        import pycuda.version
+        if pycuda.version.VERSION < (2021, 2):
+            raise RuntimeError("The version of loopy you have installed "
+                    "generates invoker code that requires PyCUDA 2021.2 "
+                    "or newer.")
+
+        if device is not None:
+            warn("Passing device is deprecated, it will stop working in 2022.",
+                    DeprecationWarning, stacklevel=2)
+
+        self.pycuda_module_name = pycuda_module_name
+
+    @property
+    def device(self):
+        warn("PyCUDATarget.device is deprecated, it will stop working in 2022.",
+                DeprecationWarning, stacklevel=2)
+        return None
+
+    # NB: Not including 'device', as that is handled specially here.
+    hash_fields = CUDATarget.hash_fields + (
+            "pycuda_module_name",)
+    comparison_fields = CUDATarget.comparison_fields + (
+            "pycuda_module_name",)
+
+    def get_host_ast_builder(self):
+        return PyCUDAPythonASTBuilder(self)
+
+    def get_device_ast_builder(self):
+        return PyCUDACASTBuilder(self)
+
+    # {{{ types
+
+    def get_dtype_registry(self):
+        from pycuda.compyte.dtypes import TYPE_REGISTRY
+        result = TYPE_REGISTRY
+# TODO: CUDA EQUIVALENTS FOR THIS STUFF ???vvv ================================================================================================================
+        from loopy.target.opencl import (
+                DTypeRegistryWrapperWithCL1Atomics,
+                DTypeRegistryWrapperWithInt8ForBool)
+
+        result = DTypeRegistryWrapperWithInt8ForBool(result)
+        if self.atomics_flavor == "cl1":
+            result = DTypeRegistryWrapperWithCL1Atomics(result)
+        else:
+            raise NotImplementedError("atomics flavor: %s" % self.atomics_flavor)
+
+        return result
+
+    def is_vector_dtype(self, dtype):
+        try:
+            import pyopencl.cltypes as cltypes
+            vec_types = cltypes.vec_types
+        except ImportError:
+            from pyopencl.array import vec
+            vec_types = vec.types
+
+        return (isinstance(dtype, NumpyType)
+                and dtype.numpy_dtype in list(vec_types.values()))
+
+    def vector_dtype(self, base, count):
+        try:
+            import pyopencl.cltypes as cltypes
+            vec_types = cltypes.vec_types
+        except ImportError:
+            from pyopencl.array import vec
+            vec_types = vec.types
+
+        return NumpyType(
+                vec_types[base.numpy_dtype, count],
+                target=self)
+# ===============================================================================================================================================================
+    def alignment_requirement(self, type_decl):
+        import struct
+
+        fmt = (type_decl.struct_format()
+                .replace("F", "ff")
+                .replace("D", "dd"))
+
+        return struct.calcsize(fmt)
+
+    # }}}
+
+    def get_kernel_executor_cache_key(self, queue, **kwargs):
+        return queue.context
+
+    def preprocess_translation_unit_for_passed_args(self, t_unit, epoint,
+                                                   passed_args_dict):
+
+        # {{{ ValueArgs -> GlobalArgs if passed as array shapes
+
+        from loopy.kernel.data import ValueArg, GlobalArg
+        import pyopencl.array as cla
+
+        knl = t_unit[epoint]
+        new_args = []
+
+        for arg in knl.args:
+            if isinstance(arg, ValueArg):
+                if (arg.name in passed_args_dict
+                        and isinstance(passed_args_dict[arg.name], cla.Array)
+                        and passed_args_dict[arg.name].shape == ()):
+                    arg = GlobalArg(name=arg.name, dtype=arg.dtype, shape=(),
+                                    is_output=False, is_input=True)
+
+            new_args.append(arg)
+
+        knl = knl.copy(args=new_args)
+
+        t_unit = t_unit.with_kernel(knl)
+
+        # }}}
+
+        return t_unit
+
+    def get_kernel_executor(self, program, queue, **kwargs):
+        from loopy.target.pycuda_execution import PyCUDAKernelExecutor
+
+        epoint = kwargs.pop("entrypoint")
+        program = self.preprocess_translation_unit_for_passed_args(program,
+                                                                   epoint,
+                                                                   kwargs)
+
+        return PyCUDAKernelExecutor(queue.context, program,
+                                      entrypoint=epoint)
+
+    def with_device(self, device):
+        from warnings import warn
+        warn("PyCUDATarget.with_device is deprecated, it will "
+                "stop working in 2022.", DeprecationWarning, stacklevel=2)
+        return self
+
+# }}}
+
+
+# {{{ host code: value arg setup
+
+def generate_value_arg_setup(kernel, devices, implemented_data_info):
+    options = kernel.options
+
+    import loopy as lp
+    from loopy.kernel.array import ArrayBase
+
+    cuda_arg_idx = 0
+    arg_idx_to_cuda_arg_idx = {}
+
+    fp_arg_count = 0
+
+    from genpy import If, Raise, Statement as S, Suite
+
+    result = []
+    gen = result.append
+
+    buf_indices_and_args = []
+    buf_pack_indices_and_args = []
+
+    from pycuda.invoker import BUF_PACK_TYPECHARS
+
+    def add_buf_arg(arg_idx, typechar, expr_str):
+        if typechar in BUF_PACK_TYPECHARS:
+            buf_pack_indices_and_args.append(arg_idx)
+            buf_pack_indices_and_args.append(repr(typechar.encode()))
+            buf_pack_indices_and_args.append(expr_str)
+        else:
+            buf_indices_and_args.append(arg_idx)
+            buf_indices_and_args.append(f"pack('{typechar}', {expr_str})")
+
+    for arg_idx, idi in enumerate(implemented_data_info):
+        arg_idx_to_cuda_arg_idx[arg_idx] = cuda_arg_idx
+
+        if not issubclass(idi.arg_class, lp.ValueArg):
+            assert issubclass(idi.arg_class, ArrayBase)
+
+            # assume each of those generates exactly one...
+            cuda_arg_idx += 1
+
+            continue
+
+        if not options.skip_arg_checks:
+            gen(If("%s is None" % idi.name,
+                Raise('RuntimeError("input argument \'{name}\' '
+                        'must be supplied")'.format(name=idi.name))))
+
+        if idi.dtype.is_composite():
+            buf_indices_and_args.append(cuda_arg_idx)
+            buf_indices_and_args.append(f"{idi.name}")
+
+            cuda_arg_idx += 1
+
+        elif idi.dtype.is_complex():
+            assert isinstance(idi.dtype, NumpyType)
+
+            dtype = idi.dtype
+
+            if dtype.numpy_dtype == np.complex64:
+                arg_char = "f"
+            elif dtype.numpy_dtype == np.complex128:
+                arg_char = "d"
+            else:
+                raise TypeError("unexpected complex type: %s" % dtype)
+
+            buf_indices_and_args.append(cuda_arg_idx)
+            buf_indices_and_args.append(
+                f"_lpy_pack('{arg_char}{arg_char}', "
+                f"{idi.name}.real, {idi.name}.imag)")
+            cuda_arg_idx += 1
+
+            fp_arg_count += 2
+
+        elif isinstance(idi.dtype, NumpyType):
+            if idi.dtype.dtype.kind == "f":
+                fp_arg_count += 1
+
+            add_buf_arg(cuda_arg_idx, idi.dtype.dtype.char, idi.name)
+            cuda_arg_idx += 1
+
+        else:
+            raise LoopyError("do not know how to pass argument of type '%s'"
+                    % idi.dtype)
+
+    for arg_kind, args_and_indices, entry_length in [
+            ("_buf", buf_indices_and_args, 2),
+            ("_buf_pack", buf_pack_indices_and_args, 3),
+            ]:
+        assert len(args_and_indices) % entry_length == 0
+        if args_and_indices:
+            gen(S(f"_lpy_knl._set_arg{arg_kind}_multi("
+                    f"({', '.join(str(i) for i in args_and_indices)},), "
+                    ")"))
+
+    return Suite(result), arg_idx_to_cuda_arg_idx, cuda_arg_idx
+
+# }}}
+
+
+def generate_array_arg_setup(kernel, implemented_data_info, arg_idx_to_cuda_arg_idx):
+    from loopy.kernel.array import ArrayBase
+    from genpy import Statement as S, Suite
+
+    result = []
+    gen = result.append
+
+    cuda_indices_and_args = []
+    for arg_idx, arg in enumerate(implemented_data_info):
+        if issubclass(arg.arg_class, ArrayBase):
+            cuda_indices_and_args.append(arg_idx_to_cuda_arg_idx[arg_idx])
+            cuda_indices_and_args.append(arg.name)
+
+    if cuda_indices_and_args:
+        assert len(cuda_indices_and_args) % 2 == 0
+
+        gen(S(f"_lpy_knl._set_arg_multi("
+            f"({', '.join(str(i) for i in cuda_indices_and_args)},)"
+            ")"))
+
+    return Suite(result)
+
+
+# {{{ host ast builder
+
+class PyCUDAPythonASTBuilder(PythonASTBuilderBase):
+    """A Python host AST builder for integration with PyCUDA.
+    """
+
+    # {{{ code generation guts
+
+    def get_function_definition(self, codegen_state, codegen_result,
+            schedule_index, function_decl, function_body):
+        from loopy.kernel.data import TemporaryVariable
+        args = (
+                ["_lpy_cuda_kernels", "queue"]
+                + [idi.name for idi in codegen_state.implemented_data_info
+                    if not issubclass(idi.arg_class, TemporaryVariable)]
+                + ["wait_for=None", "allocator=None"])
+
+        from genpy import (For, Function, Suite, Return, Line, Statement as S)
+        return Function(
+                codegen_result.current_program(codegen_state).name,
+                args,
+                Suite([
+                    Line(),
+                    ] + [
+                    Line(),
+                    function_body,
+                    Line(),
+                    ] + ([
+                        For("_tv", "_global_temporaries",
+                            # free global temporaries
+                            S("_tv.release()"))
+                        ] if self._get_global_temporaries(codegen_state) else []
+                    ) + [
+                    Line(),
+                    Return("_lpy_evt"),
+                    ]))
+
+    def get_function_declaration(self, codegen_state, codegen_result,
+            schedule_index):
+        # no such thing in Python
+        return None
+
+    def _get_global_temporaries(self, codegen_state):
+        from loopy.kernel.data import AddressSpace
+
+        return sorted(
+            (tv for tv in codegen_state.kernel.temporary_variables.values()
+            if tv.address_space == AddressSpace.GLOBAL),
+            key=lambda tv: tv.name)
+
+    def get_temporary_decls(self, codegen_state, schedule_state):
+        from genpy import Assign, Comment, Line
+        from collections import defaultdict
+        from numbers import Number
+        import pymbolic.primitives as prim
+
+        def alloc_nbytes(tv):
+            from functools import reduce
+            from operator import mul
+            return tv.dtype.numpy_dtype.itemsize * reduce(mul, tv.shape, 1)
+
+        from pymbolic.mapper.stringifier import PREC_NONE
+        ecm = self.get_expression_to_code_mapper(codegen_state)
+
+        global_temporaries = self._get_global_temporaries(codegen_state)
+        if not global_temporaries:
+            return []
+
+        # {{{ allocate space for the base_storage
+
+        base_storage_sizes = defaultdict(set)
+
+        for tv in global_temporaries:
+            if tv.base_storage:
+                base_storage_sizes[tv.base_storage].add(tv.nbytes)
+
+        # }}}
+
+        allocated_var_names = []
+        code_lines = []
+        code_lines.append(Line())
+        code_lines.append(Comment("{{{ allocate global temporaries"))
+        code_lines.append(Line())
+
+        for name, sizes in base_storage_sizes.items():
+            if all(isinstance(s, Number) for s in sizes):
+                size = max(sizes)
+            else:
+                size = prim.Max(tuple(sizes))
+
+            allocated_var_names.append(name)
+            code_lines.append(Assign(name,
+                                     f"allocator({ecm(size, PREC_NONE, 'i')})"))
+
+        for tv in global_temporaries:
+            if tv.base_storage:
+                assert tv.base_storage in base_storage_sizes
+                code_lines.append(Assign(tv.name, tv.base_storage))
+            else:
+                nbytes_str = ecm(tv.nbytes, PREC_NONE, "i")
+                allocated_var_names.append(tv.name)
+                code_lines.append(Assign(tv.name,
+                                         f"allocator({nbytes_str})"))
+
+        code_lines.append(Assign("_global_temporaries", "[{tvs}]".format(
+            tvs=", ".join(tv for tv in allocated_var_names))))
+
+        code_lines.append(Line())
+        code_lines.append(Comment("}}}"))
+        code_lines.append(Line())
+
+        return code_lines
+
+    def get_kernel_call(self, codegen_state, name, gsize, lsize, extra_args):
+        ecm = self.get_expression_to_code_mapper(codegen_state)
+
+        if not gsize:
+            gsize = (1,)
+        if not lsize:
+            lsize = (1,)
+
+        all_args = codegen_state.implemented_data_info + extra_args
+
+        value_arg_code, arg_idx_to_cuda_arg_idx, cuda_arg_count = \
+            generate_value_arg_setup(
+                    codegen_state.kernel,
+                    [self.target.device],
+                    all_args)
+        arry_arg_code = generate_array_arg_setup(
+            codegen_state.kernel,
+            all_args,
+            arg_idx_to_cuda_arg_idx)
+
+        from genpy import Suite, Assign, Assert, Line, Comment
+        from pymbolic.mapper.stringifier import PREC_NONE
+
+        import pycuda.version as cuda_ver
+        if cuda_ver.VERSION < (2020, 2):
+            from warnings import warn
+            warn("Your kernel invocation will likely fail because your "
+                    "version of PyCUDA does not support allow_empty_ndrange. "
+                    "Please upgrade to version 2020.2 or newer.")
+
+        # TODO: Generate finer-grained dependency structure
+        return Suite([
+            Comment("{{{ enqueue %s" % name),
+            Line(),
+            Assign("_lpy_knl", "_lpy_cuda_kernels."+name),
+            Assert("_lpy_knl.num_args == %d" % cuda_arg_count),
+            Line(),
+            value_arg_code,
+            arry_arg_code,
+            Assign("_lpy_evt", "%(pycuda_module_name)s.enqueue_nd_range_kernel("
+                "queue, _lpy_knl, "
+                "%(gsize)s, %(lsize)s, "
+                # using positional args because pybind is slow with kwargs
+                "None, "  # offset
+                "wait_for, "
+                "True, "  # g_times_l
+                "True, "  # allow_empty_ndrange
+                ")"
+                % dict(
+                    pycuda_module_name=self.target.pycuda_module_name,
+                    gsize=ecm(gsize, prec=PREC_NONE, type_context="i"),
+                    lsize=ecm(lsize, prec=PREC_NONE, type_context="i"))),
+            Assign("wait_for", "[_lpy_evt]"),
+            Line(),
+            Comment("}}}"),
+            Line(),
+            ])
+
+    # }}}
+
+# }}}
+
+
+# {{{ device ast builder
+
+class PyCUDACASTBuilder(CUDACASTBuilder):
+    """A C device AST builder for integration with PyCUDA.
+    """
+
+    # {{{ library
+
+    @property
+    def known_callables(self):
+        from loopy.library.random123 import get_random123_callables
+
+        # order matters: e.g. prefer our abs() over that of the
+        # superclass
+        callables = super().known_callables
+        callables.update(get_pycuda_callables())
+        callables.update(get_random123_callables(self.target))
+        return callables
+
+    def preamble_generators(self):
+        return ([
+            pycuda_preamble_generator,
+            ] + super().preamble_generators())
+
+    # }}}
+
+    def get_expression_to_c_expression_mapper(self, codegen_state):
+        return ExpressionToPyCUDACExpressionMapper(codegen_state)
+
+
+# }}}
+
+# vim: foldmethod=marker

--- a/loopy/target/pycuda_execution.py
+++ b/loopy/target/pycuda_execution.py
@@ -1,0 +1,352 @@
+# TODO: adapt for pycuda 
+
+from pytools import memoize_method
+from pytools.py_codegen import Indentation
+from loopy.target.execution import (
+    KernelExecutorBase, ExecutionWrapperGeneratorBase, _KernelInfo, _Kernels)
+import logging
+logger = logging.getLogger(__name__)
+
+
+# {{{ invoker generation
+
+# /!\ This code runs in a namespace controlled by the user.
+# Prefix all auxiliary variables with "_lpy".
+
+
+class PyCUDAExecutionWrapperGenerator(ExecutionWrapperGeneratorBase):
+    """
+    Specialized form of the :class:`ExecutionWrapperGeneratorBase` for
+    pyCUDA execution
+    """
+
+    def __init__(self):
+        system_args = [
+            "_lpy_cl_kernels", "queue", "allocator=None", "wait_for=None",
+            # ignored if options.no_numpy
+            "out_host=None"
+            ]
+        super().__init__(system_args)
+
+    def python_dtype_str_inner(self, dtype):
+        import pyopencl.tools as cl_tools
+        if dtype.isbuiltin:
+            name = dtype.name
+            if dtype.name == "bool":
+                name = "bool8"
+            return f"_lpy_np.dtype(_lpy_np.{name})"
+        else:
+            return ('_lpy_cl_tools.get_or_register_dtype("%s")'
+                    % cl_tools.dtype_to_ctype(dtype))
+
+    # {{{ handle non-numpy args
+
+    def handle_non_numpy_arg(self, gen, arg):
+        gen("if isinstance(%s, _lpy_np.ndarray):" % arg.name)
+        with Indentation(gen):
+            gen("# retain originally passed array")
+            gen(f"_lpy_{arg.name}_np_input = {arg.name}")
+            gen("# synchronous, nothing to worry about")
+            gen("%s = _lpy_cl_array.to_device("
+                    "queue, %s, allocator=allocator)"
+                    % (arg.name, arg.name))
+            gen("_lpy_encountered_numpy = True")
+        gen("elif %s is not None:" % arg.name)
+        with Indentation(gen):
+            gen("_lpy_encountered_dev = True")
+            gen("_lpy_%s_np_input = None" % arg.name)
+        gen("else:")
+        with Indentation(gen):
+            gen("_lpy_%s_np_input = None" % arg.name)
+
+        gen("")
+
+    # }}}
+
+    # {{{ handle allocation of unspecified arguments
+
+    def handle_alloc(self, gen, arg, kernel_arg, strify, skip_arg_checks):
+        """
+        Handle allocation of non-specified arguments for pyopencl execution
+        """
+        from pymbolic import var
+
+        num_axes = len(arg.strides)
+
+        itemsize = kernel_arg.dtype.numpy_dtype.itemsize
+        for i in range(num_axes):
+            gen("_lpy_ustrides_%d = %s" % (i, strify(
+                arg.unvec_strides[i])))
+
+        if not skip_arg_checks:
+            for i in range(num_axes):
+                gen("assert _lpy_ustrides_%d > 0, "
+                        "\"'%s' has negative stride in axis %d\""
+                        % (i, arg.name, i))
+
+        sym_ustrides = tuple(
+                var("_lpy_ustrides_%d" % i)
+                for i in range(num_axes))
+        sym_shape = tuple(
+                arg.unvec_shape[i]
+                for i in range(num_axes))
+
+        size_expr = (sum(astrd*(alen-1)
+            for alen, astrd in zip(sym_shape, sym_ustrides))
+            + 1)
+
+        gen("_lpy_size = %s" % strify(size_expr))
+        sym_strides = tuple(itemsize*s_i for s_i in sym_ustrides)
+
+        dtype_name = self.python_dtype_str(gen, kernel_arg.dtype.numpy_dtype)
+        gen(f"{arg.name} = _lpy_cl_array.Array(None, {strify(sym_shape)}, "
+                f"{dtype_name}, strides={strify(sym_strides)}, "
+                f"data=allocator({strify(itemsize * var('_lpy_size'))}), "
+                "allocator=allocator, "
+                "_fast=True, _size=_lpy_size, "
+                "_context=queue.context, _queue=queue)")
+
+        for i in range(num_axes):
+            gen("del _lpy_ustrides_%d" % i)
+        gen("del _lpy_size")
+        gen("")
+
+    # }}}
+
+    def target_specific_preamble(self, gen):
+        """
+        Add default pyopencl imports to preamble
+        """
+        gen.add_to_preamble("import numpy as _lpy_np")
+        gen.add_to_preamble("import pyopencl as _lpy_cl")
+        gen.add_to_preamble("import pyopencl.array as _lpy_cl_array")
+        gen.add_to_preamble("import pyopencl.tools as _lpy_cl_tools")
+        gen.add_to_preamble("from struct import pack as _lpy_pack")
+
+    def initialize_system_args(self, gen):
+        """
+        Initializes possibly empty system arguments
+        """
+        gen("if allocator is None:")
+        with Indentation(gen):
+            gen("allocator = _lpy_cl_tools.DeferredAllocator(queue.context)")
+        gen("")
+
+    # {{{ generate invocation
+
+    def generate_invocation(self, gen, kernel_name, args,
+            kernel, implemented_data_info):
+        if kernel.options.cl_exec_manage_array_events:
+            gen("""
+                if wait_for is None:
+                    wait_for = []
+                """)
+
+            gen("")
+            from loopy.kernel.data import ArrayArg
+            for arg in implemented_data_info:
+                if issubclass(arg.arg_class, ArrayArg):
+                    gen(
+                            "wait_for.extend({arg_name}.events)"
+                            .format(arg_name=arg.name))
+
+            gen("")
+
+        gen("_lpy_evt = {kernel_name}({args})"
+        .format(
+            kernel_name=kernel_name,
+            args=", ".join(
+                ["_lpy_cl_kernels", "queue"]
+                + args
+                + ["wait_for=wait_for", "allocator=allocator"])))
+
+        if kernel.options.cl_exec_manage_array_events:
+            gen("")
+            from loopy.kernel.data import ArrayArg
+            for arg in implemented_data_info:
+                if (issubclass(arg.arg_class, ArrayArg)
+                        and arg.base_name in kernel.get_written_variables()):
+                    gen(f"{arg.name}.add_event(_lpy_evt)")
+
+    # }}}
+
+    # {{{
+
+    def generate_output_handler(
+            self, gen, options, kernel, implemented_data_info):
+
+        from loopy.kernel.data import KernelArgument
+
+        if not options.no_numpy:
+            gen("if out_host is None and (_lpy_encountered_numpy "
+                    "and not _lpy_encountered_dev):")
+            with Indentation(gen):
+                gen("out_host = True")
+
+            for arg in implemented_data_info:
+                if not issubclass(arg.arg_class, KernelArgument):
+                    continue
+
+                is_written = arg.base_name in kernel.get_written_variables()
+                if is_written:
+                    np_name = "_lpy_%s_np_input" % arg.name
+                    gen("if out_host or %s is not None:" % np_name)
+                    with Indentation(gen):
+                        gen("%s = %s.get(queue=queue, ary=%s)"
+                            % (arg.name, arg.name, np_name))
+
+            gen("")
+
+        if options.return_dict:
+            gen("return _lpy_evt, {%s}"
+                    % ", ".join(f'"{arg.name}": {arg.name}'
+                        for arg in implemented_data_info
+                        if issubclass(arg.arg_class, KernelArgument)
+                        if arg.base_name in kernel.get_written_variables()))
+        else:
+            out_args = [arg
+                    for arg in implemented_data_info
+                        if issubclass(arg.arg_class, KernelArgument)
+                    if arg.base_name in kernel.get_written_variables()]
+            if out_args:
+                gen("return _lpy_evt, (%s,)"
+                        % ", ".join(arg.name for arg in out_args))
+            else:
+                gen("return _lpy_evt, ()")
+
+    # }}}
+
+    def generate_host_code(self, gen, codegen_result):
+        gen.add_to_preamble(codegen_result.host_code())
+
+    def get_arg_pass(self, arg):
+        return "%s.base_data" % arg.name
+
+# }}}
+
+
+# {{{ kernel executor
+
+class PyCUDAKernelExecutor(KernelExecutorBase):
+    """An object connecting a kernel to a :class:`pyopencl.Context`
+    for execution.
+
+    .. automethod:: __init__
+    .. automethod:: __call__
+    """
+
+    def __init__(self, context, program, entrypoint):
+        """
+        :arg context: a :class:`pyopencl.Context`
+        :arg kernel: may be a loopy.LoopKernel, a generator returning kernels
+            (a warning will be issued if more than one is returned). If the
+            kernel has not yet been loop-scheduled, that is done, too, with no
+            specific arguments.
+        """
+
+        super().__init__(program, entrypoint)
+
+        self.context = context
+
+    def get_invoker_uncached(self, program, entrypoint, codegen_result):
+        generator = PyCUDAExecutionWrapperGenerator()
+        return generator(program, entrypoint, codegen_result)
+
+    def get_wrapper_generator(self):
+        return PyCUDAExecutionWrapperGenerator()
+
+    @memoize_method
+    def translation_unit_info(self, entrypoint, arg_to_dtype_set=frozenset(),
+            all_kwargs=None):
+        program = self.get_typed_and_scheduled_translation_unit(
+                entrypoint, arg_to_dtype_set)
+
+        # FIXME: now just need to add the types to the arguments
+        from loopy.codegen import generate_code_v2
+        from loopy.target.execution import get_highlighted_code
+        codegen_result = generate_code_v2(program)
+
+        dev_code = codegen_result.device_code()
+
+        if program[entrypoint].options.write_cl:
+            #FIXME: redirect to "translation unit" level option as well.
+            output = dev_code
+            if self.program[entrypoint].options.highlight_cl:
+                output = get_highlighted_code(output)
+
+            if self.program[entrypoint].options.write_cl is True:
+                print(output)
+            else:
+                with open(self.program[entrypoint].options.write_cl, "w") as outf:
+                    outf.write(output)
+
+        if program[entrypoint].options.edit_cl:
+            #FIXME: redirect to "translation unit" level option as well.
+            from pytools import invoke_editor
+            dev_code = invoke_editor(dev_code, "code.cl")
+
+        import pyopencl as cl
+
+        #FIXME: redirect to "translation unit" level option as well.
+        cl_program = (
+                cl.Program(self.context, dev_code)
+                .build(options=program[entrypoint].options.cl_build_options))
+
+        cl_kernels = _Kernels()
+        for dp in cl_program.kernel_names.split(";"):
+            setattr(cl_kernels, dp, getattr(cl_program, dp))
+
+        return _KernelInfo(
+                program=program,
+                cl_kernels=cl_kernels,
+                implemented_data_info=codegen_result.implemented_data_infos[
+                    entrypoint],
+                invoker=self.get_invoker(program, entrypoint, codegen_result))
+
+    def __call__(self, queue, *,
+            allocator=None, wait_for=None, out_host=None, entrypoint=None,
+            **kwargs):
+        """
+        :arg allocator: a callable passed a byte count and returning
+            a :class:`pyopencl.Buffer`. A :mod:`pyopencl` allocator
+            maybe.
+        :arg wait_for: A list of :class:`pyopencl.Event` instances
+            for which to wait.
+        :arg out_host: :class:`bool`
+            Decides whether output arguments (i.e. arguments
+            written by the kernel) are to be returned as
+            :mod:`numpy` arrays. *True* for yes, *False* for no.
+
+            For the default value of *None*, if all (input) array
+            arguments are :mod:`numpy` arrays, defaults to
+            returning :mod:`numpy` arrays as well.
+
+        :returns: ``(evt, output)`` where *evt* is a :class:`pyopencl.Event`
+            associated with the execution of the kernel, and
+            output is a tuple of output arguments (arguments that
+            are written as part of the kernel). The order is given
+            by the order of kernel arguments. If this order is unspecified
+            (such as when kernel arguments are inferred automatically),
+            enable :attr:`loopy.Options.return_dict` to make *output* a
+            :class:`dict` instead, with keys of argument names and values
+            of the returned arrays.
+        """
+
+        assert entrypoint is not None
+
+        if __debug__:
+            self.check_for_required_array_arguments(kwargs.keys())
+
+        if self.packing_controller is not None:
+            kwargs = self.packing_controller(kwargs)
+
+        translation_unit_info = self.translation_unit_info(entrypoint,
+                self.arg_to_dtype_set(kwargs))
+
+        return translation_unit_info.invoker(
+                translation_unit_info.cl_kernels, queue, allocator, wait_for,
+                out_host, **kwargs)
+
+# }}}
+
+# vim: foldmethod=marker

--- a/loopy/target/pycuda_execution.py
+++ b/loopy/target/pycuda_execution.py
@@ -1,4 +1,4 @@
-# TODO: adapt for pycuda 
+# TODO: adapt for pycuda -> PyCUDAKernelExecutor.PyCUDAExecutionWrapperGenerator
 
 from pytools import memoize_method
 from pytools.py_codegen import Indentation


### PR DESCRIPTION
Initial work on support for executing Loopy kernels via PyCUDA. 

_Current status_: Added preliminary implementation of PyCUDA device code derived from PyOpenCL implementation). Also included PyCUDA based loopy kernel execution example. Current code raises a NotImplemented exception when run:

`Traceback (most recent call last):
  File "examples/python/pycuda-loopy.py", line 16, in <module>
    cuda_knl(a=a, b=b, c=c)
  File "/home/aju3/emirge/loopy/loopy/translation_unit.py", line 335, in __call__
    key = self.target.get_kernel_executor_cache_key(*args, **kwargs)
  File "/home/aju3/emirge/loopy/loopy/target/c/__init__.py", line 449, in get_kernel_executor_cache_key
    raise NotImplementedError
NotImplementedError`

_Next steps_: Adapt kernel executor for PyCUDA and rework PyCUDA target code. Add complex number support (?). 