### PR TITLE
Update insn ids in addition to updating dependency ids in replace_instruction_ids

### DIFF
--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -294,8 +294,8 @@ def replace_instruction_ids(kernel, replacements):
     replaced according to the provided mapping.
 
     :arg replacements: a :class:`dict` mapping old insn ids to an
-    iterable of new insn ids. In the case the iterable has more than one
-    entry, the first entry of the iterable is used for replacement
+    iterable of new insn ids.
+    The first entry of the iterable is used for replacement
     purposes. Additional insn ids after the first are added to
     dependency list of instructions that have a dependency on the old insn id.
     """

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -294,10 +294,10 @@ def replace_instruction_ids(kernel, replacements):
     replaced according to the provided mapping.
 
     :arg replacements: a :class:`dict` mapping old insn ids to an
-    iterable of new insn ids.
-    The first entry of the iterable is used for replacement
-    purposes. Additional insn ids after the first are added to
-    dependency list of instructions that have a dependency on the old insn id.
+        iterable of new insn ids.
+        The first entry of the iterable is used for replacement
+        purposes. Additional insn ids after the first are added to
+        dependency list of instructions that have a dependency on the old insn id.
     """
 
     if not replacements:

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -296,7 +296,7 @@ def replace_instruction_ids(kernel, replacements):
     :arg replacements: a :class:`dict` mapping old insn ids to an
         iterable of new insn ids.
         The first entry of the iterable is used for replacement
-        purposes. Additional insn ids after the first are added to
+        purposes. Additional insn ids after the first are added to the
         dependency list of instructions that have a dependency on the old insn id.
     """
 

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -20,9 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from typing import Sequence, Mapping, List, Tuple
 from loopy.diagnostic import LoopyError
 from loopy.kernel import LoopKernel
 from loopy.kernel.function_interface import (ScalarCallable, CallableKernel)
+from loopy.kernel.instruction import InstructionBase
 from loopy.translation_unit import TranslationUnit, for_each_kernel
 from loopy.symbolic import RuleAwareIdentityMapper
 
@@ -255,11 +257,13 @@ def remove_instructions(kernel, insn_ids):
 
 # {{{ replace_instruction_ids
 
-def replace_instruction_ids_in_insn(insn, replacements):
+def replace_instruction_ids_in_insn(
+        insn: InstructionBase, replacements: Mapping[str, Sequence[str]]
+        ) -> InstructionBase:
     changed = False
     new_depends_on = list(insn.depends_on)
-    extra_depends_on = []
-    new_no_sync_with = []
+    extra_depends_on: List[str] = []
+    new_no_sync_with: List[Tuple[str, str]] = []
 
     if insn.id in replacements:
         insn = insn.copy(id=replacements[insn.id][0])
@@ -289,7 +293,9 @@ def replace_instruction_ids_in_insn(insn, replacements):
         return insn
 
 
-def replace_instruction_ids(kernel, replacements):
+def replace_instruction_ids(
+        kernel: LoopKernel, replacements: Mapping[str, Sequence[str]]
+        ) -> LoopKernel:
     """Return a new kernel with the ids of instructions and dependencies
     replaced according to the provided mapping.
 

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -261,6 +261,11 @@ def replace_instruction_ids_in_insn(insn, replacements):
     extra_depends_on = []
     new_no_sync_with = []
 
+    if insn.id in replacements:
+        insn = insn.copy(id=replacements[insn.id][0])
+
+    new_depends_on = list(insn.depends_on)
+    extra_depends_on = []
     for idep, dep in enumerate(insn.depends_on):
         if dep in replacements:
             new_deps = list(replacements[dep])
@@ -285,6 +290,16 @@ def replace_instruction_ids_in_insn(insn, replacements):
 
 
 def replace_instruction_ids(kernel, replacements):
+    """Return a new kernel with the ids of instructions and dependencies
+    replaced according to the provided mapping.
+
+    :arg replacements: a :class:`dict` mapping old insn ids to an
+    iterable of new insn ids. In the case the list has more than one
+    entry, the first entry of the iterable is used for replacement
+    purposes. Additional insn ids after the first are added to
+    dependency list of instructions that have a dependency on the old insn id.
+    """
+
     if not replacements:
         return kernel
 

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -294,7 +294,7 @@ def replace_instruction_ids(kernel, replacements):
     replaced according to the provided mapping.
 
     :arg replacements: a :class:`dict` mapping old insn ids to an
-    iterable of new insn ids. In the case the list has more than one
+    iterable of new insn ids. In the case the iterable has more than one
     entry, the first entry of the iterable is used for replacement
     purposes. Additional insn ids after the first are added to
     dependency list of instructions that have a dependency on the old insn id.


### PR DESCRIPTION
Currently `replace_instruction_ids` only updates the instruction ids in an instruction's `depends_on` set and `no_sync_with` set. It doesn't actually update the id property of an instruction, which for me seems unintuitive. This change adds this capability and some documentation for `replace_instruction_ids`.