### PR TITLE
[assignment_to_subst] rename subst arguments

### DIFF
--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1515,7 +1515,7 @@ def test_finite_difference_expr_subst(ctx_factory):
             gpu_knl, "f_subst", "inew_inner", fetch_bounding_box=True,
             default_tag="l.auto")
 
-    precomp_knl = lp.tag_inames(precomp_knl, {"j_outer": "unr"})
+    precomp_knl = lp.tag_inames(precomp_knl, {"j_0_outer": "unr"})
     precomp_knl = lp.set_options(precomp_knl, return_dict=True)
     evt, _ = precomp_knl(queue, u=u, h=h)
 


### PR DESCRIPTION
This avoids confusion with the names already present in the kernel.
On main:
```python
t_unit = lp.make_kernel(
    "{[i]: 0<=i<10}",
    """
    <> tmp[i] = 2*i
    out[i] = 2*tmp[i]
    """)
t_unit = lp.assignment_to_subst(t_unit, "tmp")
```
would yield:
```
---------------------------------------
DOMAINS:
{ [i] : 0 <= i <= 9 }
---------------------------------------
INAME TAGS:
i: None
---------------------------------------
SUBSTITUTION RULES:
tmp_subst(i) := 2*i
---------------------------------------
INSTRUCTIONS:
for i
  out[i] = 2*tmp_subst(i)  {id=insn_0}
end i
---------------------------------------
```

Notice how the substitution argument is 'i' and the kernel contains 'i'
as a domain dim.