### PR TITLE
Implements `lp.rename_inames`

### DIFF
--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -71,7 +71,7 @@ from loopy.version import VERSION, MOST_RECENT_LANGUAGE_VERSION
 from loopy.transform.iname import (
         set_loop_priority, prioritize_loops, untag_inames,
         split_iname, chunk_iname, join_inames, tag_inames, duplicate_inames,
-        rename_iname, remove_unused_inames,
+        rename_iname, rename_inames, remove_unused_inames,
         split_reduction_inward, split_reduction_outward,
         affine_map_inames, find_unused_axis_tag,
         make_reduction_inames_unique,
@@ -198,7 +198,7 @@ __all__ = [
         "set_loop_priority", "prioritize_loops", "untag_inames",
         "split_iname", "chunk_iname", "join_inames", "tag_inames",
         "duplicate_inames",
-        "rename_iname", "remove_unused_inames",
+        "rename_iname", "rename_inames", "remove_unused_inames",
         "split_reduction_inward", "split_reduction_outward",
         "affine_map_inames", "find_unused_axis_tag",
         "make_reduction_inames_unique",

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1324,6 +1324,20 @@ def test_precompute_does_not_lead_to_dep_cycle(ctx_factory):
     lp.auto_test_vs_ref(knl, ctx, ref_knl)
 
 
+def test_rename_inames(ctx_factory):
+    ctx = ctx_factory()
+
+    knl = lp.make_kernel(
+        "{[i1, i2]: 0<=i1, i2<10}",
+        """
+        y1[i1] = 2
+        y2[i2] = 3
+        """)
+    ref_knl = knl
+    knl = lp.rename_inames(knl, ["i1", "i2"], "ifused")
+    lp.auto_test_vs_ref(knl, ctx, ref_knl)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Q. Why not use `rename_iname` repeatedly?
A. That would lead to multiple traversals of the IR and hence would bump up the operation complexity of certain transformations like [Loop Fusion](https://github.com/inducer/loopy/pull/493).