### PR TITLE
Cleanup numpy deprecations

### DIFF
--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -488,8 +488,8 @@ class CMathCallable(ScalarCallable):
         # {{{ (abs|max|min) -> (fabs|fmax|fmin)
 
         if name in ["abs", "min", "max"]:
-            dtype = np.find_common_type(
-                [], [dtype.numpy_dtype for dtype in arg_id_to_dtype.values()])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for dtype in arg_id_to_dtype.values()])
             if dtype.kind == "f":
                 name = "f" + name
 
@@ -558,9 +558,9 @@ class CMathCallable(ScalarCallable):
                         self.copy(arg_id_to_dtype=arg_id_to_dtype),
                         callables_table)
 
-            dtype = np.find_common_type(
-                [], [dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
-                     if id >= 0])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if id >= 0])
             real_dtype = np.empty(0, dtype=dtype).real.dtype
 
             if name in ["fmax", "fmin", "copysign"] and dtype.kind == "c":
@@ -598,9 +598,9 @@ class CMathCallable(ScalarCallable):
                         self.copy(arg_id_to_dtype=arg_id_to_dtype),
                         callables_table)
 
-            dtype = np.find_common_type(
-                [], [dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
-                     if id >= 0])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if id >= 0])
             if dtype.kind not in "iu":
                 # only support integers for now to avoid having to deal with NaNs
                 raise LoopyError(f"{name} does not support '{dtype}' arguments.")

--- a/loopy/target/cuda.py
+++ b/loopy/target/cuda.py
@@ -154,9 +154,9 @@ class CudaCallable(ScalarCallable):
                             self.copy(arg_id_to_dtype=arg_id_to_dtype),
                             callables_table)
 
-            dtype = np.find_common_type(
-                    [], [dtype.numpy_dtype for id, dtype in
-                        arg_id_to_dtype.items() if id >= 0])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if id >= 0])
 
             updated_arg_id_to_dtype = {id: NumpyType(dtype)
                     for id in range(-1, num_args)}

--- a/loopy/target/opencl.py
+++ b/loopy/target/opencl.py
@@ -268,9 +268,9 @@ class OpenCLCallable(ScalarCallable):
                         self.copy(arg_id_to_dtype=arg_id_to_dtype),
                         callables_table)
 
-            dtype = np.find_common_type(
-                [], [dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
-                     if id >= 0])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if id >= 0])
 
             if dtype.kind == "c":
                 raise LoopyTypeError(f"'{name}' does not support complex numbers")
@@ -289,9 +289,9 @@ class OpenCLCallable(ScalarCallable):
                 return (
                         self.copy(arg_id_to_dtype=arg_id_to_dtype),
                         callables_table)
-            common_dtype = np.find_common_type(
-                    [], [dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
-                        if (id >= 0 and dtype is not None)])
+            common_dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if (id >= 0 and dtype is not None)])
 
             if common_dtype.kind in ["u", "i", "f"]:
                 if common_dtype.kind == "f":
@@ -332,9 +332,9 @@ class OpenCLCallable(ScalarCallable):
                 if not -1 <= id <= 1:
                     raise LoopyError(f"'{name}' can take only 2 arguments.")
 
-            common_dtype = np.find_common_type(
-                    [], [dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
-                        if (id >= 0 and dtype is not None)])
+            common_dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if (id >= 0 and dtype is not None)])
 
             if common_dtype == np.float64:
                 name = "powf64"
@@ -366,9 +366,9 @@ class OpenCLCallable(ScalarCallable):
                             self.copy(arg_id_to_dtype=arg_id_to_dtype),
                             callables_table)
 
-            dtype = np.find_common_type(
-                    [], [dtype.numpy_dtype for id, dtype in
-                        arg_id_to_dtype.items() if id >= 0])
+            dtype = np.result_type(*[
+                    dtype.numpy_dtype for id, dtype in arg_id_to_dtype.items()
+                    if id >= 0])
 
             if dtype.kind == "c":
                 raise LoopyError("%s does not support complex numbers"

--- a/test/test_c_execution.py
+++ b/test/test_c_execution.py
@@ -117,7 +117,7 @@ def test_c_target_strides_nonsquare():
     # test with C-order
     knl = __get_kernel("C")
     a_lp = next(x for x in knl["nonsquare_strides"].args if x.name == "a")
-    a_np = np.reshape(np.arange(np.product(a_lp.shape), dtype=np.float32),
+    a_np = np.reshape(np.arange(np.prod(a_lp.shape), dtype=np.float32),
                       a_lp.shape,
                       order="C")
 
@@ -127,7 +127,7 @@ def test_c_target_strides_nonsquare():
     # test with F-order
     knl = __get_kernel("F")
     a_lp = next(x for x in knl["nonsquare_strides"].args if x.name == "a")
-    a_np = np.reshape(np.arange(np.product(a_lp.shape), dtype=np.float32),
+    a_np = np.reshape(np.arange(np.prod(a_lp.shape), dtype=np.float32),
                       a_lp.shape,
                       order="F")
 
@@ -163,7 +163,7 @@ def test_c_optimizations():
     # test with ILP
     knl, sizes = __get_kernel("C")
     knl = lp.split_iname(knl, "i", 4, inner_tag="ilp")
-    a_np = np.reshape(np.arange(np.product(sizes), dtype=np.float32),
+    a_np = np.reshape(np.arange(np.prod(sizes), dtype=np.float32),
                       sizes,
                       order="C")
 
@@ -172,7 +172,7 @@ def test_c_optimizations():
     # test with unrolling
     knl, sizes = __get_kernel("C")
     knl = lp.split_iname(knl, "i", 4, inner_tag="unr")
-    a_np = np.reshape(np.arange(np.product(sizes), dtype=np.float32),
+    a_np = np.reshape(np.arange(np.prod(sizes), dtype=np.float32),
                       sizes,
                       order="C")
 


### PR DESCRIPTION
This replaces `np.find_common_type` and `np.product`, which are deprecated in numpy 1.25.

Are the `find_common_type` replacements correct? They all used the `scalar_types` instead of `array_types` argument and I'm not sure of the subtle differences..