### PR TITLE
Do not emit temporary decls for temporaries not used in a subkernel 

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -899,14 +899,12 @@ class CFamilyASTBuilder(ASTBuilderBase[Generable]):
 
         ecm = self.get_expression_to_code_mapper(codegen_state)
 
-        for tv in sorted(
-                kernel.temporary_variables.values(),
-                key=lambda key_tv: key_tv.name):
+        for tv_name in sorted(sub_knl_temps):
+            tv = kernel.temporary_variables[tv_name]
             if not tv.base_storage:
                 # global temp vars are mapped to arguments or global
                 # declarations, no need to declare locally.
-                if tv.address_space != AddressSpace.GLOBAL and (
-                        tv.name in sub_knl_temps):
+                if tv.address_space != AddressSpace.GLOBAL:
                     decl = self.get_temporary_var_declarator(codegen_state, tv)
 
                     if tv.initializer is not None:

--- a/loopy/transform/data.py
+++ b/loopy/transform/data.py
@@ -1025,7 +1025,7 @@ def allocate_temporaries_for_base_storage(kernel: LoopKernel,
             assert isinstance(tv.dtype, LoopyType)
 
             if tv.address_space is auto:
-                raise LoopyError("Ahen allocating base storage for temporary "
+                raise LoopyError("When allocating base storage for temporary "
                         f"'{tv.name}', the address space of the temporary "
                         "was not yet determined (set to 'auto').")
 
@@ -1084,7 +1084,7 @@ def allocate_temporaries_for_base_storage(kernel: LoopKernel,
             warn("Base storage allocation was performed implicitly during "
                     "preprocessing. This is deprecated and will stop working "
                     "in 2023. Call loopy.allocate_temporaries_for_base_storage "
-                    "explicitly to aovid this warning.", DeprecationWarning)
+                    "explicitly to avoid this warning.", DeprecationWarning)
 
         return kernel.copy(temporary_variables=new_tvs)
     else:

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3392,6 +3392,43 @@ def test_creation_kwargs():
             ksdfjlasdf=None)
 
 
+def test_global_temps_with_multiple_base_storages(ctx_factory):
+    # See https://github.com/inducer/loopy/issues/737
+
+    n = 10
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    prg = lp.make_kernel(
+        "{[r0, r1]: 0<=r0,r1< %s}" % n,
+        """
+        tmp0 = sum(r0, r0**2)
+        ... gbarrier
+        tmp1 = sum(r1, r1**3)
+        ... gbarrier
+        out = tmp0 + tmp1
+        """,
+        [lp.TemporaryVariable("tmp0",
+                              shape=lp.auto,
+                              address_space=lp.AddressSpace.GLOBAL,
+                              base_storage="base1"),
+         lp.TemporaryVariable("tmp1",
+                              shape=lp.auto,
+                              address_space=lp.AddressSpace.GLOBAL,
+                              base_storage="base2"),
+         ...],
+        seq_dependencies=True
+    )
+
+    prg = lp.infer_unknown_types(prg)
+    prg = lp.allocate_temporaries_for_base_storage(prg)
+    print(prg)
+
+    _, (out,) = prg(cq)
+
+    assert out == sum(i**2 for i in range(n)) + sum(i**3 for i in range(n))
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
cc @kaushikcfd 

Alternate fix for #737. Supersedes #738.

Closes #737.