### PR TITLE
Add `test_long_kernel`

### DIFF
--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -3689,6 +3689,21 @@ def test_no_unnecessary_lbarrier(ctx_factory):
     assert not barrier_between(knl, "write_s_a", "write_ao")
 
 
+def test_long_kernel():
+    n = 500
+    insns = [
+        f"a{i}[j{i}] = j{i}"
+        for i in range(n)
+    ]
+    domains = [
+        f"{{ [j{i}]: 0<=j{i}<10 }}"
+        for i in range(n)
+    ]
+    t_unit = lp.make_kernel(domains, insns)
+    t_unit = lp.preprocess_kernel(t_unit)
+    lp.get_one_linearized_kernel(t_unit.default_entrypoint, t_unit.callables_table)
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
On Python 3.12, this provokes a stack overflow in the scheduler. It is not quite clear why that's the case; pure-Python recursion even with generators seems to respond well to setrecursionlimit():

```py
def f(n):
    if n:
        yield from f(n-1)
    else:
        yield 5

import sys
sys.setrecursionlimit(3500)
print(list(f(3400)))
```

That said, there have been [behavior](https://github.com/python/cpython/pull/96510) [changes](https://github.com/python/cpython/issues/112215) in Py3.12 in this regard, but it is not clear what exactly about Loopy's behavior makes it fall into the 'bad' case.

This is a smaller reproducer of an issue flagged by @a-alveyblanc in the context of tensor product code generated from Pytato.

It appears that Py3.12 [will receive some changes](https://github.com/python/cpython/pull/115083/files) soon that mitigate this. More broadly, a better scheduling algorithm would help with this, as would #350.