### PR TITLE
ignore proto-tests/, ndarray/ dirs for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ per-file-ignores =
 
 [tool:pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
+addopts = --ignore=proto-tests --ignore=loopy/target/c/compyte/ndarray
 
 [mypy]
 python_version = 3.8


### PR DESCRIPTION
With this change, one can run `pytest` directly in the main dir of loopy (without specifying the test dir).