### PR TITLE
Fix TranslationUnit._hash_value disappearing during pickling

### DIFF
--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -373,14 +373,14 @@ class TranslationUnit(ImmutableRecord):
         self._program_executor_cache = {}
 
     def __hash__(self):
-        if self._hash_value is not None:
-            return self._hash_value
+        # NOTE: _hash_value may vanish during pickling
+        if getattr(self, "_hash_value", None) is None:
+            from loopy.tools import LoopyKeyBuilder
+            from pytools.persistent_dict import new_hash
+            key_hash = new_hash()
+            self.update_persistent_hash(key_hash, LoopyKeyBuilder())
+            self._hash_value = hash(key_hash.digest())
 
-        from loopy.tools import LoopyKeyBuilder
-        from pytools.persistent_dict import new_hash
-        key_hash = new_hash()
-        self.update_persistent_hash(key_hash, LoopyKeyBuilder())
-        self._hash_value = hash(key_hash.digest())
         return self._hash_value
 
 # }}}

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3350,6 +3350,19 @@ def test_different_index_dtypes():
         lp.generate_code_v2(knl)
 
 
+def test_translation_unit_pickle():
+    tunit = lp.make_kernel(
+        "{[i]: 0<=i<16}",
+        """
+        y[i] = i
+        """)
+    assert isinstance(hash(tunit), int)
+
+    from pickle import dumps, loads
+    tunit = loads(dumps(tunit))
+    assert isinstance(hash(tunit), int)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Matches the handling in the base class `ImmutableRecord` at
https://github.com/inducer/pytools/blob/7f5e62f34661a8ef40a0b73e0e7f55b54dbdf95e/pytools/__init__.py#L489-L496