### PR TITLE
lp.rename_iname: support renaming reduction iname.

### DIFF
--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -935,7 +935,8 @@ def duplicate_inames(kernel, inames, within, new_inames=None, suffix=None,
             within=within)
 
     def _does_access_old_inames(kernel, insn, *args):
-        return bool(frozenset(inames) & insn.dependency_names())
+        return bool(frozenset(inames) & (insn.dependency_names()
+                                         | insn.reduction_inames()))
 
     kernel = rule_mapping_context.finish_kernel(
             indup.map_kernel(kernel, within=_does_access_old_inames,

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1324,6 +1324,19 @@ def test_precompute_does_not_lead_to_dep_cycle(ctx_factory):
     lp.auto_test_vs_ref(knl, ctx, ref_knl)
 
 
+def test_rename_inames_redn():
+    t_unit = lp.make_kernel(
+        "{[i, j0, j1]: 0<=i, j0, j1<10}",
+        """
+        y0[i] = sum(j0, sum([j1], 2*A[i, j0, j1]))
+        """)
+
+    t_unit = lp.rename_iname(t_unit, "j1", "ifused")
+
+    assert "j1" not in t_unit.default_entrypoint.all_inames()
+    assert "ifused" in t_unit.default_entrypoint.all_inames()
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
- Attached regression fails on `main`.

Q. Aren't reduction inames included in an instruction's dependencies?
A. Apparently not, see `DependencyMapper.map_reduction`: https://github.com/inducer/loopy/blob/125bc1f24818c9c038ccfb64aaf71e3c4908f322/loopy/symbolic.py#L406-L408