### PR TITLE
PyOpenCL invoker: tolerate zero-size temporaries

### DIFF
--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -676,8 +676,10 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
                     Line(),
                     ] + ([
                         For("_tv", "_global_temporaries",
-                            # free global temporaries
-                            S("_tv.release()"))
+                            # Free global temporaries.
+                            # Zero-size temporaries allocate as None, tolerate that.
+                            # https://documen.tician.de/pyopencl/tools.html#pyopencl.tools.ImmediateAllocator
+                            S("if _tv is not None: _tv.release()"))
                         ] if self._get_global_temporaries(codegen_state) else []
                     ) + [
                     Line(),


### PR DESCRIPTION
This came up in putting together https://github.com/inducer/meshmode/pull/312.