### PR TITLE
[lp.remove_unused_inames] Sort the inames before removing them

### DIFF
--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1141,7 +1141,7 @@ def remove_unused_inames(kernel, inames=None):
     # {{{ remove them
 
     domains = kernel.domains
-    for iname in unused_inames:
+    for iname in sorted(unused_inames):
         new_domains = []
 
         for dom in domains:


### PR DESCRIPTION
Picking a deterministic order in which the inames are removed is
*necessary* to ensure that the left over domain is the same across
interpreter runs