### PR TITLE
Correctly handle type inference of substitution rules

### DIFF
--- a/loopy/type_inference.py
+++ b/loopy/type_inference.py
@@ -79,23 +79,14 @@ class FunctionNameChanger(RuleAwareIdentityMapper):
         name, tag = parse_tagged_name(expr.function)
 
         if name not in self.rule_mapping_context.old_subst_rules:
-            expanded_expr = self.subst_expander(expr)
-            if expr in self.calls_to_new_names:
-                return type(expr)(
-                        ResolvedFunction(self.calls_to_new_names[expr]),
-                        tuple(self.rec(child, expn_state)
-                            for child in expr.parameters))
-            elif expanded_expr in self.calls_to_new_names:
-                # FIXME: This is killing the substitution.
-                # Maybe using a RuleAwareIdentityMapper for TypeInferenceMapper
-                # would help.
+            expanded_expr = self.subst_expander(expn_state.apply_arg_context(expr))
+            if expanded_expr in self.calls_to_new_names:
                 return type(expr)(
                         ResolvedFunction(self.calls_to_new_names[expanded_expr]),
                         tuple(self.rec(child, expn_state)
-                            for child in expanded_expr.parameters))
+                              for child in expr.parameters))
             else:
-                return super().map_call(
-                        expr, expn_state)
+                return super().map_call(expr, expn_state)
         else:
             return self.map_substitution(name, tag, expr.parameters, expn_state)
 

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3456,6 +3456,23 @@ def test_t_unit_to_python_with_substs():
     lp.t_unit_to_python(t_unit)  # contains check to assert roundtrip equivalence
 
 
+def test_type_inference_of_clbls_in_substitutions(ctx_factory):
+    # Regression for https://github.com/inducer/loopy/issues/746
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+
+    knl = lp.make_kernel(
+        "{[i]: 0<=i<10}",
+        """
+        subst_0(_0) := abs(10.0 * (_0-5))
+
+        y[i] = subst_0(i)
+        """)
+
+    evt, (out,) = knl(cq)
+    np.testing.assert_allclose(out.get(), np.abs(10.0*(np.arange(10)-5)))
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
My understanding of `RuleAwareIdentityMapper` was unclear, which was why I introduced the bug. I fixed it now. (Hopefully, the CI agrees)

Fixes #746.