### PR TITLE
Fix _InameDuplicator.within

### DIFF
--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2536,13 +2536,6 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
 
     assert len(knl.instructions) == len(inames_to_dup)
 
-    from loopy import duplicate_inames
-    from loopy.match import Id
-    for insn, insn_inames_to_dup in zip(knl.instructions, inames_to_dup):
-        for old_iname, new_iname in insn_inames_to_dup:
-            knl = duplicate_inames(knl, old_iname,
-                    within=Id(insn.id), new_inames=new_iname)
-
     check_for_nonexistent_iname_deps(knl)
 
     knl = create_temporaries(knl, default_order)
@@ -2563,6 +2556,27 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
     knl = add_inferred_inames(knl)
     from loopy.transform.parameter import fix_parameters
     knl = fix_parameters(knl, **fixed_parameters)
+
+    # -------------------------------------------------------------------------
+    # Ordering dependency:
+    # -------------------------------------------------------------------------
+    # Must duplicate inames after adding all the inames to the instructions.
+    # To duplicate an iname "i" in statement "S", lp.duplicate requires that
+    # the statement "S" be nested within the iname "i".
+    # -------------------------------------------------------------------------
+    from loopy import duplicate_inames
+    from loopy.match import Id
+    for insn, insn_inames_to_dup in zip(knl.instructions, inames_to_dup):
+        for old_iname, new_iname in insn_inames_to_dup:
+            knl = duplicate_inames(knl, old_iname,
+                    within=Id(insn.id), new_inames=new_iname)
+            new_insn = knl.id_to_insn[insn.id]
+            assert old_iname not in (
+                new_insn.within_inames
+                | new_insn.reduction_inames()
+                | new_insn.sub_array_ref_inames()
+            )
+
     # -------------------------------------------------------------------------
     # Ordering dependency:
     # -------------------------------------------------------------------------

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -21,7 +21,7 @@ THE SOFTWARE.
 """
 
 
-from typing import FrozenSet, Optional
+from typing import Any, FrozenSet, Optional
 
 import islpy as isl
 from islpy import dim_type
@@ -29,6 +29,7 @@ from islpy import dim_type
 from loopy.diagnostic import LoopyError
 from loopy.kernel import LoopKernel
 from loopy.kernel.function_interface import CallableKernel
+from loopy.kernel.instruction import InstructionBase
 from loopy.symbolic import (
     RuleAwareIdentityMapper,
     RuleAwareSubstitutionMapper,
@@ -919,9 +920,13 @@ def duplicate_inames(kernel, inames, within, new_inames=None, suffix=None,
             old_to_new=dict(list(zip(inames, new_inames))),
             within=within)
 
-    def _does_access_old_inames(kernel, insn, *args):
-        return bool(frozenset(inames) & (insn.dependency_names()
-                                         | insn.reduction_inames()))
+    def _does_access_old_inames(kernel: LoopKernel,
+                                insn: InstructionBase,
+                                *args: Any) -> bool:
+        all_inames = (insn.within_inames
+                      | insn.reduction_inames()
+                      | insn.sub_array_ref_inames())
+        return bool(frozenset(inames) & all_inames)
 
     kernel = rule_mapping_context.finish_kernel(
             indup.map_kernel(kernel, within=_does_access_old_inames,


### PR DESCRIPTION
* Changed to update the inames of the instructions that do not access an inames, yet, are nested within the iname to be duplicated.
* Closes #859 