### PR TITLE
Bump version to 2024.1

### DIFF
--- a/loopy/version.py
+++ b/loopy/version.py
@@ -42,7 +42,7 @@ else:
 # }}}
 
 
-VERSION = (2022, 1)
+VERSION = (2024, 1)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS
 


### PR DESCRIPTION
Could we also have a version bump on pypi. Thanks! (See https://github.com/inducer/loopy/issues/159#issuecomment-1467136411)