### PR TITLE
Adress code review comments on branch fix_648

### DIFF
--- a/loopy/target/__init__.py
+++ b/loopy/target/__init__.py
@@ -161,10 +161,14 @@ class TargetBase():
         raise NotImplementedError()
 
     @abc.abstractproperty
-    def is_executable(self) -> bool:
-        """
-        Returns *True* only if the target allows executing loopy
-        translation units through :attr:`loopy.TranslationUnit.__call__`.
+    def single_subkernel_is_entrypoint(self) -> bool:
+        r"""
+        Returns *True* if *self* does NOT support generating code for
+        linearized kernels with more than one
+        :class:`~loopy.schedule.CallKernel`\ s. This guarantees the
+        :class:`~loopy.schedule.CallKernel` for which we generate code is the
+        entrypoint kernel. This also allows the target to skip the invoker
+        level code.
         """
 
 

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -256,7 +256,7 @@ class CudaTarget(CFamilyTarget):
     # }}}
 
     @property
-    def is_executable(self) -> bool:
+    def single_subkernel_is_entrypoint(self) -> bool:
         return False
 
 # }}}

--- a/loopy/target/ispc.py
+++ b/loopy/target/ispc.py
@@ -199,8 +199,8 @@ class ISPCTarget(CFamilyTarget):
     # }}}
 
     @property
-    def is_executable(self) -> bool:
-        return False
+    def single_subkernel_is_entrypoint(self) -> bool:
+        return True
 
 
 class ISPCASTBuilder(CFamilyASTBuilder):
@@ -226,9 +226,9 @@ class ISPCASTBuilder(CFamilyASTBuilder):
             # subkernel launches occur only as part of entrypoint kernels for now
             from loopy.schedule.tools import get_subkernel_arg_info
             skai = get_subkernel_arg_info(codegen_state.kernel, subkernel_name)
-            passed_names = (skai.passed_names
-                            if self.target.is_executable
-                            else [arg.name for arg in kernel.args])
+            passed_names = ([arg.name for arg in kernel.args]
+                            if self.target.single_subkernel_is_entrypoint
+                            else skai.passed_names)
             written_names = skai.written_names
         else:
             passed_names = [arg.name for arg in kernel.args]
@@ -269,7 +269,8 @@ class ISPCASTBuilder(CFamilyASTBuilder):
                         "assert(programCount == (%s))"
                         % ecm(lsize[0], PREC_NONE)))
 
-        if codegen_state.is_entrypoint and self.target.is_executable:
+        if (codegen_state.is_entrypoint and
+                self.target.single_subkernel_is_entrypoint):
             # subkernel launches occur only as part of entrypoint kernels for now
             from loopy.schedule.tools import get_subkernel_arg_info
             skai = get_subkernel_arg_info(codegen_state.kernel, subkernel_name)

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -599,7 +599,7 @@ class OpenCLTarget(CFamilyTarget):
         return NumpyType(vec.types[base.numpy_dtype, count])
 
     @property
-    def is_executable(self) -> bool:
+    def single_subkernel_is_entrypoint(self) -> bool:
         return False
 
 # }}}

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -552,8 +552,8 @@ class PyOpenCLTarget(OpenCLTarget):
         return self
 
     @property
-    def is_executable(self) -> bool:
-        return True
+    def single_subkernel_is_entrypoint(self) -> bool:
+        return False
 
 # }}}
 


### PR DESCRIPTION
Change naming of `is_executable` on Target class to `single_subkernel_is_entrypoint,` add docs and error when there is more than one subkernel.