### PR TITLE
PyOpenCLTarget: do not use the same executor cache key for different entrypoints

### DIFF
--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -478,7 +478,9 @@ class PyOpenCLTarget(OpenCLTarget):
     # }}}
 
     def get_kernel_executor_cache_key(self, queue, **kwargs):
-        return queue.context
+        import weakref
+        # Use weakref for CL context to avoid keeping context artifically alive
+        return (weakref.ref(queue.context), kwargs["entrypoint"])
 
     def preprocess_translation_unit_for_passed_args(self, t_unit, epoint,
                                                    passed_args_dict):

--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -204,10 +204,7 @@ class TranslationUnit(ImmutableRecord):
                 func_id_to_in_knl_callable_mappers=(
                     func_id_to_in_knl_callable_mappers))
 
-        from weakref import WeakKeyDictionary
-        # Since PyOpenCL uses CL contexts as keys, this avoids artificially
-        # keeping contexts alive.
-        self._program_executor_cache = WeakKeyDictionary()
+        self._program_executor_cache = {}
         self._hash_value = None
 
     hash_fields = (


### PR DESCRIPTION
/cc @matthiasdiener 