### PR TITLE
Extend nonnegative check to products as well

### DIFF
--- a/loopy/isl_helpers.py
+++ b/loopy/isl_helpers.py
@@ -346,8 +346,14 @@ def duplicate_axes(isl_obj, duplicate_inames, new_inames):
 
 
 def is_nonnegative(expr, over_set):
-    space = over_set.get_space()
     from loopy.symbolic import aff_from_expr
+    from pymbolic.primitives import Product
+
+    if isinstance(expr, Product) and all(
+            is_nonnegative(child, over_set) for child in expr.children):
+        return True
+
+    space = over_set.get_space()
     try:
         aff = aff_from_expr(space, -expr-1)
     except Exception:

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -486,7 +486,7 @@ def test_integer_associativity():
     print(lp.generate_code_v2(knl).device_code())
     assert (
             "u[ncomp * indices[i % elemsize + elemsize "
-            "* loopy_floor_div_int32(i, ncomp * elemsize)] "
+            "* (i / (ncomp * elemsize))] "
             "+ loopy_mod_pos_b_int32(i / elemsize, ncomp)]"
             in lp.generate_code_v2(knl).device_code())
 

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -491,6 +491,18 @@ def test_integer_associativity():
             in lp.generate_code_v2(knl).device_code())
 
 
+def test_floor_div():
+    knl = lp.make_kernel(
+        "{ [i]: 0<=i<10 }",
+        "out[i] = (i-1)*(i-2)//2")
+    assert "loopy_floor_div" in lp.generate_code_v2(knl).device_code()
+
+    knl = lp.make_kernel(
+        "{ [i]: 0<=i<10 }",
+        "out[i] = (i*(i+1))//2")
+    assert "loopy_floor_div" not in lp.generate_code_v2(knl).device_code()
+
+
 def test_divide_precedence(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)


### PR DESCRIPTION
This is needed in order to not generate complicated code for values like `(i*(i+1))//2`.