### PR TITLE
schedule, codegen: log cache misses

### DIFF
--- a/loopy/codegen/__init__.py
+++ b/loopy/codegen/__init__.py
@@ -577,10 +577,11 @@ def generate_code_v2(program):
         try:
             result = code_gen_cache[input_program]
             logger.debug(f"TranslationUnit with entrypoints {program.entrypoints}:"
-                         " code generation cache hit")
+                          " code generation cache hit")
             return result
         except KeyError:
-            pass
+            logger.debug(f"TranslationUnit with entrypoints {program.entrypoints}:"
+                          " code generation cache miss")
 
     # }}}
 

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -2159,10 +2159,10 @@ def get_one_linearized_kernel(kernel, callables_table):
         try:
             result = schedule_cache[sched_cache_key]
 
-            logger.debug("%s: schedule cache hit" % kernel.name)
+            logger.debug(f"{kernel.name}: schedule cache hit")
             from_cache = True
         except KeyError:
-            pass
+            logger.debug(f"{kernel.name}: schedule cache miss")
 
     if not from_cache:
         with ProcessLogger(logger, "%s: schedule" % kernel.name):


### PR DESCRIPTION
Makes the logging more consistent with cache hits, and more consistent with the typed-and-scheduled and invoker cache logging.