### PR TITLE
Pass address corresponding to `base_storage` only once to the device kernel

### DIFF
--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -105,7 +105,7 @@ class ImplementedDataInfo(ImmutableRecord):
     .. attribute:: is_written
     """
 
-    def __init__(self, target, name, dtype, arg_class,
+    def __init__(self, name, dtype, arg_class,
             base_name=None,
             shape=None, strides=None,
             unvec_shape=None, unvec_strides=None,
@@ -512,7 +512,6 @@ def generate_code_for_a_single_kernel(kernel, callables_table, target,
 
         elif isinstance(arg, ValueArg):
             implemented_data_info.append(ImplementedDataInfo(
-                target=target,
                 name=arg.name,
                 dtype=arg.dtype,
                 arg_class=ValueArg,

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -55,7 +55,6 @@ def synthesize_idis_for_extra_args(kernel, schedule_index):
     for iname in sched_item.extra_inames:
         idis.append(
             ImplementedDataInfo(
-                target=kernel.target,
                 name=iname,
                 dtype=kernel.index_dtype,
                 arg_class=InameArg,

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -1126,7 +1126,6 @@ class ArrayBase(ImmutableRecord, Taggable):
 
                     stride_args.append(
                             ImplementedDataInfo(
-                                target=target,
                                 name=stride_name,
                                 dtype=index_dtype,
                                 arg_class=ValueArg,
@@ -1135,7 +1134,6 @@ class ArrayBase(ImmutableRecord, Taggable):
                                 is_written=False))
 
                 yield ImplementedDataInfo(
-                            target=target,
                             name=full_name,
                             base_name=self.name,
 
@@ -1154,7 +1152,6 @@ class ArrayBase(ImmutableRecord, Taggable):
                 if self.offset is lp.auto:
                     offset_name = full_name+"_offset"
                     yield ImplementedDataInfo(
-                                target=target,
                                 name=offset_name,
                                 dtype=index_dtype,
                                 arg_class=ValueArg,

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -677,8 +677,12 @@ class TemporaryVariable(ArrayBase):
 
     def get_arg_decl(self, ast_builder, name_suffix, shape, dtype, is_written):
         if self.address_space == AddressSpace.GLOBAL:
-            return ast_builder.get_array_arg_decl(self.name + name_suffix,
-                    AddressSpace.GLOBAL, shape, dtype, is_written)
+            if self.base_storage:
+                return ast_builder.get_array_arg_decl(self.base_storage,
+                        AddressSpace.GLOBAL, shape, dtype, is_written)
+            else:
+                return ast_builder.get_array_arg_decl(self.name + name_suffix,
+                        AddressSpace.GLOBAL, shape, dtype, is_written)
         else:
             raise LoopyError("unexpected request for argument declaration of "
                     "non-global temporary")

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -703,6 +703,9 @@ class OpenCLCASTBuilder(CFamilyASTBuilder):
             return CLLocal(decl)
         elif scope == AddressSpace.PRIVATE:
             return decl
+        elif scope == AddressSpace.GLOBAL:
+            from cgen.opencl import CLGlobal
+            return CLGlobal(decl)
         else:
             raise ValueError("unexpected temporary variable scope: %s"
                     % scope)


### PR DESCRIPTION
For the kernel:

```python

t_unit = lp.make_kernel(
    "{[i]: 0<=i<20000}",
    """
    <>tmp1[i] = 2 * i
    <>tmp2[i] = 3 * i
    out[i] = tmp1[i] + tmp2[i]
    """,
    seq_dependencies=True,
    lang_version=(2018, 2))

knl = t_unit.default_entrypoint
tmp1_tv = knl.temporary_variables["tmp1"]
tmp2_tv = knl.temporary_variables["tmp2"]


new_tvs = {"tmp1": tmp1_tv.copy(base_storage="base",
                                offset=0,
                                storage_shape=(40_000,),
                                address_space=lp.AddressSpace.GLOBAL,
                                ),
           "tmp2": tmp2_tv.copy(base_storage="base",
                                offset=20_000,
                                storage_shape=(40_000,),
                                address_space=lp.AddressSpace.GLOBAL,
                                )
           }

knl = knl.copy(temporary_variables=new_tvs)
```

the following CL kernel is generated:
```c
__kernel void __attribute__ ((reqd_work_group_size(1, 1, 1))) loopy_kernel(__global int *__restrict__ out, __global int *__restrict__ base)        
{                                                                                                                                                  
  __global int *const __restrict__ tmp1 = (__global int *const __restrict__ ) (base + 0);                                                          
  __global int *const __restrict__ tmp2 = (__global int *const __restrict__ ) (base + 0);                                                          
                                                                                                                                                   
  for (int i = 0; i <= 19999; ++i)                                                                                                                 
  {                                                                                                                                                
    tmp1[i] = 2 * i;                                                                                                                               
    tmp2[20000 + i] = 3 * i;                                                                                                                       
    out[i] = tmp1[i] + tmp2[20000 + i];                                                                                                            
  }
}
```

Notice how we only pass a single argument for `tmp1` and `tmp2`. This doesn't happen on `main`.

---

Draft because:
- [x] Cleanup
- [x] Needs tests