### PR TITLE
Implements `lp.simplify_indices`.

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -84,7 +84,8 @@ from loopy.transform.instruction import (
         remove_instructions,
         replace_instruction_ids,
         tag_instructions,
-        add_nosync)
+        add_nosync,
+        simplify_indices)
 
 from loopy.transform.data import (
         add_prefetch, change_arg_to_image,
@@ -217,6 +218,7 @@ __all__ = [
         "replace_instruction_ids",
         "tag_instructions",
         "add_nosync",
+        "simplify_indices",
 
         "extract_subst", "expand_subst", "assignment_to_subst",
         "find_rules_matching", "find_one_rule_matching",

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -70,6 +70,9 @@ import numpy as np
 __doc__ = """
 .. currentmodule:: loopy.symbolic
 
+Loopy-specific expression types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. autoclass:: Literal
 
 .. autoclass:: ArrayLiteral
@@ -95,6 +98,12 @@ __doc__ = """
 .. autoclass:: ResolvedFunction
 
 .. autoclass:: SubArrayRef
+
+
+Expression Manipulation Helpers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: simplify_using_aff
 """
 
 
@@ -1960,6 +1969,11 @@ def qpolynomial_from_expr(space, expr):
 
 @memoize_on_first_arg
 def simplify_using_aff(kernel, expr):
+    """
+    Simplifies *expr* on *kernel*'s domain.
+
+    :arg expr: An instance of :class:`pymbolic.primitives.Expression`.
+    """
     inames = get_dependencies(expr) & kernel.all_inames()
 
     # FIXME: Ideally, we should find out what inames are usable and allow

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -884,6 +884,50 @@ def test_privatize_with_nonzero_lbound(ctx_factory):
     np.testing.assert_allclose(out.get()[10:14], np.arange(10, 14))
 
 
+def test_simplify_indices(ctx_factory):
+    ctx = ctx_factory()
+    twice = lp.make_function(
+        "{[i, j]: 0<=i<10 and 0<=j<4}",
+        """
+        y[i,j] = 2*x[i,j]
+        """, name="zerozerozeroonezeroify")
+
+    knl = lp.make_kernel(
+        "{:}",
+        """
+        Y[:,:] = zerozerozeroonezeroify(X[:,:])
+        """, [lp.GlobalArg("X,Y",
+                           shape=(10, 4),
+                           dtype=np.float64)])
+
+    class ContainsFloorDiv(lp.symbolic.CombineMapper):
+        def combine(self, values):
+            return any(values)
+
+        def map_floor_div(self, expr):
+            return True
+
+        def map_variable(self, expr):
+            return False
+
+        def map_constant(self, expr):
+            return False
+
+    knl = lp.merge([knl, twice])
+    knl = lp.inline_callable_kernel(knl, "zerozerozeroonezeroify")
+    simplified_knl = lp.simplify_indices(knl)
+    contains_floordiv = ContainsFloorDiv()
+
+    assert any(contains_floordiv(insn.expression)
+               for insn in knl.default_entrypoint.instructions
+               if isinstance(insn, lp.MultiAssignmentBase))
+    assert all(not contains_floordiv(insn.expression)
+               for insn in simplified_knl.default_entrypoint.instructions
+               if isinstance(insn, lp.MultiAssignmentBase))
+
+    lp.auto_test_vs_ref(knl, ctx, simplified_knl)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
`lp.simplify_indices` would simplify the indexing expressions. Typically helpful if one wants to look at a kernel with redundant expressions in the subscripts