### PR TITLE
Map domain transformation v2

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -76,7 +76,7 @@ from loopy.transform.iname import (
         affine_map_inames, find_unused_axis_tag,
         make_reduction_inames_unique,
         has_schedulable_iname_nesting, get_iname_duplication_options,
-        add_inames_to_insn, add_inames_for_unused_hw_axes)
+        add_inames_to_insn, add_inames_for_unused_hw_axes, map_domain)
 
 from loopy.transform.instruction import (
         find_instructions, map_instructions,
@@ -202,7 +202,7 @@ __all__ = [
         "affine_map_inames", "find_unused_axis_tag",
         "make_reduction_inames_unique",
         "has_schedulable_iname_nesting", "get_iname_duplication_options",
-        "add_inames_to_insn", "add_inames_for_unused_hw_axes",
+        "add_inames_to_insn", "add_inames_for_unused_hw_axes", "map_domain",
 
         "add_prefetch", "change_arg_to_image",
         "tag_array_axes", "tag_data_axes",

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -825,15 +825,14 @@ def add_eq_constraint_from_names(isl_obj, var1, var2):
 
 # {{{ find_and_rename_dim
 
-def find_and_rename_dim(isl_obj, dim_types, old_name, new_name):
+def find_and_rename_dim(isl_obj, dt, old_name, new_name):
     """Rename a dimension in an ISL object.
 
     :arg isl_obj: An :class:`islpy.Set` or  :class:`islpy.Map` containing the
         dimension to be renamed.
 
-    :arg dim_types: An iterable of :class:`islpy.dim_type` values (i.e.,
-        :class:`int` values) specifying the dimension types for any dimensions
-        to be renamed.
+    :arg dt: An :class:`islpy.dim_type` (i.e., :class:`int`) specifying the
+        dimension type containing the dimension to be renamed.
 
     :arg old_name: A :class:`str` specifying the name of the dimension to be
         renamed.
@@ -845,10 +844,8 @@ def find_and_rename_dim(isl_obj, dim_types, old_name, new_name):
         *old_name* renamed to *new_name*.
 
     """
-    for dt in dim_types:
-        isl_obj = isl_obj.set_dim_name(
+    return isl_obj.set_dim_name(
             dt, isl_obj.find_dim_by_name(dt, old_name), new_name)
-    return isl_obj
 
 # }}}
 

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -789,10 +789,10 @@ def add_and_name_dims(isl_obj, dt, names):
     """
 
     new_idx_start = isl_obj.dim(dt)
-    new_obj = isl_obj.add_dims(dt, len(names))
+    isl_obj = isl_obj.add_dims(dt, len(names))
     for i, name in enumerate(names):
-        new_obj = new_obj.set_dim_name(dt, new_idx_start+i, name)
-    return new_obj
+        isl_obj = isl_obj.set_dim_name(dt, new_idx_start+i, name)
+    return isl_obj
 
 # }}}
 

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -767,4 +767,54 @@ def subst_into_pwaff(new_space, pwaff, subst_dict):
 
 # }}}
 
+
+# {{{ add_and_name_isl_dims
+
+def add_and_name_isl_dims(isl_map, dt, names):
+    # (This function is also defined in independent, unmerged branch
+    # statement-instance-order-and-lex-order-map, and used in child branches
+    # thereof. Once these branches are all merged, it may make sense to move
+    # this function to a location for more general-purpose machinery. In the
+    # other branches, this function's name excludes the leading underscore.)
+    new_idx_start = isl_map.dim(dt)
+    new_map = isl_map.add_dims(dt, len(names))
+    for i, name in enumerate(names):
+        new_map = new_map.set_dim_name(dt, new_idx_start+i, name)
+    return new_map
+
+# }}}
+
+
+# {{{ add_eq_isl_constraint_from_names
+
+def add_eq_isl_constraint_from_names(isl_map, var1, var2):
+    # (This function is also defined in independent, unmerged branch
+    # statement-instance-order-and-lex-order-map, and used in child branches
+    # thereof. Once these branches are all merged, it may make sense to move
+    # this function to a location for more general-purpose machinery. In the
+    # other branches, this function's name excludes the leading underscore.)
+
+    # add constraint var1 = var2
+
+    return isl_map.add_constraint(
+               isl.Constraint.eq_from_names(
+                   isl_map.space,
+                   {1: 0, var1: 1, var2: -1}))
+
+# }}}
+
+
+# {{{ find_and_rename_dim
+
+def find_and_rename_dim(map, dim_types, old_name, new_name):
+    # (This function is only used once here, but do not inline it; it is used many
+    # times in child branch update-dependencies-during-transformations.)
+    for dt in dim_types:
+        map = map.set_dim_name(
+            dt, map.find_dim_by_name(dt, old_name), new_name)
+    return map
+
+# }}}
+
+
 # vim: foldmethod=marker

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -768,37 +768,25 @@ def subst_into_pwaff(new_space, pwaff, subst_dict):
 # }}}
 
 
-# {{{ add_and_name_isl_dims
+# {{{ add_and_name_dims
 
-def add_and_name_isl_dims(isl_map, dt, names):
-    # (This function is also defined in independent, unmerged branch
-    # statement-instance-order-and-lex-order-map, and used in child branches
-    # thereof. Once these branches are all merged, it may make sense to move
-    # this function to a location for more general-purpose machinery. In the
-    # other branches, this function's name excludes the leading underscore.)
-    new_idx_start = isl_map.dim(dt)
-    new_map = isl_map.add_dims(dt, len(names))
+def add_and_name_dims(isl_obj, dt, names):
+    new_idx_start = isl_obj.dim(dt)
+    new_obj = isl_obj.add_dims(dt, len(names))
     for i, name in enumerate(names):
-        new_map = new_map.set_dim_name(dt, new_idx_start+i, name)
-    return new_map
+        new_obj = new_obj.set_dim_name(dt, new_idx_start+i, name)
+    return new_obj
 
 # }}}
 
 
-# {{{ add_eq_isl_constraint_from_names
+# {{{ add_eq_constraint_from_names
 
-def add_eq_isl_constraint_from_names(isl_map, var1, var2):
-    # (This function is also defined in independent, unmerged branch
-    # statement-instance-order-and-lex-order-map, and used in child branches
-    # thereof. Once these branches are all merged, it may make sense to move
-    # this function to a location for more general-purpose machinery. In the
-    # other branches, this function's name excludes the leading underscore.)
-
+def add_eq_constraint_from_names(isl_obj, var1, var2):
     # add constraint var1 = var2
-
-    return isl_map.add_constraint(
+    return isl_obj.add_constraint(
                isl.Constraint.eq_from_names(
-                   isl_map.space,
+                   isl_obj.space,
                    {1: 0, var1: 1, var2: -1}))
 
 # }}}
@@ -806,13 +794,11 @@ def add_eq_isl_constraint_from_names(isl_map, var1, var2):
 
 # {{{ find_and_rename_dim
 
-def find_and_rename_dim(map, dim_types, old_name, new_name):
-    # (This function is only used once here, but do not inline it; it is used many
-    # times in child branch update-dependencies-during-transformations.)
+def find_and_rename_dim(isl_obj, dim_types, old_name, new_name):
     for dt in dim_types:
-        map = map.set_dim_name(
-            dt, map.find_dim_by_name(dt, old_name), new_name)
-    return map
+        isl_obj = isl_obj.set_dim_name(
+            dt, isl_obj.find_dim_by_name(dt, old_name), new_name)
+    return isl_obj
 
 # }}}
 

--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -771,6 +771,23 @@ def subst_into_pwaff(new_space, pwaff, subst_dict):
 # {{{ add_and_name_dims
 
 def add_and_name_dims(isl_obj, dt, names):
+    """Append dimensions of the specified dimension type to the provided ISL
+    object, and set their names.
+
+    :arg isl_obj: An :class:`islpy.Set` or  :class:`islpy.Map` to which
+        new dimensions will be added.
+
+    :arg dt: An :class:`islpy.dim_type`, i.e., an :class:`int`, specifying the
+        dimension type for the new dimensions.
+
+    :arg names: An iterable of :class:`str` values specifying the names of the
+        new dimensions to be added.
+
+    :returns: An object of the same type as *isl_obj* with the new dimensions
+        added and named.
+
+    """
+
     new_idx_start = isl_obj.dim(dt)
     new_obj = isl_obj.add_dims(dt, len(names))
     for i, name in enumerate(names):
@@ -783,7 +800,21 @@ def add_and_name_dims(isl_obj, dt, names):
 # {{{ add_eq_constraint_from_names
 
 def add_eq_constraint_from_names(isl_obj, var1, var2):
-    # add constraint var1 = var2
+    """Add constraint *var1* = *var2* to an ISL object.
+
+    :arg isl_obj: An :class:`islpy.Set` or  :class:`islpy.Map` to which
+        a new constraint will be added.
+
+    :arg var1: A :class:`str` specifying the name of the first variable
+        involved in constraint *var1* = *var2*.
+
+    :arg var2: A :class:`str` specifying the name of the second variable
+        involved in constraint *var1* = *var2*.
+
+    :returns: An object of the same type as *isl_obj* with the constraint
+        *var1* = *var2*.
+
+    """
     return isl_obj.add_constraint(
                isl.Constraint.eq_from_names(
                    isl_obj.space,
@@ -795,6 +826,25 @@ def add_eq_constraint_from_names(isl_obj, var1, var2):
 # {{{ find_and_rename_dim
 
 def find_and_rename_dim(isl_obj, dim_types, old_name, new_name):
+    """Rename a dimension in an ISL object.
+
+    :arg isl_obj: An :class:`islpy.Set` or  :class:`islpy.Map` containing the
+        dimension to be renamed.
+
+    :arg dim_types: An iterable of :class:`islpy.dim_type` values (i.e.,
+        :class:`int` values) specifying the dimension types for any dimensions
+        to be renamed.
+
+    :arg old_name: A :class:`str` specifying the name of the dimension to be
+        renamed.
+
+    :arg new_name: A :class:`str` specifying the new name of the dimension to
+        be renamed.
+
+    :returns: An object of the same type as *isl_obj* with the dimension
+        *old_name* renamed to *new_name*.
+
+    """
     for dt in dim_types:
         isl_obj = isl_obj.set_dim_name(
             dt, isl_obj.find_dim_by_name(dt, old_name), new_name)

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1964,20 +1964,20 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
     # suffixed with a single apostrophe.)
 
     from loopy.isl_helpers import (
-        add_and_name_isl_dims, add_eq_isl_constraint_from_names)
+        add_and_name_dims, add_eq_constraint_from_names)
 
     # {{{ Find any missing vars and add them to the input and output space
 
     missing_dims = list(
         set(desired_dims) - set(mapping.get_var_names(dim_type.in_)))
-    augmented_mapping = add_and_name_isl_dims(
+    augmented_mapping = add_and_name_dims(
         mapping, dim_type.in_, missing_dims)
 
     missing_dims_proxies = [d+"_'prox'_" for d in missing_dims]
     assert not set(missing_dims_proxies) & set(
         augmented_mapping.get_var_dict().keys())
 
-    augmented_mapping = add_and_name_isl_dims(
+    augmented_mapping = add_and_name_dims(
         augmented_mapping, dim_type.out, missing_dims_proxies)
 
     proxy_name_pairs = list(zip(missing_dims, missing_dims_proxies))
@@ -1987,7 +1987,7 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
     # {{{ Add identity constraint (v = v_'proxy'_) for each new pair of dims
 
     for real_iname, proxy_iname in proxy_name_pairs:
-        augmented_mapping = add_eq_isl_constraint_from_names(
+        augmented_mapping = add_eq_constraint_from_names(
             augmented_mapping, proxy_iname, real_iname)
 
     # }}}

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2208,8 +2208,7 @@ def map_domain(kernel, transform_map):
 
         # Make sure transform map is applicable to this set. Then transform.
 
-        if not transform_map_in_dims.issubset(
-                frozenset(old_domain.get_var_dict())):
+        if not transform_map_in_dims <= frozenset(old_domain.get_var_dict()):
 
             # Map not applicable to this set because map transforms at least
             # one iname that is not present in the set. Don't transform.

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2003,21 +2003,52 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
     return augmented_mapping, proxy_name_pairs
 
 
+def _error_if_any_iname_in_constraint(
+        inames, nest_constraints,
+        constraint_descriptor_str):
+    for constraint in nest_constraints:
+        for tier in constraint:
+            for iname in inames:
+                if tier.contains(iname):
+                    raise ValueError(
+                        "%s constraint %s contains iname(s) "
+                        "transformed by map in map_domain."
+                        % (constraint_descriptor_str, constraint))
+
+
 @for_each_kernel
 def map_domain(kernel, isl_map):
     # FIXME: Express _split_iname_backend in terms of this
     #   Missing/deleted for now:
     #     - slab processing
     #     - priorities processing
-    # FIXME: Process priorities
     # FIXME: Express affine_map_inames in terms of this, deprecate
     # FIXME: Document
 
+    # Make sure the map is bijective
     if not isl_map.is_bijective():
         raise LoopyError("isl_map must be bijective")
 
     transform_map_out_dims = frozenset(isl_map.get_var_dict(dim_type.out))
     transform_map_in_dims = frozenset(isl_map.get_var_dict(dim_type.in_))
+
+    # {{{ Make sure that none of the mapped inames are involved in loop priorities
+
+    if hasattr(kernel, "loop_priority") and kernel.loop_priority:
+        for prio in kernel.loop_priority:
+            if set(prio) & transform_map_in_dims:
+                raise ValueError(
+                    "Loop priority %s contains iname(s) transformed by "
+                    "map %s in map_domain." % (prio, isl_map))
+    if hasattr(kernel, "loop_nest_constraints") and kernel.loop_nest_constraints:
+        _error_if_any_iname_in_constraint(
+            transform_map_in_dims,
+            kernel.loop_nest_constraints.must_nest, "Must-nest")
+        _error_if_any_iname_in_constraint(
+            transform_map_in_dims,
+            kernel.loop_nest_constraints.must_not_nest, "Must-not-nest")
+
+    # }}}
 
     # {{{ solve for representation of old inames in terms of new
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1946,6 +1946,16 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
     input space for *mapping*, add input dimension v, output dimension
     v_'proxy'_, and constraint v = v_'proxy'_ to the mapping. Also return a
     list of the (v, v_'proxy'_) pairs.
+
+    :arg mapping: An :class:`islpy.Map`.
+
+    :arg desired_dims: An iterable of :class:`str` specifying the names of the
+        desired map input dimensions.
+
+    :returns: A two-tuple containing the mapping with the new dimensions and
+        constraints added, and a list of two-tuples of :class:`str` values
+        specifying the (v, v_'proxy'_) pairs.
+
     """
 
     # If the transform map in map_domain (below) does not contain all the

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1850,7 +1850,7 @@ class _MapDomainMapper(RuleAwareIdentityMapper):
         arg_ctx_overlap = frozenset(expn_state.arg_context) & self.old_inames
         if red_overlap:
             if len(red_overlap) != len(self.old_inames):
-                raise LoopyError("reduction '%s' involves a part "
+                raise LoopyError("Reduction '%s' involves a part "
                         "of the map domain inames. Reductions must "
                         "either involve all or none of the map domain "
                         "inames." % str(expr))
@@ -1861,7 +1861,7 @@ class _MapDomainMapper(RuleAwareIdentityMapper):
                     return super(_MapDomainMapper, self).map_reduction(
                             expr, expn_state)
                 else:
-                    raise LoopyError("reduction '%s' has"
+                    raise LoopyError("Reduction '%s' has"
                             "some of the reduction variables affected "
                             "by the map_domain shadowed by context. "
                             "Either all or none must be shadowed."
@@ -1928,7 +1928,7 @@ def _find_aff_subst_from_map(iname, isl_map):
                 # not suitable, coefficient does not have unit coefficient
                 continue
 
-    raise LoopyError("no suitable equation for '%s' found" % iname)
+    raise LoopyError("No suitable equation for '%s' found" % iname)
 
 
 def _add_and_name_isl_dims(isl_map, dt, names):

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1969,14 +1969,13 @@ def _add_eq_isl_constraint_from_names(isl_map, var1, var2):
                    {1: 0, var1: 1, var2: -1}))
 
 
-def _find_and_rename_dim(old_map, dim_types, old_name, new_name):
+def _find_and_rename_dim(map, dim_types, old_name, new_name):
     # (This function is only used once here, but do not inline it; it is used many
     # times in child branch update-dependencies-during-transformations.)
-    new_map = old_map.copy()
     for dt in dim_types:
-        new_map = new_map.set_dim_name(
-            dt, new_map.find_dim_by_name(dt, old_name), new_name)
-    return new_map
+        map = map.set_dim_name(
+            dt, map.find_dim_by_name(dt, old_name), new_name)
+    return map
 
 # }}}
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2090,11 +2090,12 @@ def map_domain(kernel, transform_map):
 
         # If there are dims in s that are not mapped by transform_map, add them
         # to the in/out space of transform_map so that they remain unchanged.
-        # (temporary proxy dim names are needed in out space of transform
-        # map because isl won't allow any dim names to match, i.e., instead
-        # of just mapping {[unused_iname]->[unused_iname]}, we have to map
+        # We cannot just map {[unused_iname]->[unused_iname]} because isl won't
+        # allow any dim names to match, so temporary proxy dim names are needed
+        # in out space of transform map. I.e., we apply mapping
         # {[unused_name]->[unused_name__prox] : unused_name__prox = unused_name},
-        # and then rename unused_name__prox afterward.)
+        # and then rename unused_name__prox afterward.
+
         augmented_transform_map, proxy_name_pairs = \
             _apply_identity_for_missing_map_dims(
                 transform_map, s.get_var_names(dim_type.set))

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2021,8 +2021,13 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
 
 
 def _error_if_any_iname_in_constraint(
-        inames, nest_constraints,
-        constraint_descriptor_str):
+        inames, nest_constraints, constraint_descriptor_str):
+    """Raise informative error if any iname in *inames* is constrained by any
+    nest constraint in *nest_constraints*.
+    """
+    # (This function is only used when new machinery from
+    # new-loop-nest-constraints branch is detected.)
+
     for constraint in nest_constraints:
         for tier in constraint:
             for iname in inames:

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1939,10 +1939,6 @@ def _find_aff_subst_from_map(iname, isl_map):
     raise LoopyError("no suitable equation for '%s' found" % iname)
 
 
-# FIXME to match convention elsewhere, swap 'dt' and 'dim_type' identifiers
-# (use dt to abbreviate islpy.dim_type, and use dim_type for variables
-# containing a specific dim_type)
-
 def _add_and_name_isl_dims(isl_map, dt, names):
     # (This function is also defined in independent, unmerged branch
     # statement-instance-order-and-lex-order-map, and used in child branches

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2085,10 +2085,10 @@ def map_domain(kernel, transform_map):
     from loopy.symbolic import aff_to_expr
     from pymbolic import var
     for iname in transform_map_in_dims:
-        substitutions[iname] = aff_to_expr(
-                _find_aff_subst_from_map(iname, transform_map))
-        var_substitutions[var(iname)] = aff_to_expr(
-                _find_aff_subst_from_map(iname, transform_map))
+        subst_from_map = aff_to_expr(
+            _find_aff_subst_from_map(iname, transform_map))
+        substitutions[iname] = subst_from_map
+        var_substitutions[var(iname)] = subst_from_map
 
     applied_iname_rewrites.append(var_substitutions)
     del var_substitutions

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1834,7 +1834,9 @@ def add_inames_to_insn(kernel, inames, insn_match):
 # }}}
 
 
-# {{{ map_domain
+# {{{ map_domain and associated functions
+
+# {{{ _MapDomainMapper
 
 class _MapDomainMapper(RuleAwareIdentityMapper):
     def __init__(self, rule_mapping_context, new_inames, substitutions):
@@ -1886,6 +1888,10 @@ class _MapDomainMapper(RuleAwareIdentityMapper):
         else:
             return super(_MapDomainMapper, self).map_variable(expr, expn_state)
 
+# }}}
+
+
+# {{{ _find_aff_subst_from_map(iname, isl_map)
 
 def _find_aff_subst_from_map(iname, isl_map):
     if not isinstance(isl_map, isl.BasicMap):
@@ -1930,6 +1936,10 @@ def _find_aff_subst_from_map(iname, isl_map):
 
     raise LoopyError("No suitable equation for '%s' found" % iname)
 
+# }}}
+
+
+# {{{ ISL map wrangling helper functions
 
 def _add_and_name_isl_dims(isl_map, dt, names):
     # (This function is also defined in independent, unmerged branch
@@ -1968,6 +1978,10 @@ def _find_and_rename_dim(old_map, dim_types, old_name, new_name):
             dt, new_map.find_dim_by_name(dt, old_name), new_name)
     return new_map
 
+# }}}
+
+
+# {{{ _apply_identity_for_missing_map_dims(mapping, desired_dims)
 
 def _apply_identity_for_missing_map_dims(mapping, desired_dims):
     """For every variable v in *desired_dims* that is not found in the
@@ -2019,6 +2033,10 @@ def _apply_identity_for_missing_map_dims(mapping, desired_dims):
 
     return augmented_mapping, proxy_name_pairs
 
+# }}}
+
+
+# {{{ _error_if_any_iname_in_constraint
 
 def _error_if_any_iname_in_constraint(
         inames, nest_constraints, constraint_descriptor_str):
@@ -2037,6 +2055,10 @@ def _error_if_any_iname_in_constraint(
                         "transformed by map in map_domain."
                         % (constraint_descriptor_str, constraint))
 
+# }}}
+
+
+# {{{ map_domain
 
 @for_each_kernel
 def map_domain(kernel, transform_map):
@@ -2256,6 +2278,8 @@ def map_domain(kernel, transform_map):
     kernel = rule_mapping_context.finish_kernel(kernel)
 
     return kernel
+
+# }}}
 
 # }}}
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2151,7 +2151,7 @@ def map_domain(kernel, transform_map):
         from loopy.isl_helpers import find_and_rename_dim
         for real_iname, proxy_iname in proxy_name_pairs:
             new_s = find_and_rename_dim(
-                new_s, [dim_type.set], proxy_iname, real_iname)
+                new_s, dim_type.set, proxy_iname, real_iname)
 
         return new_s
 

--- a/test/test_reduction.py
+++ b/test/test_reduction.py
@@ -442,6 +442,24 @@ def test_reduction_with_conditional():
     assert code.index("if") < code.index("for")
 
 
+def test_any_all(ctx_factory):
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    knl = lp.make_kernel(
+        "{[i, j]: 0<=i,j<10}",
+        """
+        out1 = reduce(any, [i], i == 4)
+        out2 = reduce(all, [j], j == 5)
+        """)
+    knl = lp.set_options(knl, return_dict=True)
+
+    _, out_dict = knl(cq)
+
+    assert out_dict["out1"].get()
+    assert not out_dict["out2"].get()
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -743,16 +743,13 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
 
     # Prioritize loops
+    desired_prio = "x, t_outer, t_inner, z, y_new"
 
     # Use constrain_loop_nesting if it's available
     cln_attr = getattr(lp, "constrain_loop_nesting", None)
     if cln_attr is not None:
-        desired_prio = "x, t_outer, t_inner, z, y_new"
         knl_map_dom = lp.constrain_loop_nesting(knl_map_dom, desired_prio)
     else:
-        # For some reason, prioritize_loops can't handle the ordering above
-        # when linearizing knl_split_iname below
-        desired_prio = "z, y_new, x, t_outer, t_inner"
         knl_map_dom = lp.prioritize_loops(knl_map_dom, desired_prio)
 
     # Get a linearization

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -655,7 +655,8 @@ def test_map_domain_vs_split_iname(ctx_factory):
     knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
 
     # Prioritize loops (prio should eventually be updated in map_domain?)
-    knl_map_dom = lp.prioritize_loops(knl_map_dom, "x, t_outer, t_inner")
+    loop_priority = "x, t_outer, t_inner"
+    knl_map_dom = lp.prioritize_loops(knl_map_dom, loop_priority)
 
     # Get a linearization
     proc_knl_map_dom = lp.preprocess_kernel(knl_map_dom)
@@ -668,7 +669,7 @@ def test_map_domain_vs_split_iname(ctx_factory):
 
     knl_split_iname = ref_knl
     knl_split_iname = lp.split_iname(knl_split_iname, "t", 32)
-    knl_split_iname = lp.prioritize_loops(knl_split_iname, "x, t_outer, t_inner")
+    knl_split_iname = lp.prioritize_loops(knl_split_iname, loop_priority)
     proc_knl_split_iname = lp.preprocess_kernel(knl_split_iname)
     lin_knl_split_iname = lp.get_one_linearized_kernel(
         proc_knl_split_iname["loopy_kernel"], proc_knl_split_iname.callables_table)
@@ -719,8 +720,8 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
 
     # }}}
 
-    # {{{ Make sure map_domain succeeds when we apply a map that includes 2 of 4
-    # dims in the domain.
+    # {{{ Make sure map_domain *succeeds* when map includes 2 of 4 dims in one
+    # domain.
 
     # {{{ Apply domain change mapping that splits t and renames y; (similar to
     # split_iname test above, but doesn't hurt to test this slightly different
@@ -759,7 +760,7 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
 
     # }}}
 
-    # {{{ Use split_iname, and rename_iname, and make sure we get the same result
+    # {{{ Use split_iname and rename_iname, and make sure we get the same result
 
     knl_split_iname = ref_knl
     knl_split_iname = lp.split_iname(knl_split_iname, "t", 16)
@@ -870,7 +871,7 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     # {{{ Make sure we error when stmt.within_inames contains at least one but
     # not all mapped inames
 
-    # {{{ Make kernel
+    # {{{ Make potentially problematic kernel
 
     knl = lp.make_kernel(
         [

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -920,7 +920,6 @@ def test_diamond_tiling(ctx_factory, interactive=False):
             - u[ix, it])
         """)
 
-    # FIXME: Handle priorities in map_domain
     knl_for_transform = ref_knl
 
     ref_knl = lp.prioritize_loops(ref_knl, "it, ix")

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -618,7 +618,7 @@ def _ensure_dim_names_match_and_align(obj_map, tgt_map):
     return align_spaces(obj_map, tgt_map)
 
 
-def test_map_domain_vs_split_iname():
+def test_map_domain_vs_split_iname(ctx_factory):
 
     # {{{ Make kernel
 
@@ -686,6 +686,9 @@ def test_map_domain_vs_split_iname():
 
     # Can't easily compare instructions because equivalent subscript
     # expressions may have different orders
+
+    lp.auto_test_vs_ref(proc_knl_split_iname, ctx_factory(), proc_knl_map_dom,
+        parameters={"nx": 256, "nt": 256, "ni": 256})
 
     # }}}
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -733,9 +733,9 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     import islpy as isl
     transform_map = isl.BasicMap(
         "[nx,nt] -> {[t, y] -> [t_outer, t_inner, y_new]: "
-        "0 <= t_inner < 32 and "
-        "32*t_outer + t_inner = t and "
-        "0 <= 32*t_outer + t_inner < nt and "
+        "0 <= t_inner < 16 and "
+        "16*t_outer + t_inner = t and "
+        "0 <= 16*t_outer + t_inner < nt and "
         "y = y_new"
         "}")
 
@@ -765,7 +765,7 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     # {{{ Use split_iname, and rename_iname, and make sure we get the same result
 
     knl_split_iname = ref_knl
-    knl_split_iname = lp.split_iname(knl_split_iname, "t", 32)
+    knl_split_iname = lp.split_iname(knl_split_iname, "t", 16)
     knl_split_iname = lp.rename_iname(knl_split_iname, "y", "y_new")
     try:
         # Use constrain_loop_nesting if it's available
@@ -791,7 +791,7 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     # expressions may have different orders
 
     lp.auto_test_vs_ref(proc_knl_split_iname, ctx_factory(), proc_knl_map_dom,
-        parameters={"nx": 64, "nt": 64, "m": 64})
+        parameters={"nx": 32, "nt": 32, "m": 32})
 
     # }}}
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -594,6 +594,248 @@ def test_nested_substs_in_insns(ctx_factory):
     lp.auto_test_vs_ref(ref_prg, ctx, t_unit)
 
 
+# {{{ test_map_domain_vs_split_iname
+
+def _ensure_dim_names_match_and_align(obj_map, tgt_map):
+    # (This function is also defined in independent, unmerged branch
+    # new-dependency-and-nest-constraint-semantics-development, and used in
+    # child branches thereof. Once these branches are all merged, it may make
+    # sense to move this function to a location for more general-purpose
+    # machinery. In the other branches, this function's name excludes the
+    # leading underscore.)
+    from islpy import align_spaces
+    from islpy import dim_type as dt
+
+    # first make sure names match
+    if not all(
+            set(obj_map.get_var_names(dt)) == set(tgt_map.get_var_names(dt))
+            for dt in
+            [dt.in_, dt.out, dt.param]):
+        raise ValueError(
+            "Cannot align spaces; names don't match:\n%s\n%s"
+            % (obj_map, tgt_map))
+
+    return align_spaces(obj_map, tgt_map)
+
+
+def test_map_domain_vs_split_iname():
+
+    # {{{ Make kernel
+
+    knl = lp.make_kernel(
+        [
+            "[nx,nt] -> {[x, t]: 0 <= x < nx and 0 <= t < nt}",
+            "[ni] -> {[i]: 0 <= i < ni}",
+        ],
+        """
+        a[x,t] = b[x,t]  {id=stmta}
+        c[x,t] = d[x,t]  {id=stmtc}
+        e[i] = f[i]
+        """,
+        lang_version=(2018, 2),
+        )
+    knl = lp.add_and_infer_dtypes(knl, {"b,d,f": np.float32})
+    ref_knl = knl
+
+    # }}}
+
+    # {{{ Apply domain change mapping
+
+    knl_map_dom = ref_knl  # loop priority goes away, deps stay
+
+    # Create map_domain mapping:
+    import islpy as isl
+    transform_map = isl.BasicMap(
+        "[nt] -> {[t] -> [t_outer, t_inner]: "
+        "0 <= t_inner < 32 and "
+        "32*t_outer + t_inner = t and "
+        "0 <= 32*t_outer + t_inner < nt}")
+
+    # Call map_domain to transform kernel
+    knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
+
+    # Prioritize loops (prio should eventually be updated in map_domain?)
+    knl_map_dom = lp.prioritize_loops(knl_map_dom, "x, t_outer, t_inner")
+
+    # Get a linearization
+    proc_knl_map_dom = lp.preprocess_kernel(knl_map_dom)
+    lin_knl_map_dom = lp.get_one_linearized_kernel(
+        proc_knl_map_dom["loopy_kernel"], proc_knl_map_dom.callables_table)
+
+    # }}}
+
+    # {{{ Split iname and see if we get the same result
+
+    knl_split_iname = ref_knl
+    knl_split_iname = lp.split_iname(knl_split_iname, "t", 32)
+    knl_split_iname = lp.prioritize_loops(knl_split_iname, "x, t_outer, t_inner")
+    proc_knl_split_iname = lp.preprocess_kernel(knl_split_iname)
+    lin_knl_split_iname = lp.get_one_linearized_kernel(
+        proc_knl_split_iname["loopy_kernel"], proc_knl_split_iname.callables_table)
+
+    for d_map_domain, d_split_iname in zip(
+            knl_map_dom["loopy_kernel"].domains,
+            knl_split_iname["loopy_kernel"].domains):
+        d_map_domain_aligned = _ensure_dim_names_match_and_align(
+            d_map_domain, d_split_iname)
+        assert d_map_domain_aligned == d_split_iname
+
+    for litem_map_domain, litem_split_iname in zip(
+            lin_knl_map_dom.linearization, lin_knl_split_iname.linearization):
+        assert litem_map_domain == litem_split_iname
+
+    # Can't easily compare instructions because equivalent subscript
+    # expressions may have different orders
+
+    # }}}
+
+# }}}
+
+
+# {{{ test_map_domain_with_transform_map_missing_dims
+
+def test_map_domain_with_transform_map_missing_dims():
+    # Make sure map_domain works correctly when the mapping doesn't include
+    # all the dims in the domain.
+
+    # {{{ Make kernel
+
+    knl = lp.make_kernel(
+        [
+            "[nx,nt] -> {[x, y, z, t]: 0 <= x,y,z < nx and 0 <= t < nt}",
+        ],
+        """
+        a[y,x,t,z] = b[y,x,t,z]  {id=stmta}
+        """,
+        lang_version=(2018, 2),
+        )
+    knl = lp.add_and_infer_dtypes(knl, {"b": np.float32})
+    ref_knl = knl
+
+    # }}}
+
+    # {{{ Apply domain change mapping
+
+    knl_map_dom = ref_knl  # loop priority goes away, deps stay
+
+    # Create map_domain mapping that only includes t and y
+    # (x and z should be unaffected)
+    import islpy as isl
+    transform_map = isl.BasicMap(
+        "[nx,nt] -> {[t, y] -> [t_outer, t_inner, y_new]: "
+        "0 <= t_inner < 32 and "
+        "32*t_outer + t_inner = t and "
+        "0 <= 32*t_outer + t_inner < nt and "
+        "y = y_new"
+        "}")
+
+    # Call map_domain to transform kernel
+    knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
+
+    # Prioritize loops (prio should eventually be updated in map_domain?)
+    try:
+        # Use constrain_loop_nesting if it's available
+        desired_prio = "x, t_outer, t_inner, z, y_new"
+        knl_map_dom = lp.constrain_loop_nesting(knl_map_dom, desired_prio)
+    except AttributeError:
+        # For some reason, prioritize_loops can't handle the ordering above
+        # when linearizing knl_split_iname below
+        desired_prio = "z, y_new, x, t_outer, t_inner"
+        knl_map_dom = lp.prioritize_loops(knl_map_dom, desired_prio)
+
+    # Get a linearization
+    proc_knl_map_dom = lp.preprocess_kernel(knl_map_dom)
+    lin_knl_map_dom = lp.get_one_linearized_kernel(
+        proc_knl_map_dom["loopy_kernel"], proc_knl_map_dom.callables_table)
+
+    # }}}
+
+    # {{{ Split iname and see if we get the same result
+
+    knl_split_iname = ref_knl
+    knl_split_iname = lp.split_iname(knl_split_iname, "t", 32)
+    knl_split_iname = lp.rename_iname(knl_split_iname, "y", "y_new")
+    try:
+        # Use constrain_loop_nesting if it's available
+        knl_split_iname = lp.constrain_loop_nesting(knl_split_iname, desired_prio)
+    except AttributeError:
+        knl_split_iname = lp.prioritize_loops(knl_split_iname, desired_prio)
+    proc_knl_split_iname = lp.preprocess_kernel(knl_split_iname)
+    lin_knl_split_iname = lp.get_one_linearized_kernel(
+        proc_knl_split_iname["loopy_kernel"], proc_knl_split_iname.callables_table)
+
+    for d_map_domain, d_split_iname in zip(
+            knl_map_dom["loopy_kernel"].domains,
+            knl_split_iname["loopy_kernel"].domains):
+        d_map_domain_aligned = _ensure_dim_names_match_and_align(
+            d_map_domain, d_split_iname)
+        assert d_map_domain_aligned == d_split_iname
+
+    for litem_map_domain, litem_split_iname in zip(
+            lin_knl_map_dom.linearization, lin_knl_split_iname.linearization):
+        assert litem_map_domain == litem_split_iname
+
+    # Can't easily compare instructions because equivalent subscript
+    # expressions may have different orders
+
+    # }}}
+
+# }}}
+
+
+def test_diamond_tiling(ctx_factory, interactive=False):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+
+    ref_knl = lp.make_kernel(
+        "[nx,nt] -> {[ix, it]: 1<=ix<nx-1 and 0<=it<nt}",
+        """
+        u[ix, it+2] = (
+            2*u[ix, it+1]
+            + dt**2/dx**2 * (u[ix+1, it+1] - 2*u[ix, it+1] + u[ix-1, it+1])
+            - u[ix, it])
+        """)
+
+    # FIXME: Handle priorities in map_domain
+    knl_for_transform = ref_knl
+
+    ref_knl = lp.prioritize_loops(ref_knl, "it, ix")
+
+    import islpy as isl
+    m = isl.BasicMap(
+        "[nx,nt] -> {[ix, it] -> [tx, tt, tparity, itt, itx]: "
+        "16*(tx - tt) + itx - itt = ix - it and "
+        "16*(tx + tt + tparity) + itt + itx = ix + it and "
+        "0<=tparity<2 and 0 <= itx - itt < 16 and 0 <= itt+itx < 16}")
+    knl = lp.map_domain(knl_for_transform, m)
+    knl = lp.prioritize_loops(knl, "tt,tparity,tx,itt,itx")
+
+    if interactive:
+        nx = 43
+        u = np.zeros((nx, 200))
+        x = np.linspace(-1, 1, nx)
+        dx = x[1] - x[0]
+        u[:, 0] = u[:, 1] = np.exp(-100*x**2)
+
+        u_dev = cl.array.to_device(queue, u)
+        knl(queue, u=u_dev, dx=dx, dt=dx)
+
+        u = u_dev.get()
+        import matplotlib.pyplot as plt
+        plt.imshow(u.T)
+        plt.show()
+    else:
+        types = {"dt,dx,u": np.float64}
+        knl = lp.add_and_infer_dtypes(knl, types)
+        ref_knl = lp.add_and_infer_dtypes(ref_knl, types)
+
+        lp.auto_test_vs_ref(ref_knl, ctx, knl,
+                parameters={
+                    "nx": 200, "nt": 300,
+                    "dx": 1, "dt": 1
+                    })
+
+
 def test_extract_subst_with_iname_deps_in_templ(ctx_factory):
     knl = lp.make_kernel(
             "{[i, j, k]: 0<=i<100 and 0<=j,k<5}",

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -749,7 +749,8 @@ def test_map_domain_transform_map_validity_and_errors(ctx_factory):
     # Use constrain_loop_nesting if it's available
     cln_attr = getattr(lp, "constrain_loop_nesting", None)
     if cln_attr is not None:
-        knl_map_dom = lp.constrain_loop_nesting(knl_map_dom, desired_prio)
+        knl_map_dom = lp.constrain_loop_nesting(  # noqa pylint:disable=no-member
+            knl_map_dom, desired_prio)
     else:
         knl_map_dom = lp.prioritize_loops(knl_map_dom, desired_prio)
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -692,20 +692,22 @@ def test_map_domain_vs_split_iname():
 # }}}
 
 
-# {{{ test_map_domain_with_transform_map_missing_dims
+# {{{ test_map_domain_transform_map_validity_and_errors
 
-def test_map_domain_with_transform_map_missing_dims():
-    # Make sure map_domain works correctly when the mapping doesn't include
-    # all the dims in the domain.
+def test_map_domain_transform_map_validity_and_errors():
 
     # {{{ Make kernel
 
     knl = lp.make_kernel(
         [
             "[nx,nt] -> {[x, y, z, t]: 0 <= x,y,z < nx and 0 <= t < nt}",
+            "[m] -> {[j]: 0 <= j < m}",
         ],
         """
         a[y,x,t,z] = b[y,x,t,z]  {id=stmta}
+        for j
+            <>temp = j  {dep=stmta}
+        end
         """,
         lang_version=(2018, 2),
         )
@@ -713,6 +715,9 @@ def test_map_domain_with_transform_map_missing_dims():
     ref_knl = knl
 
     # }}}
+
+    # Make sure map_domain works correctly when the mapping doesn't include
+    # all the dims in the domain.
 
     # {{{ Apply domain change mapping
 
@@ -729,10 +734,10 @@ def test_map_domain_with_transform_map_missing_dims():
         "y = y_new"
         "}")
 
-    # Call map_domain to transform kernel
+    # Call map_domain to transform kernel; this should not produce an error
     knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
 
-    # Prioritize loops (prio should eventually be updated in map_domain?)
+    # Prioritize loops (prio should eventually be updated in map_domain)
     try:
         # Use constrain_loop_nesting if it's available
         desired_prio = "x, t_outer, t_inner, z, y_new"
@@ -780,9 +785,7 @@ def test_map_domain_with_transform_map_missing_dims():
 
     # }}}
 
-    # {{{ Make sure there's an error if transform map contains *extra* dims
-    # Note, this is only okay if transform map 'in' dims don't match *any*
-    # domain inames, in which case nothing happens.
+    # {{{ Make sure we error on a map that is not bijective
 
     # Not bijective
     transform_map = isl.BasicMap(
@@ -798,43 +801,42 @@ def test_map_domain_with_transform_map_missing_dims():
     except LoopyError as err:
         assert "map must be bijective" in str(err)
 
-    # Bijective and rogue dim
-    # (with some inames missing from in-dims, which would otherwise be okay)
-    transform_map = isl.BasicMap(
-        "[nx,nt] -> {[t, y, rogue] -> [t_new, y_new, rogue_new]: "
-        "y = y_new and t = t_new and rogue = rogue_new"
-        "}")
+    # }}}
 
-    try:
-        knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
-        raise AssertionError()
-    except LoopyError as err:
-        assert (
-            "attempts to map variables that are not present in domain" in str(err))
+    # {{{ Make sure there's an error if transform map does not apply to
+    # exactly one domain.
 
-    # Bijective and rogue dim
-    # (with all inames present in in-dims)
-    transform_map = isl.BasicMap(
-        "[nx,nt] -> {[t, y, x, z, rogue] -> [t_new, y_new, x_new, z_new, rogue_new]:"
-        "y = y_new and t = t_new and x = x_new and z = z_new and rogue = rogue_new"
-        "}")
+    test_maps = [
+        # Map where some inames match exactly one domain but there's also a
+        # rogue dim
+        isl.BasicMap(
+            "[nx,nt] -> {[t, y, rogue] -> [t_new, y_new, rogue_new]: "
+            "y = y_new and t = t_new and rogue = rogue_new"
+            "}"),
+        # Map where all inames match exactly one domain but there's also a
+        # rogue dim
+        isl.BasicMap(
+            "[nx,nt] -> {[t, y, x, z, rogue] -> "
+            "[t_new, y_new, x_new, z_new, rogue_new]: "
+            "y = y_new and t = t_new and x = x_new and z = z_new "
+            "and rogue = rogue_new"
+            "}"),
+        # Map where no inames match any domain
+        isl.BasicMap(
+            "[nx,nt] -> {[rogue] -> [rogue_new]: "
+            "rogue = rogue_new"
+            "}"),
+        ]
 
-    try:
-        knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
-        raise AssertionError()
-    except LoopyError as err:
-        assert (
-            "attempts to map variables that are not present in domain" in str(err))
-
-    # Bijective and rogue dim with *no* inames present in domain
-    # (allowed but does nothing)
-    transform_map = isl.BasicMap(
-        "[nx,nt] -> {[rogue] -> [rogue_new]: "
-        "rogue = rogue_new"
-        "}")
-
-    # This should not raise an error
-    knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
+    for transform_map in test_maps:
+        try:
+            knl_map_dom = lp.map_domain(knl_map_dom, transform_map)
+            raise AssertionError()
+        except LoopyError as err:
+            assert (
+                "was applicable to 0 domains. "
+                "Transform map must be applicable to exactly one domain."
+                in str(err))
 
     # }}}
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -834,7 +834,7 @@ def test_map_domain_transform_map_validity_and_errors():
             raise AssertionError()
         except LoopyError as err:
             assert (
-                "was applicable to 0 domains. "
+                "was not applicable to any domain. "
                 "Transform map must be applicable to exactly one domain."
                 in str(err))
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -858,6 +858,52 @@ def test_map_domain_transform_map_validity_and_errors():
 
     # }}}
 
+    # {{{ Make sure we error when stmt.within_inames contains at least one but
+    # not all mapped inames
+
+    # {{{ Make kernel
+
+    knl = lp.make_kernel(
+        [
+            "[n, m] -> { [i, j]: 0 <= i < n and 0 <= j < m }",
+            "[ell] -> { [k]: 0 <= k < ell }",
+        ],
+        """
+        for i
+            <>t0 = i  {id=stmt0}
+            for j
+                <>t1 = j  {id=stmt1, dep=stmt0}
+            end
+            <>t2 = i + 1  {id=stmt2, dep=stmt1}
+        end
+        for k
+           <>t3 = k  {id=stmt3, dep=stmt2}
+        end
+        """,
+        lang_version=(2018, 2),
+        )
+
+    # }}}
+
+    # This should fail:
+    try:
+        transform_map = isl.BasicMap(
+            "[n, m] -> {[i, j] -> [i_new, j_new]: "
+            "i_new = i + j and j_new = 2 + i }")
+        knl = lp.map_domain(knl, transform_map)
+        raise AssertionError()
+    except LoopyError as err:
+        assert (
+            "Statements must be within all or none of the mapped inames"
+            in str(err))
+
+    # This should succeed:
+    transform_map = isl.BasicMap(
+        "[n, m] -> {[i] -> [i_new]: i_new = i + 2 }")
+    knl = lp.map_domain(knl, transform_map)
+
+    # }}}
+
 # }}}
 
 


### PR DESCRIPTION
Add `map_domain` transformation.

This PR/branch is one of **two parents** of [**child PR/branch:  Update dependencies during transformation**](https://github.com/inducer/loopy/pull/279)

This PR/branch was moved here to independent, top-level PR/branch from [**old PR/branch**: Add map_domain transformation](https://github.com/inducer/loopy/pull/300).

Note that to keep these branches independent, some helper functions are defined in both branches.