### PR TITLE
c_execution: remove unused source_suffix argument to GCCToolchain

### DIFF
--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -280,6 +280,7 @@ class CCompiler:
                 # default args
                 self.toolchain = GCCToolchain(
                     cc="gcc",
+                    ld="ld",
                     cflags="-std=c99 -O3 -fPIC".split(),
                     ldflags="-shared".split(),
                     libraries=[],
@@ -288,7 +289,8 @@ class CCompiler:
                     undefines=[],
                     so_ext=".so",
                     o_ext=".o",
-                    include_dirs=[])
+                    include_dirs=[],
+                    features=set())
 
         if toolchain is None:
             # copy in all differing values

--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -286,7 +286,6 @@ class CCompiler:
                     library_dirs=[],
                     defines=[],
                     undefines=[],
-                    source_suffix="c",
                     so_ext=".so",
                     o_ext=".o",
                     include_dirs=[])

--- a/test/test_c_execution.py
+++ b/test/test_c_execution.py
@@ -336,11 +336,6 @@ def test_missing_compilers():
         # the default (non-guessed) toolchain!
         __test(eval_tester, ExecutableCTarget, compiler=ccomp)
 
-    # and test that we will fail if we remove a required attribute
-    del ccomp.toolchain.undefines
-    with pytest.raises(AttributeError):
-        __test(eval_tester, ExecutableCTarget, compiler=ccomp)
-
     # next test that some made up compiler can be specified
     ccomp = CCompiler(cc="foo")
     assert isinstance(ccomp.toolchain, GCCToolchain)


### PR DESCRIPTION
This doesn't seem to be used anywhere -- the `CCompiler` class has its own `source_suffix` argument.

xref: Tried to remove `pytools.Record` from `codepy` and this field was added only here.

Needs inducer/arraycontext#252.