### PR TITLE
Realize reduction in conditional

### DIFF
--- a/loopy/preprocess.py
+++ b/loopy/preprocess.py
@@ -881,18 +881,19 @@ class RealizeReductionCallbackMapper(ReductionCallbackMapper):
 
     def map_if(self, expr, callables_table, guarding_predicates, nresults=1):
         import pymbolic.primitives as prim
-        return prim.If(self.rec(expr.condition, callables_table=callables_table,
+        rec_cond = self.rec(expr.condition, callables_table=callables_table,
                                 guarding_predicates=guarding_predicates,
-                                nresults=nresults),
+                                nresults=nresults)
+        return prim.If(rec_cond,
                        self.rec(expr.then, callables_table=callables_table,
                                 guarding_predicates=(
                                     guarding_predicates
-                                    | frozenset([expr.condition])),
+                                    | frozenset([rec_cond])),
                                 nresults=nresults),
                        self.rec(expr.else_, callables_table=callables_table,
                                 guarding_predicates=(
                                     guarding_predicates
-                                    | frozenset([prim.LogicalNot(expr.condition)])),
+                                    | frozenset([prim.LogicalNot(rec_cond)])),
                                 nresults=nresults))
 
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3248,6 +3248,21 @@ def test_predicated_redn(ctx_factory):
     lp.auto_test_vs_ref(knl, ctx, knl)
 
 
+def test_redn_in_predicate(ctx_factory):
+    ctx = ctx_factory()
+
+    knl = lp.make_kernel(
+        ["{[i]: 0<= i < 5}",
+         "{[j]: 0<= j < 10}",
+         "{[k]: 0<=k<10}"],
+        """
+        y[j] = sum(i, i**3) if (sum(k, k**2) < 2) else (10 - j)
+        """,
+        seq_dependencies=True)
+
+    lp.auto_test_vs_ref(knl, ctx, knl)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Provided test fails on `main` with

```
pymbolic.mapper.UnsupportedExpressionError: <class 'loopy.target.pyopencl.ExpressionToPyOpenCLCExpressionMapper'> cannot handle expressions of type <class 'loopy.symbolic.Reduction'>
```