### PR TITLE
Fix zero length sep arrays handling

### DIFF
--- a/loopy/preprocess.py
+++ b/loopy/preprocess.py
@@ -179,7 +179,7 @@ def make_arrays_for_sep_arrays(kernel: LoopKernel) -> LoopKernel:
 
         new_args.append(arg.copy(_separation_info=sep_info))
 
-        for san in sorted(sep_info.subarray_names.values()):
+        for _ind, san in sorted(sep_info.subarray_names.items()):
             new_args.append(
                     arg.copy(
                         name=san,

--- a/loopy/target/pyopencl_execution.py
+++ b/loopy/target/pyopencl_execution.py
@@ -242,8 +242,14 @@ class PyOpenCLExecutionWrapperGenerator(ExecutionWrapperGeneratorBase):
                         for arg_name in kai.passed_arg_names
                         if kernel.arg_dict[arg_name].is_output))
         else:
-            out_names = [arg_name for arg_name in kai.passed_arg_names
-                    if kernel.arg_dict[arg_name].is_output]
+            passed_arg_names_set = frozenset(kai.passed_arg_names)
+            out_names = [
+                    # Must ensure that these occur in the same order as in
+                    # kernel.args.
+                    arg.name
+                    for arg in kernel.args
+                    if arg.name in passed_arg_names_set
+                    if arg.is_output]
             if out_names:
                 gen("return _lpy_evt, (%s,)"
                         % ", ".join(out_names))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 git+https://github.com/inducer/genpy.git#egg=genpy
 git+https://github.com/inducer/codepy.git#egg=codepy
 
-git+https://github.com/inducer/f2py#egg=f2py
+fparser
 
 # Optional, needed for using the C preprocessor on Fortran
 ply>=3.6


### PR DESCRIPTION
Manage to track down the failure in inducer/pytential#167 to the way loopy handles zero length arrays with the `sep` tag (not super sure that's related?).

This contains a MWE, but I haven't had the time to get a fix. Any suggestions where to start looking?