### PR TITLE
`get_usable_inames_for_conditional`: allow only 'related' parallel inames

### DIFF
--- a/loopy/codegen/loop.py
+++ b/loopy/codegen/loop.py
@@ -358,6 +358,7 @@ def generate_sequential_loop_dim_code(codegen_state, sched_index):
     # Note: this does not include loop_iname itself!
     usable_inames = get_usable_inames_for_conditional(kernel, sched_index,
             codegen_state.codegen_cachemanager)
+
     domain = kernel.get_inames_domain(loop_iname)
 
     result = []

--- a/loopy/codegen/tools.py
+++ b/loopy/codegen/tools.py
@@ -27,7 +27,7 @@ from loopy.schedule import (EnterLoop, LeaveLoop, CallKernel, ReturnFromKernel,
                             Barrier, BeginBlockItem, gather_schedule_block,
                             ScheduleItem)
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import FrozenSet, List, Dict
 from loopy.kernel.instruction import InstructionBase
 from loopy.kernel import LoopKernel
 from loopy.kernel.data import Iname
@@ -86,7 +86,7 @@ class CodegenOperationCacheManager:
         An instance of :class:`KernelProxyForCodegenOperationCacheManager`.
 
     .. automethod:: with_kernel
-    .. automethod:: get_parallel_inames_in_a_callkernel
+    .. automethod:: get_concurrent_inames_in_a_callkernel
     """
     def __init__(self, kernel_proxy):
         assert isinstance(kernel_proxy, KernelProxyForCodegenOperationCacheManager)
@@ -199,9 +199,10 @@ class CodegenOperationCacheManager:
                                          sched_index)
 
     @memoize_method
-    def get_parallel_inames_in_a_callkernel(self, callkernel_index):
+    def get_concurrent_inames_in_a_callkernel(
+            self, callkernel_index: int) -> FrozenSet[str]:
         """
-        Returns a :class:`frozenset` of parallel inames in a callkernel
+        Returns a :class:`frozenset` of concurrent inames in a callkernel
 
         :arg callkernel_index: Index of the :class:`loopy.schedule.CallKernel`
             in the :attr:`CodegenOperationCacheManager.kernel_proxy`'s

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -339,6 +339,7 @@ class CUDACASTBuilder(CFamilyASTBuilder):
             fdecl = Extern("C", fdecl)
 
         from loopy.schedule import get_insn_ids_for_block_at
+        assert codegen_state.kernel.linearization is not None
         _, local_grid_size = \
                 codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                         get_insn_ids_for_block_at(

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -654,6 +654,7 @@ class OpenCLCASTBuilder(CFamilyASTBuilder):
         fdecl = CLKernel(fdecl)
 
         from loopy.schedule import get_insn_ids_for_block_at
+        assert codegen_state.kernel.linearization is not None
         _, local_sizes = codegen_state.kernel.get_grid_sizes_for_insn_ids_as_exprs(
                 get_insn_ids_for_block_at(
                     codegen_state.kernel.linearization, schedule_index),

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3563,6 +3563,52 @@ def test_no_barrier_err_for_global_temps_with_base_storage(ctx_factory):
     np.testing.assert_allclose(2*np.arange(16) + 2, out)
 
 
+def test_dgemm_with_rectangular_tile_prefetch(ctx_factory):
+    # See <https://github.com/inducer/loopy/issues/724>
+    t_unit = lp.make_kernel(
+        "{[i,j,k]: 0<=i,j<72 and 0<=k<32}",
+        """
+        C[i,j] = sum(k, A[i,k] * B[k,j])
+        """,
+        [lp.GlobalArg("A,B", dtype=np.float64, shape=lp.auto),
+         ...],
+    )
+    ref_t_unit = t_unit
+
+    tx = 8
+    ty = 23
+    tk = 11
+
+    t_unit = lp.split_iname(t_unit, "i", tx, inner_tag="l.0", outer_tag="g.0")
+    t_unit = lp.split_iname(t_unit, "j", ty, inner_tag="l.1", outer_tag="g.1")
+    t_unit = lp.split_iname(t_unit, "k", tk)
+    t_unit = lp.add_prefetch(
+        t_unit, "A",
+        sweep_inames=["i_inner", "k_inner"],
+        temporary_address_space=lp.AddressSpace.LOCAL,
+        fetch_outer_inames=frozenset({"i_outer", "j_outer", "k_outer"}),
+        dim_arg_names=["iprftch_A", "kprftch_A"],
+        default_tag=None,
+    )
+
+    t_unit = lp.add_prefetch(
+        t_unit, "B",
+        sweep_inames=["k_inner", "j_inner"],
+        temporary_address_space=lp.AddressSpace.LOCAL,
+        fetch_outer_inames=frozenset({"i_outer", "j_outer", "k_outer"}),
+        dim_arg_names=["kprftch_B", "jprftch_B"],
+        default_tag=None,
+    )
+
+    t_unit = lp.split_iname(t_unit, "kprftch_A", tx, inner_tag="l.0")
+    t_unit = lp.split_iname(t_unit, "iprftch_A", ty, inner_tag="l.1")
+    t_unit = lp.split_iname(t_unit, "jprftch_B", tx, inner_tag="l.0")
+    t_unit = lp.split_iname(t_unit, "kprftch_B", ty, inner_tag="l.1")
+
+    ctx = cl.create_some_context()
+    lp.auto_test_vs_ref(ref_t_unit, ctx, t_unit)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Closes #724.

This is an alternative to #751.