### PR TITLE
Set TypeReader.symbols_with_unknown_types at init

### DIFF
--- a/loopy/type_inference.py
+++ b/loopy/type_inference.py
@@ -613,6 +613,7 @@ class TypeReader(TypeInferenceMapper):
         self.kernel = kernel
         self.callables = callables
         self.new_assignments = new_assignments
+        self.symbols_with_unknown_types = set()
         CombineMapper.__init__(self)
 
     # {{{ disabled interface


### PR DESCRIPTION
This is a blind fix (for the superficial issue, but might be symptomatic of some other problem) for, e.g., the following kernel:

```python
import loopy as lp

knl = lp.make_kernel(
    "{[i, j, k]: 0 <= i, j, k < n }",
    """
    z = simul_reduce(sum, [i, j, k], i + j + k)
    z2 = simul_reduce(sum, [i, j, k], i * j * k)
    """,
    lang_version=(2018, 2)
)

knl = lp.split_reduction_inward(knl, "k")
from loopy.transform.data import reduction_arg_to_subst_rule
knl = reduction_arg_to_subst_rule(knl, ["i", "j"])
knl = lp.realize_reduction(knl)
```

which throws `AttributeError: 'TypeReader' object has no attribute 'symbols_with_unknown_types'` from [this line](https://github.com/inducer/loopy/blob/main/loopy/type_inference.py#L226=). `TypeReader` is simply missing a `symbols_with_unknown_types` attribute that its base class has (as well as other attributes `TypeInferenceReader` sets at `__init__`, incidentally). (The example is a minimal one derived roughly from [`test_global_parallel_reduction`](https://github.com/inducer/loopy/blob/main/test/test_reduction.py#L214=), for context. The resulting kernel looks fine after this fix.)