### PR TITLE
Fix import of `loopy.version`

### DIFF
--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -42,7 +42,6 @@ from islpy import dim_type
 from pytools import ProcessLogger
 
 from sys import intern
-import loopy.version
 
 import re
 
@@ -2325,8 +2324,9 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
 
     from loopy.version import LANGUAGE_VERSION_SYMBOLS
 
+    import loopy.version as v
     version_to_symbol = {
-            getattr(loopy.version, lvs): lvs
+            getattr(v, lvs): lvs
             for lvs in LANGUAGE_VERSION_SYMBOLS}
 
     lang_version = kwargs.pop("lang_version", None)


### PR DESCRIPTION
Mysteriously, this fixes a doc build failure in grudge with a backtrace saying
``` 
File /home/runner/work/grudge/grudge/.conda-root/envs/testing/lib/python3.11/site-packages/loopy/kernel/creation.py, line 2329, in <dictcomp>
    getattr(loopy.version, lvs): lvs
            ^^^^^^^^^^^^^
AttributeError: module 'loopy' has no attribute 'version'
```
Build failure: https://github.com/inducer/grudge/actions/runs/5915142781/job/16041111199#step:3:1191