### PR TITLE
Support `TypeCast` in `CombineMapper`

### DIFF
--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -277,6 +277,9 @@ class CombineMapper(CombineMapperBase):
     def map_reduction(self, expr, *args, **kwargs):
         return self.rec(expr.expr, *args, **kwargs)
 
+    def map_type_cast(self, expr, *args, **kwargs):
+        return self.rec(expr.child, *args, **kwargs)
+
     def map_sub_array_ref(self, expr):
         return self.combine((
             self.rec(expr.subscript),

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -280,10 +280,12 @@ class CombineMapper(CombineMapperBase):
     def map_type_cast(self, expr, *args, **kwargs):
         return self.rec(expr.child, *args, **kwargs)
 
-    def map_sub_array_ref(self, expr):
+    def map_sub_array_ref(self, expr, *args, **kwargs):
         return self.combine((
-            self.rec(expr.subscript),
-            self.combine(tuple(self.rec(idx) for idx in expr.swept_inames))))
+            self.rec(expr.subscript, *args, **kwargs),
+            self.combine(tuple(
+                         self.rec(idx, *args, **kwargs)
+                         for idx in expr.swept_inames))))
 
     map_linear_subscript = CombineMapperBase.map_subscript
 


### PR DESCRIPTION
Should address failures like
```
pymbolic.mapper.UnsupportedExpressionError: <class 'loopy.kernel.tools._IndexCollector'> cannot handle expressions of type <class 'loopy.symbolic.TypeCast'>
```
observed in e.g. [this run](https://github.com/illinois-ceesd/mirgecom/actions/runs/9626097768/job/26924869997?pr=926)

NB: `_IndexCollector` is not in main (yet?), it was added in @kaushikcfd's loop fusion branch.

cc @mtcam @matthiasdiener 