### PR TITLE
Add scalar minimum/maximum to function mapper

### DIFF
--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -1601,6 +1601,16 @@ class FunctionToPrimitiveMapper(UncachedIdentityMapper):
             else:
                 raise TypeError("if takes three arguments")
 
+        elif name in ["minimum", "maximum"]:
+            if len(expr.parameters) == 2:
+                from pymbolic.primitives import Min, Max
+                return {
+                    "minimum": Min,
+                    "maximum": Max
+                }[name](tuple(self.rec(p) for p in expr.parameters))
+            else:
+                raise TypeError(f"{name} takes two arguments")
+
         else:
             # see if 'name' is an existing reduction op
 


### PR DESCRIPTION
Following the discussion in #794, adds `minimum` and `maximum` as scalar callables to `map_call` in the function to primitive mapper.