### PR TITLE
Revert "Avoid failing firedrake gtmg tests"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,7 @@ jobs:
                 # patch so exception messages get shown
                 curl -L https://gist.githubusercontent.com/inducer/17d7134ace215f0df1f3627eac4195c7/raw/63edfaf2ec8bf06987896569a4f24264df490e9e/firedrake-debug-patch.diff | patch -p1
 
-                # 'not gtmg' because of https://github.com/firedrakeproject/firedrake/issues/2514
-                pytest --tb=native -rsxw --durations=10 -m 'not parallel' -k 'not gtmg' tests/multigrid/
+                pytest --tb=native -rsxw --durations=10 -m 'not parallel' tests/multigrid/
 
         -   name: "Prepare for tmate"
             run: |


### PR DESCRIPTION
Reverts inducer/loopy#655

Fix has landed in Firedrake.