### PR TITLE
Use a `WeakKeyDictionary` for `program_executor_cache` to avoid keeping CL contexts alive

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -1365,6 +1365,10 @@ class CASTBuilder(CFamilyASTBuilder):
 
 # {{{ executable c target
 
+class _CExecutorCacheKey:
+    pass
+
+
 class ExecutableCTarget(CTarget):
     """
     An executable CFamilyTarget that uses (by default) JIT compilation of C-code
@@ -1377,7 +1381,10 @@ class ExecutableCTarget(CTarget):
     def get_kernel_executor_cache_key(self, *args, **kwargs):
         # This is for things like the context in OpenCL. There is no such
         # thing that CPU JIT is specific to.
-        return None
+
+        # We can't use None here, because this will be a key in a WeakKeyDict,
+        # and None isn't allowed in that setting.
+        return _CExecutorCacheKey
 
     def get_kernel_executor(self, t_unit, *args, **kwargs):
         from loopy.target.c.c_execution import CKernelExecutor

--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -204,7 +204,10 @@ class TranslationUnit(ImmutableRecord):
                 func_id_to_in_knl_callable_mappers=(
                     func_id_to_in_knl_callable_mappers))
 
-        self._program_executor_cache = {}
+        from weakref import WeakKeyDictionary
+        # Since PyOpenCL uses CL contexts as keys, this avoids artificially
+        # keeping contexts alive.
+        self._program_executor_cache = WeakKeyDictionary()
         self._hash_value = None
 
     hash_fields = (


### PR DESCRIPTION
Without this, things like the schedule cache will indirectly hold (strong) references to CL contexts, programs and kernels, which means that those will have a hard time getting cleaned up.