### PR TITLE
ExpressionToPythonMapper: use str instead of repr for map_constant

### DIFF
--- a/loopy/target/python.py
+++ b/loopy/target/python.py
@@ -58,7 +58,7 @@ class ExpressionToPythonMapper(StringifyMapper):
     __call__ = rec
 
     def map_constant(self, expr, enclosing_prec):
-        return repr(expr)
+        return str(expr)
 
     def map_variable(self, expr, enclosing_prec):
         if expr.name in self.codegen_state.var_subst_map:


### PR DESCRIPTION
```console
$ python -c 'import numpy as np; print(np.__version__, repr(np.int32(42)))'  # numpy 2
2.0.0 np.int32(42)

$ python -c 'import numpy as np; print(np.__version__, repr(np.int32(42)))'  # numpy<2
1.26.4 42
```
😱 

This fixes the meshmode test failures seen in e.g. https://github.com/inducer/pyopencl/pull/771