### PR TITLE
TypeInferenceMapper: allow np.bool in map_type_case

### DIFF
--- a/loopy/type_inference.py
+++ b/loopy/type_inference.py
@@ -396,7 +396,7 @@ class TypeInferenceMapper(CombineMapper):
 
     def map_type_cast(self, expr):
         subtype, = self.rec(expr.child)
-        if not issubclass(subtype.dtype.type, np.number):
+        if not issubclass(subtype.dtype.type, (np.number, np.bool_)):
             raise LoopyError(f"Can't cast a '{subtype}' to '{expr.type}'")
         return [expr.type]
 


### PR DESCRIPTION
9f2e8ce2a13835e7e6d8529b500a7076a9b9f415 broke some mirgecom [runs](https://github.com/illinois-ceesd/mirgecom/actions/runs/9997932395/job/27640650287?pr=1047):

```console

[...]
  File "/home/runner/work/mirgecom/mirgecom/src/loopy/loopy/type_inference.py", line 329, in map_sum
    dtype_set = self.rec(child)
                ^^^^^^^^^^^^^^^
  File "/home/runner/work/mirgecom/mirgecom/src/pymbolic/pymbolic/mapper/__init__.py", line 271, in __call__
    result = method(expr, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mirgecom/mirgecom/src/loopy/loopy/type_inference.py", line 400, in map_type_cast
    raise LoopyError(f"Can't cast a '{subtype}' to '{expr.type}'")
loopy.diagnostic.LoopyError: Can't cast a 'np:dtype('bool')' to 'np:dtype('float64')'
```