### PR TITLE
Assignment.sub_array_ref_inames: avoid expression traversals

### DIFF
--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -992,6 +992,11 @@ class Assignment(MultiAssignmentBase):
     def assignees(self):
         return (self.assignee,)
 
+    @memoize_method
+    def sub_array_ref_inames(self):
+        assert super().sub_array_ref_inames() == frozenset()
+        return frozenset()
+
     # }}}
 
 


### PR DESCRIPTION
Should help avoid some expression traversals `if not __debug__`.