### PR TITLE
CudaTarget: no address space qualifier for arguments

### DIFF
--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -434,8 +434,7 @@ class CUDACASTBuilder(CFamilyASTBuilder):
             self, arg: ArrayArg, is_written: bool) -> Declarator:
         from cgen.cuda import CudaRestrictPointer
         arg_decl = CudaRestrictPointer(
-                self.wrap_decl_for_address_space(
-                    self.get_array_base_declarator(arg), arg.address_space))
+                    self.get_array_base_declarator(arg))
 
         if not is_written:
             arg_decl = Const(arg_decl)

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -1841,7 +1841,7 @@ def test_header_extract():
     cuknl = knl.copy(target=lp.CudaTarget())
     assert str(lp.generate_header(cuknl)[0]) == (
             'extern "C" __global__ void __launch_bounds__(1) '
-            "loopy_kernel(__global__ float *__restrict__ T);")
+            "loopy_kernel(float *__restrict__ T);")
 
     #test OpenCL
     oclknl = knl.copy(target=lp.PyOpenCLTarget())


### PR DESCRIPTION
Address space qualifiers are ignored, so better to not generate them.

```c
(feinsum_env) kgk2@bock:~/temp$ cat ok.cu 
#define bIdx(N) ((int) blockIdx.N)
#define tIdx(N) ((int) threadIdx.N)

extern "C" __global__ void __launch_bounds__(1) foo(int const N, __global__ double *__restrict__ a)
{
  a[bIdx(x)] = bIdx(x);
}
(feinsum_env) kgk2@bock:~/temp$ nvcc -c ok.cu 
ok.cu:4:1: warning: ‘global’ attribute directive ignored [-Wattributes]
    4 | extern "C" __global__ void __launch_bounds__(1) foo(int const N, __global__ double *__restrict__ a)
      | ^

```

@thilinarmtb also pointed kernels with the address space qualifiers raise compilation error with `nvrtc`.