### PR TITLE
Argument passing/return: consider `is_{input,output}`

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -112,9 +112,9 @@ always see loopy's view of a kernel by printing it.
     KERNEL: loopy_kernel
     ---------------------------------------------------------------------------
     ARGUMENTS:
-    a: type: <auto/runtime>, shape: (n), dim_tags: (N0:stride:1) aspace: global
+    a: type: <auto/runtime>, shape: (n), dim_tags: (N0:stride:1) in aspace: global
     n: ValueArg, type: <auto/runtime>
-    out: type: <auto/runtime>, shape: (n), dim_tags: (N0:stride:1) aspace: global
+    out: type: <auto/runtime>, shape: (n), dim_tags: (N0:stride:1) out aspace: global
     ---------------------------------------------------------------------------
     DOMAINS:
     [n] -> { [i] : 0 <= i < n }

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -375,10 +375,18 @@ class ArrayArg(ArrayBase, KernelArgument):
 
         aspace_str = AddressSpace.stringify(self.address_space)
 
+        assert self.is_input or self.is_output
+
+        inout = []
+        if self.is_input:
+            inout.append("in")
+        if self.is_output:
+            inout.append("out")
+
         return (
                 self.stringify(include_typename=include_typename)
-                +
-                " aspace: %s" % aspace_str)
+                + " " + "/".join(inout)
+                + " aspace: %s" % aspace_str)
 
     def update_persistent_hash(self, key_hash, key_builder):
         """Custom hash computation function for use with

--- a/loopy/target/execution.py
+++ b/loopy/target/execution.py
@@ -414,7 +414,7 @@ class ExecutionWrapperGeneratorBase(ABC):
             if not options.no_numpy:
                 self.handle_non_numpy_arg(gen, arg)
 
-            if not options.skip_arg_checks and not is_written:
+            if not options.skip_arg_checks and kernel_arg.is_input:
                 gen("if %s is None:" % arg.name)
                 with Indentation(gen):
                     gen("raise RuntimeError(\"input argument '%s' must "
@@ -441,7 +441,8 @@ class ExecutionWrapperGeneratorBase(ABC):
 
             # {{{ allocate written arrays, if needed
 
-            if is_written and arg.arg_class in [lp.ArrayArg, lp.ConstantArg] \
+            if kernel_arg.is_output \
+                    and arg.arg_class in [lp.ArrayArg, lp.ConstantArg] \
                     and arg.shape is not None \
                     and all(si is not None for si in arg.shape):
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -708,6 +708,20 @@ def test_zero_size_temporaries(ctx_factory):
     assert out.shape == (0,)
 
 
+def test_empty_array_output(ctx_factory):
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    knl = lp.make_kernel(
+        "{[i]: i > 0 and i < 0}",
+        [],
+        [lp.GlobalArg("a", shape=(0,), dtype=np.float32,
+            is_output=True, is_input=False)])
+
+    _evt, (out, ) = knl(cq)
+    assert out.shape == (0,)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
@majosm's multi-volume work in mirgecom brought empty arrays into pytato DAGs, which, after https://github.com/inducer/pytato/pull/320, exposed an issue in Loopy's argument handling. It ignored the provided `is_{input, output}` flags (in favor of "whether it's written") when determining when an array is required as input or returned. This logic, of course, falls apart if the array is never written because it's empty.

Best read commit-by-commit. The included regression test fails on 696c6a98e742275de7f9d67769a4011e6e2ba5c0.