### PR TITLE
[pyopencl target]: Fix host code for zero-strided outputs

### DIFF
--- a/loopy/target/pyopencl_execution.py
+++ b/loopy/target/pyopencl_execution.py
@@ -101,7 +101,7 @@ class PyOpenCLExecutionWrapperGenerator(ExecutionWrapperGeneratorBase):
 
         if not skip_arg_checks:
             for i in range(num_axes):
-                gen("assert _lpy_ustrides_%d > 0, "
+                gen("assert _lpy_ustrides_%d >= 0, "
                         "\"'%s' has negative stride in axis %d\""
                         % (i, arg.name, i))
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3216,6 +3216,21 @@ def test_get_return_from_kernel_mapping():
     assert ret_from_knl_idx[9] == 10
 
 
+def test_zero_stride_array(ctx_factory):
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    knl = lp.make_kernel(
+        ["{[i]: 0<=i<10}",
+         "{[j]: 1=0}"],
+        """
+        y[i, j] = 1
+        """, [lp.GlobalArg("y", shape=(10, 0))])
+
+    evt, (out,) = knl(cq)
+    assert out.shape == (10, 0)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Provided regression fails on [`main`](https://github.com/inducer/loopy/commit/c33406c9098879737bf476380b7e1c53c7c87c78).