### PR TITLE
Drop uses of islpy.SuppressedWarnings (deprecated, now a no-op)

### DIFF
--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -349,8 +349,7 @@ def is_nonnegative(expr, over_set):
     space = over_set.get_space()
     from loopy.symbolic import aff_from_expr
     try:
-        with isl.SuppressedWarnings(space.get_ctx()):
-            aff = aff_from_expr(space, -expr-1)
+        aff = aff_from_expr(space, -expr-1)
     except Exception:
         return None
     expr_neg_set = isl.BasicSet.universe(space).add_constraint(

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -818,8 +818,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
         If *axis* is None, find a suitable axis automatically.
         """
         try:
-            with isl.SuppressedWarnings(kernel.isl_context):
-                desired_length = kernel.get_constant_iname_length(iname)
+            desired_length = kernel.get_constant_iname_length(iname)
         except isl.Error:
             # Likely unbounded, automatic assignment is not
             # going to happen for this iname.
@@ -947,8 +946,7 @@ def assign_automatic_axes(kernel, callables_table, axis=0, local_size=None):
 
             def get_iname_length(iname):
                 try:
-                    with isl.SuppressedWarnings(kernel.isl_context):
-                        return kernel.get_constant_iname_length(iname)
+                    return kernel.get_constant_iname_length(iname)
                 except isl.Error:
                     return -1
             # assign longest auto axis inames first

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -1875,23 +1875,23 @@ def with_aff_conversion_guard(f, space, expr, *args):
     from loopy.diagnostic import ExpressionNotAffineError
 
     err = None
-    with isl.SuppressedWarnings(space.get_ctx()):
-        try:
-            return f(space, expr, *args)
-        except TypeError as e:
-            err = e
-        except isl.Error as e:
-            err = e
-        except UnknownVariableError as e:
-            err = e
-        except ExpressionNotAffineError as e:
-            err = e
 
-        assert err is not None
-        from loopy.diagnostic import ExpressionToAffineConversionError
-        raise ExpressionToAffineConversionError(
-                "could not convert expression '%s' to affine representation: "
-                "%s: %s" % (expr, type(err).__name__, str(err)))
+    try:
+        return f(space, expr, *args)
+    except TypeError as e:
+        err = e
+    except isl.Error as e:
+        err = e
+    except UnknownVariableError as e:
+        err = e
+    except ExpressionNotAffineError as e:
+        err = e
+
+    assert err is not None
+    from loopy.diagnostic import ExpressionToAffineConversionError
+    raise ExpressionToAffineConversionError(
+            "could not convert expression '%s' to affine representation: "
+            "%s: %s" % (expr, type(err).__name__, str(err)))
 
 
 def guarded_aff_from_expr(space, expr, vars_to_zero=None):

--- a/loopy/transform/realize_reduction.py
+++ b/loopy/transform/realize_reduction.py
@@ -469,10 +469,9 @@ def _try_infer_scan_and_sweep_bounds(kernel, scan_iname, sweep_iname, within_ina
             within_inames | kernel.non_iname_variable_names(), (isl.dim_type.param,))
 
     try:
-        with isl.SuppressedWarnings(domain.get_ctx()):
-            sweep_lower_bound = domain.dim_min(sweep_idx)
-            sweep_upper_bound = domain.dim_max(sweep_idx)
-            scan_lower_bound = domain.dim_min(scan_idx)
+        sweep_lower_bound = domain.dim_min(sweep_idx)
+        sweep_upper_bound = domain.dim_max(sweep_idx)
+        scan_lower_bound = domain.dim_min(scan_idx)
     except isl.Error as e:
         raise ValueError("isl error: %s" % e)
 
@@ -499,11 +498,10 @@ def _try_infer_scan_stride(kernel, scan_iname, sweep_iname, sweep_lower_bound):
     # Should be equal to k * sweep_iname, where k is the stride.
 
     try:
-        with isl.SuppressedWarnings(domain_with_sweep_param.get_ctx()):
-            scan_iname_range = (
-                    domain_with_sweep_param.dim_max(scan_iname_idx)
-                    - domain_with_sweep_param.dim_min(scan_iname_idx)
-                    ).gist(domain_with_sweep_param.params())
+        scan_iname_range = (
+                domain_with_sweep_param.dim_max(scan_iname_idx)
+                - domain_with_sweep_param.dim_min(scan_iname_idx)
+                ).gist(domain_with_sweep_param.params())
     except isl.Error as e:
         raise ValueError("isl error: '%s'" % e)
 


### PR DESCRIPTION
As of islpy 2022.1 / https://github.com/inducer/islpy/pull/85, islpy packages its error messages into the exception like a normal library, rather than spewing them onto stderr. That makes uses of `isl.SuppressedWarnings` moot (which is also now deprecated).