### PR TITLE
`memoize_on_disk`: segregate caches by wrapped function 

### DIFF
--- a/loopy/tools.py
+++ b/loopy/tools.py
@@ -914,7 +914,8 @@ def memoize_on_disk(func, key_builder_t=LoopyKeyBuilder):
             else:
                 return arg
 
-        cache_key = (tuple(_get_persistent_hashable_arg(arg)
+        cache_key = (func.__qualname__, func.__name__,
+                     tuple(_get_persistent_hashable_arg(arg)
                            for arg in args),
                      {kw: _get_persistent_hashable_arg(arg)
                       for kw, arg in kwargs.items()})

--- a/loopy/tools.py
+++ b/loopy/tools.py
@@ -893,6 +893,13 @@ def memoize_on_disk(func, key_builder_t=LoopyKeyBuilder):
     from loopy.kernel import LoopKernel
     import pymbolic.primitives as prim
 
+    transform_cache = WriteOncePersistentDict(
+        ("loopy-memoize-cache-"
+            f"{func.__name__}-"
+            f"{key_builder_t.__qualname__}.{key_builder_t.__name__}"
+            f"-v0-{DATA_MODEL_VERSION}"),
+        key_builder=key_builder_t())
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         from loopy import CACHING_ENABLED
@@ -900,12 +907,6 @@ def memoize_on_disk(func, key_builder_t=LoopyKeyBuilder):
         if (not CACHING_ENABLED
                 or kwargs.pop("_no_memoize_on_disk", False)):
             return func(*args, **kwargs)
-
-        transform_cache = WriteOncePersistentDict(
-            ("loopy-memoize-cache-"
-             f"{key_builder_t.__qualname__}-{key_builder_t.__name__}"
-             f"-v0-{DATA_MODEL_VERSION}"),
-            key_builder=key_builder_t())
 
         def _get_persistent_hashable_arg(arg):
             if isinstance(arg, prim.Expression):


### PR DESCRIPTION
Note that this adds the (unqualified) function name to the name of the cache *and* the function itself to the cache key.