### PR TITLE
InstructionBase: implement _with_new_tags

### DIFF
--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -463,6 +463,9 @@ class InstructionBase(ImmutableRecord, Taggable):
         self.within_inames = (
                 intern_frozenset_of_ids(self.within_inames))
 
+    def _with_new_tags(self, tags: FrozenSet[Tag]):
+        return self.copy(tags=tags)
+
 # }}}
 
 


### PR DESCRIPTION
cc @MTCam

Needed due to https://github.com/illinois-ceesd/meshmode/blob/e7337041c950fc45a86ca39235e929a5733ee620/meshmode/array_context.py#L1165 - not sure how that worked before.

Perhaps related to #850 or #853.