### PR TITLE
fix flake8 B026

### DIFF
--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -334,8 +334,8 @@ class TranslationUnit:
                         "Maybe you want to invoke 'with_entrypoints' before "
                         "calling the translation unit?")
 
-        return self.target.get_kernel_executor(self, entrypoint=entrypoint,
-                                               *args, **kwargs)
+        return self.target.get_kernel_executor(self, *args,
+                                               entrypoint=entrypoint, **kwargs)
 
     def __call__(self, *args, **kwargs):
         """


### PR DESCRIPTION
Fixes:
`./loopy/translation_unit.py:338:48: B026 Star-arg unpacking after a keyword argument is strongly discouraged, because it only works when the keyword parameter is declared after all parameters supplied by the unpacked sequence, and this change of ordering can surprise and mislead readers.`