### PR TITLE
remove float128 reference

### DIFF
--- a/loopy/target/c/codegen/expression.py
+++ b/loopy/target/c/codegen/expression.py
@@ -578,8 +578,7 @@ class ExpressionToCExpressionMapper(IdentityMapper):
         else:
             if isinstance(expr.data_type(float("nan")), np.float32):
                 return p.Variable("NAN")
-            elif isinstance(expr.data_type(float("nan")), (np.float64,
-                                                              np.float128)):
+            elif isinstance(expr.data_type(float("nan")), np.floating):
                 registry = self.codegen_state.ast_builder.target.get_dtype_registry()
                 lpy_type = NumpyType(np.dtype(expr.data_type))
                 cast = var("(%s)" % registry.dtype_to_ctype(lpy_type))


### PR DESCRIPTION
Not all architectures have `np.float128` (e.g., Mac M1)

See e.g. https://github.com/mpi4jax/mpi4jax/issues/112