### PR TITLE
Add raise_on_domain_mismatch parameter to rename_iname

### DIFF
--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2506,7 +2506,7 @@ def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
 def rename_iname(kernel, old_iname, new_iname, existing_ok=False,
                  within=None, preserve_tags=True,
                  raise_on_domain_mismatch: bool = __debug__):
-    """
+    r"""
     Single iname version of :func:`loopy.rename_inames`.
     :arg existing_ok: execute even if *new_iname* already exists
     :arg within: a stack match understood by :func:`loopy.match.parse_stack_match`.

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2508,12 +2508,12 @@ def rename_iname(kernel, old_iname, new_iname, existing_ok=False,
                  raise_on_domain_mismatch: bool = __debug__):
     r"""
     Single iname version of :func:`loopy.rename_inames`.
-    :arg existing_ok: execute even if *new_iname* already exists
+    :arg existing_ok: execute even if *new_iname* already exists.
     :arg within: a stack match understood by :func:`loopy.match.parse_stack_match`.
-    :arg preserve_tags: copy the tags on the old iname to the new iname
+    :arg preserve_tags: copy the tags on the old iname to the new iname.
     :arg raise_on_domain_mismatch: If *True*, raises an error if
-        :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
-        \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
+    :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
+    \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
     """
     from itertools import product
     from loopy import tag_inames

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2504,18 +2504,23 @@ def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
 
 @for_each_kernel
 def rename_iname(kernel, old_iname, new_iname, existing_ok=False,
-                 within=None, preserve_tags=True):
+                 within=None, preserve_tags=True,
+                 raise_on_domain_mismatch: bool = __debug__):
     """
     Single iname version of :func:`loopy.rename_inames`.
     :arg existing_ok: execute even if *new_iname* already exists
     :arg within: a stack match understood by :func:`loopy.match.parse_stack_match`.
     :arg preserve_tags: copy the tags on the old iname to the new iname
+    :arg raise_on_domain_mismatch: If *True*, raises an error if
+        :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
+        \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
     """
     from itertools import product
     from loopy import tag_inames
 
     tags = kernel.inames[old_iname].tags
-    kernel = rename_inames(kernel, [old_iname], new_iname, existing_ok, within)
+    kernel = rename_inames(kernel, [old_iname], new_iname, existing_ok,
+                           within, raise_on_domain_mismatch)
     if preserve_tags:
         kernel = tag_inames(kernel, product([new_iname], tags))
     return kernel

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2368,7 +2368,7 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
 @for_each_kernel
 @remove_any_newly_unused_inames
 def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
-                  within=None, raise_on_domain_mismatch: bool = __debug__):
+                  within=None, raise_on_domain_mismatch: bool = None):
     r"""
     :arg old_inames: A collection of inames that must be renamed to **new_iname**.
     :arg within: a stack match as understood by
@@ -2395,6 +2395,9 @@ def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
            for insn in kernel.instructions):
         raise LoopyError("old_inames contains nested inames"
                          " -- renaming is illegal.")
+
+    if raise_on_domain_mismatch is None:
+        raise_on_domain_mismatch = __debug__
 
     # sort to have deterministic implementation.
     old_inames = sorted(old_inames)
@@ -2505,7 +2508,7 @@ def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
 @for_each_kernel
 def rename_iname(kernel, old_iname, new_iname, existing_ok=False,
                  within=None, preserve_tags=True,
-                 raise_on_domain_mismatch: bool = __debug__):
+                 raise_on_domain_mismatch: bool = None):
     r"""
     Single iname version of :func:`loopy.rename_inames`.
     :arg existing_ok: execute even if *new_iname* already exists.

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -35,6 +35,7 @@ from loopy.translation_unit import (TranslationUnit,
 from loopy.kernel import LoopKernel
 from loopy.kernel.function_interface import CallableKernel
 
+from typing import Optional
 
 __doc__ = """
 .. currentmodule:: loopy
@@ -2368,7 +2369,7 @@ def add_inames_for_unused_hw_axes(kernel, within=None):
 @for_each_kernel
 @remove_any_newly_unused_inames
 def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
-                  within=None, raise_on_domain_mismatch: bool = None):
+                  within=None, raise_on_domain_mismatch: Optional[bool] = None):
     r"""
     :arg old_inames: A collection of inames that must be renamed to **new_iname**.
     :arg within: a stack match as understood by
@@ -2508,7 +2509,7 @@ def rename_inames(kernel, old_inames, new_iname, existing_ok=False,
 @for_each_kernel
 def rename_iname(kernel, old_iname, new_iname, existing_ok=False,
                  within=None, preserve_tags=True,
-                 raise_on_domain_mismatch: bool = None):
+                 raise_on_domain_mismatch: Optional[bool] = None):
     r"""
     Single iname version of :func:`loopy.rename_inames`.
     :arg existing_ok: execute even if *new_iname* already exists.


### PR DESCRIPTION
Adds keyword parameter to `rename_iname` so raise_on_domain_mismatch can be passed into the call to `rename_inames`.