### PR TITLE
LazilyUnpickling{Dict,List}: add __repr__

### DIFF
--- a/loopy/tools.py
+++ b/loopy/tools.py
@@ -348,6 +348,9 @@ class _PickledObject:
     def __getstate__(self):
         return {"objstring": self.objstring}
 
+    def __repr__(self) -> str:
+        return repr(self.unpickle())
+
 
 class _PickledObjectWithEqAndPersistentHashKeys(_PickledObject):
     """Like :class:`_PickledObject`, with two additional attributes:
@@ -406,6 +409,9 @@ class LazilyUnpicklingDict(abc.MutableMapping):
             key: _PickledObject(val)
             for key, val in self._map.items()}}
 
+    def __repr__(self) -> str:
+        return type(self).__name__ + "(" + repr(self._map) + ")"
+
 # }}}
 
 
@@ -443,6 +449,9 @@ class LazilyUnpicklingList(abc.MutableSequence):
 
     def __mul__(self, other):
         return self._list * other
+
+    def __repr__(self) -> str:
+        return type(self).__name__ + "(" + repr(self._list) + ")"
 
 
 class LazilyUnpicklingListWithEqAndPersistentHashing(LazilyUnpicklingList):

--- a/loopy/tools.py
+++ b/loopy/tools.py
@@ -349,7 +349,7 @@ class _PickledObject:
         return {"objstring": self.objstring}
 
     def __repr__(self) -> str:
-        return repr(self.unpickle())
+        return type(self).__name__ + "(" + repr(self.unpickle()) + ")"
 
 
 class _PickledObjectWithEqAndPersistentHashKeys(_PickledObject):


### PR DESCRIPTION
```python
from loopy.tools import LazilyUnpicklingList, LazilyUnpicklingDict, _PickledObject
l = LazilyUnpicklingList([1, 2, 3, 4])
print(l)
d = LazilyUnpicklingDict({'a':1, 'b':2})
print(d)
p = _PickledObject(7)
print(p)
```

before:
```
<loopy.tools.LazilyUnpicklingList object at 0x101810810>
<loopy.tools.LazilyUnpicklingDict object at 0x104b2ccd0>
<loopy.tools._PickledObject object at 0x10103a450>
```

after:
```
LazilyUnpicklingList([1, 2, 3, 4])
LazilyUnpicklingDict({'a': 1, 'b': 2})
_PickledObject(7)
```

(If you want, I could add `__str__` methods that don't include the class names.)