### PR TITLE
Cleanups 2024

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ Loopy: Transformation-Based Generation of High-Performance CPU/GPU Code
 .. image:: https://gitlab.tiker.net/inducer/loopy/badges/main/pipeline.svg
     :alt: Gitlab Build Status
     :target: https://gitlab.tiker.net/inducer/loopy/commits/main
-.. image:: https://github.com/inducer/loopy/workflows/CI/badge.svg?branch=main&event=push
+.. image:: https://github.com/inducer/loopy/workflows/CI/badge.svg?branch=main
     :alt: Github Build Status
-    :target: https://github.com/inducer/loopy/actions?query=branch%3Amain+workflow%3ACI+event%3Apush
+    :target: https://github.com/inducer/loopy/actions?query=branch%3Amain+workflow%3ACI
 .. image:: https://badge.fury.io/py/loopy.png
     :alt: Python Package Index Release Page
     :target: https://pypi.org/project/loopy/

--- a/doc/ref_internals.rst
+++ b/doc/ref_internals.rst
@@ -53,3 +53,7 @@ Schedule
 --------
 
 .. automodule:: loopy.schedule
+.. automodule:: loopy.schedule.tools
+.. automodule:: loopy.schedule.tree
+
+

--- a/doc/ref_kernel.rst
+++ b/doc/ref_kernel.rst
@@ -262,6 +262,7 @@ Instructions
 
 .. {{{
 
+.. autoclass:: HappensAfter
 .. autoclass:: InstructionBase
 
 .. _assignments:

--- a/doc/ref_other.rst
+++ b/doc/ref_other.rst
@@ -1,6 +1,11 @@
 Reference: Other Functionality
 ==============================
 
+Auxiliary Data Types
+--------------------
+
+.. automodule:: loopy.typing
+
 Obtaining Kernel Performance Statistics
 ---------------------------------------
 

--- a/examples/python/ispc-stream-harness.py
+++ b/examples/python/ispc-stream-harness.py
@@ -24,10 +24,7 @@ def transform(knl, vars, stream_dtype):
         knl, "i", 2**18, outer_tag="g.0", slabs=(0, 1))
     knl = lp.split_iname(knl, "i_inner", 8, inner_tag="l.0")
 
-    knl = lp.add_and_infer_dtypes(knl, {
-        var: stream_dtype
-        for var in vars
-        })
+    knl = lp.add_and_infer_dtypes(knl, dict.fromkeys(vars, stream_dtype))
 
     knl = lp.set_argument_order(knl, vars + ["n"])
 

--- a/loopy/__init__.py
+++ b/loopy/__init__.py
@@ -56,6 +56,7 @@ from loopy.kernel.instruction import (
     BarrierInstruction,
     CallInstruction,
     CInstruction,
+    HappensAfter,
     InstructionBase,
     LegacyStringInstructionTag,
     MemoryOrdering,
@@ -203,15 +204,9 @@ from loopy.transform.subst import (
     find_rules_matching,
 )
 from loopy.translation_unit import TranslationUnit, for_each_kernel, make_program
-
-# }}}
 from loopy.type_inference import infer_unknown_types
 from loopy.types import to_loopy_type
-
-# {{{ imported user interface
 from loopy.typing import auto
-
-# {{{ import transforms
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION, VERSION
 
 
@@ -242,6 +237,7 @@ __all__ = [
     "ExecutorBase",
     "GeneratedProgram",
     "GlobalArg",
+    "HappensAfter",
     "ISPCTarget",
     "ImageArg",
     "InKernelCallable",

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 import logging
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from functools import reduce
 from typing import List, Optional, Tuple, Union
 
@@ -43,7 +44,14 @@ from loopy.kernel.array import (
     FixedStrideArrayDimTag,
     SeparateArrayArrayDimTag,
 )
-from loopy.kernel.data import ArrayArg, ArrayDimImplementationTag, auto
+from loopy.kernel.data import (
+    AddressSpace,
+    ArrayArg,
+    ArrayDimImplementationTag,
+    InameImplementationTag,
+    TemporaryVariable,
+    auto,
+)
 from loopy.kernel.function_interface import CallableKernel
 from loopy.kernel.instruction import (
     CallInstruction,
@@ -52,10 +60,14 @@ from loopy.kernel.instruction import (
     NoOpInstruction,
     _DataObliviousInstruction,
 )
-from loopy.symbolic import CombineMapper, ResolvedFunction, WalkMapper
-from loopy.translation_unit import TranslationUnit, for_each_kernel
+from loopy.symbolic import CombineMapper, ResolvedFunction, SubArrayRef, WalkMapper
+from loopy.translation_unit import (
+    CallablesTable,
+    TranslationUnit,
+    check_each_kernel,
+)
 from loopy.type_inference import TypeReader
-from loopy.typing import ExpressionT
+from loopy.typing import ExpressionT, not_none
 
 
 logger = logging.getLogger(__name__)
@@ -145,8 +157,8 @@ class UnresolvedCallCollector(CombineMapper):
     map_nan = map_constant
 
 
-@for_each_kernel
-def check_functions_are_resolved(kernel):
+@check_each_kernel
+def check_functions_are_resolved(kernel: LoopKernel) -> None:
     """ Checks if all call nodes in the *kernel* expression have been
     resolved.
     """
@@ -167,7 +179,7 @@ def check_functions_are_resolved(kernel):
             raise NotImplementedError(type(insn))
 
 
-@for_each_kernel
+@check_each_kernel
 def check_separated_array_consistency(kernel: LoopKernel) -> None:
     # Boo. This is (part of) the price of redundant representation.
     for arg in kernel.args:
@@ -198,7 +210,7 @@ def check_separated_array_consistency(kernel: LoopKernel) -> None:
                                 f"'{sub_arg.name}' is not consistent.")
 
 
-@for_each_kernel
+@check_each_kernel
 def check_offsets_and_dim_tags(kernel: LoopKernel) -> None:
     from pymbolic.primitives import Expression, Variable
 
@@ -357,8 +369,8 @@ def check_for_integer_subscript_indices(t_unit):
             raise NotImplementedError(type(clbl).__name__)
 
 
-@for_each_kernel
-def check_sub_array_ref_inames_not_within_or_redn_inames(kernel):
+@check_each_kernel
+def check_sub_array_ref_inames_not_within_or_redn_inames(kernel: LoopKernel) -> None:
     all_within_inames = frozenset().union(*(insn.within_inames
                                             for insn in kernel.instructions))
     all_redn_inames = frozenset().union(*(insn.reduction_inames()
@@ -379,8 +391,8 @@ def check_sub_array_ref_inames_not_within_or_redn_inames(kernel):
                          " illegal.")
 
 
-@for_each_kernel
-def check_insn_attributes(kernel):
+@check_each_kernel
+def check_insn_attributes(kernel: LoopKernel) -> None:
     """
     Check for legality of attributes of every instruction in *kernel*.
     """
@@ -413,8 +425,8 @@ def check_insn_attributes(kernel):
                        ", ".join(no_sync_with_scopes - VALID_NOSYNC_SCOPES)))
 
 
-@for_each_kernel
-def check_for_duplicate_insn_ids(knl):
+@check_each_kernel
+def check_for_duplicate_insn_ids(knl: LoopKernel) -> None:
     """
     Check if multiple instructions of *knl* have the same
     :attr:`loopy.InstructionBase.id`.
@@ -429,8 +441,8 @@ def check_for_duplicate_insn_ids(knl):
         insn_ids.add(insn.id)
 
 
-@for_each_kernel
-def check_loop_priority_inames_known(kernel):
+@check_each_kernel
+def check_loop_priority_inames_known(kernel: LoopKernel) -> None:
     """
     Checks if the inames in :attr:`loopy.LoopKernel.loop_priority` are part of
     the *kernel*'s domain.
@@ -441,8 +453,8 @@ def check_loop_priority_inames_known(kernel):
                 raise LoopyError("unknown iname '%s' in loop priorities" % iname)
 
 
-@for_each_kernel
-def check_multiple_tags_allowed(kernel):
+@check_each_kernel
+def check_multiple_tags_allowed(kernel: LoopKernel) -> None:
     """
     Checks if a multiple tags of an iname are compatible.
     """
@@ -466,7 +478,10 @@ def check_multiple_tags_allowed(kernel):
                                  "tags: {}".format(iname.name, iname.tags))
 
 
-def _check_for_double_use_of_hw_axes_inner(kernel, callables_table):
+def _check_for_double_use_of_hw_axes_inner(
+            kernel: LoopKernel,
+            callables_table: CallablesTable
+        ) -> None:
     from loopy.kernel.data import GroupInameTag, LocalInameTag, UniqueInameTag
     from loopy.kernel.instruction import CallInstruction
     from loopy.symbolic import ResolvedFunction
@@ -490,7 +505,7 @@ def _check_for_double_use_of_hw_axes_inner(kernel, callables_table):
                 insn_tag_keys.add(key)
 
 
-def check_for_double_use_of_hw_axes(t_unit):
+def check_for_double_use_of_hw_axes(t_unit: TranslationUnit) -> None:
     """
     Check if any instruction of *kernel* is within multiple inames tagged with
     the same hw axis tag.
@@ -506,8 +521,8 @@ def check_for_double_use_of_hw_axes(t_unit):
             raise NotImplementedError(type(clbl).__name__)
 
 
-@for_each_kernel
-def check_for_inactive_iname_access(kernel):
+@check_each_kernel
+def check_for_inactive_iname_access(kernel: LoopKernel) -> None:
     """
     Check if any instruction accesses an iname but is not within it.
     """
@@ -524,8 +539,8 @@ def check_for_inactive_iname_access(kernel):
                                   - insn.within_inames), kernel.name))
 
 
-@for_each_kernel
-def check_for_unused_inames(kernel):
+@check_each_kernel
+def check_for_unused_inames(kernel: LoopKernel) -> None:
     """
     Check if there are any unused inames in the kernel.
     """
@@ -541,7 +556,7 @@ def check_for_unused_inames(kernel):
             % unused_inames)
 
 
-def _is_racing_iname_tag(tv, tag):
+def _is_racing_iname_tag(tv: TemporaryVariable, tag: InameImplementationTag) -> bool:
     from loopy.kernel.data import (
         AddressSpace,
         ConcurrentTag,
@@ -572,8 +587,8 @@ def _is_racing_iname_tag(tv, tag):
                 "temporary variable '%s'" % tv.name)
 
 
-@for_each_kernel
-def check_for_write_races(kernel):
+@check_each_kernel
+def check_for_write_races(kernel: LoopKernel) -> None:
     """
     Check if any memory accesses lead to write races.
     """
@@ -621,8 +636,8 @@ def check_for_write_races(kernel):
                         WriteRaceConditionWarning)
 
 
-@for_each_kernel
-def check_for_data_dependent_parallel_bounds(kernel):
+@check_each_kernel
+def check_for_data_dependent_parallel_bounds(kernel: LoopKernel) -> None:
     """
     Check that inames tagged as hw axes have bounds that are known at kernel
     launch.
@@ -849,7 +864,7 @@ class _AccessCheckMapper(WalkMapper):
             _check_bounds_inner_rec(subkernel, self.callables_table)
 
 
-def _check_bounds_inner(kernel, callables_table):
+def _check_bounds_inner(kernel: LoopKernel, callables_table: CallablesTable) -> None:
     from loopy.kernel.instruction import get_insn_domain
 
     temp_var_names = set(kernel.temporary_variables)
@@ -875,7 +890,10 @@ def _check_bounds_inner(kernel, callables_table):
         insn.with_transformed_expressions(run_acm)
 
 
-def _check_bounds_inner_rec(kernel, callables_table):
+def _check_bounds_inner_rec(
+            kernel: LoopKernel,
+            callables_table: CallablesTable
+        ) -> None:
     if kernel.options.enforce_array_accesses_within_bounds not in [
             "no_check",
             True,
@@ -900,7 +918,7 @@ def _check_bounds_inner_rec(kernel, callables_table):
                 warn_with_kernel(kernel, "array_access_out_of_bounds", str(e))
 
 
-def check_bounds(t_unit):
+def check_bounds(t_unit: TranslationUnit) -> None:
     """
     Performs out-of-bound check for every array access.
     """
@@ -913,8 +931,8 @@ def check_bounds(t_unit):
 
 # {{{ check write destinations
 
-@for_each_kernel
-def check_write_destinations(kernel):
+@check_each_kernel
+def check_write_destinations(kernel: LoopKernel) -> None:
     for insn in kernel.instructions:
         for wvar in insn.assignee_var_names():
             if wvar in kernel.all_inames():
@@ -941,8 +959,8 @@ def check_write_destinations(kernel):
 
 # {{{ check_has_schedulable_iname_nesting
 
-@for_each_kernel
-def check_has_schedulable_iname_nesting(kernel):
+@check_each_kernel
+def check_has_schedulable_iname_nesting(kernel: LoopKernel) -> None:
     from loopy.transform.iname import (
         get_iname_duplication_options,
         has_schedulable_iname_nesting,
@@ -989,8 +1007,8 @@ def declares_nosync_with(kernel, var_address_space, dep_a, dep_b):
     return ab_nosync and ba_nosync
 
 
-def _get_address_space(kernel, var):
-    from loopy.kernel.data import AddressSpace, ArrayArg, ValueArg
+def _get_address_space(kernel: LoopKernel, var: str) -> AddressSpace | type[auto]:
+    from loopy.kernel.data import ArrayArg, ValueArg
     if var in kernel.temporary_variables:
         address_space = kernel.temporary_variables[var].address_space
     else:
@@ -1006,7 +1024,7 @@ def _get_address_space(kernel, var):
     return address_space
 
 
-def _get_topological_order(kernel):
+def _get_topological_order(kernel: LoopKernel) -> Sequence[str]:
     """
     Returns a :class:`list` of insn ids of *kernel* in a topological sort
     order.
@@ -1034,7 +1052,7 @@ def _get_topological_order(kernel):
     return order
 
 
-def _check_variable_access_ordered_inner(kernel):
+def _check_variable_access_ordered_inner(kernel: LoopKernel) -> None:
     from loopy.kernel.tools import find_aliasing_equivalence_classes
     from loopy.symbolic import AccessRangeOverlapChecker
     overlap_checker = AccessRangeOverlapChecker(kernel)
@@ -1051,7 +1069,7 @@ def _check_variable_access_ordered_inner(kernel):
     # the mapping in both directions.
     #
     # Note: This can be worst-case O(n^2) in the number of instructions.
-    dep_reqs_to_vars = {}
+    dep_reqs_to_vars: dict[tuple[str, str], set[str]] = {}
 
     wmap = kernel.writer_map()
     rmap = kernel.reader_map()
@@ -1082,14 +1100,16 @@ def _check_variable_access_ordered_inner(kernel):
     # {{{ compute rev_depends, depends_on
 
     # depends_on: mapping from insn_ids to their dependencies
-    depends_on = {insn.id: set() for insn in kernel.instructions}
+    depends_on: dict[str, set[str]] = {
+        not_none(insn.id): set() for insn in kernel.instructions}
     # rev_depends: mapping from insn_ids to their reverse deps.
-    rev_depends = {insn.id: set() for insn in kernel.instructions}
+    rev_depends: dict[str, set[str]] = {
+        not_none(insn.id): set() for insn in kernel.instructions}
 
     for insn in kernel.instructions:
-        depends_on[insn.id].update(insn.depends_on)
+        depends_on[not_none(insn.id)].update(insn.depends_on)
         for dep in insn.depends_on:
-            rev_depends[dep].add(insn.id)
+            rev_depends[dep].add(not_none(insn.id))
 
     # }}}
 
@@ -1097,7 +1117,8 @@ def _check_variable_access_ordered_inner(kernel):
 
     topological_order = _get_topological_order(kernel)
 
-    def satisfy_dep_reqs_in_order(dep_reqs_to_vars, edges, order):
+    # TODO: Type this
+    def satisfy_dep_reqs_in_order(dep_reqs_to_vars, edges, order) -> None:
         """
         Considering a graph defined by *edges* (as ``key -> value``),
         remove pairs of nodes from *dep_reqs_to_vars* for which edges
@@ -1215,8 +1236,8 @@ def _check_variable_access_ordered_inner(kernel):
     # }}}
 
 
-@for_each_kernel
-def check_variable_access_ordered(kernel):
+@check_each_kernel
+def check_variable_access_ordered(kernel: LoopKernel) -> None:
     """Checks that between each write to a variable and all other accesses to
     the variable there is either:
 
@@ -1253,7 +1274,7 @@ def check_variable_access_ordered(kernel):
 # }}}
 
 
-def pre_schedule_checks(t_unit):
+def pre_schedule_checks(t_unit: TranslationUnit) -> None:
     try:
         logger.debug("pre-schedule checks start for entrypoints: "
                      f"{t_unit.entrypoints}.")
@@ -1331,8 +1352,11 @@ def check_for_nested_base_storage(kernel: LoopKernel) -> None:
 
 # {{{ check for unused hw axes
 
-def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
-        sched_index=None):
+def _check_for_unused_hw_axes_in_kernel_chunk(
+            kernel: LoopKernel,
+            callables_table: CallablesTable,
+            sched_index: int | None = None
+        ) -> int:
     from loopy.schedule import (
         Barrier,
         CallKernel,
@@ -1343,6 +1367,7 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
         gather_schedule_block,
         get_insn_ids_for_block_at,
     )
+    assert kernel.linearization is not None
 
     if sched_index is None:
         group_axes = set()
@@ -1443,7 +1468,10 @@ def _check_for_unused_hw_axes_in_kernel_chunk(kernel, callables_table,
     return past_end_i
 
 
-def check_for_unused_hw_axes_in_insns(kernel, callables_table):
+def check_for_unused_hw_axes_in_insns(
+            kernel: LoopKernel,
+            callables_table: CallablesTable
+        ) -> None:
     if kernel.linearization:
         _check_for_unused_hw_axes_in_kernel_chunk(kernel,
                 callables_table)
@@ -1453,7 +1481,9 @@ def check_for_unused_hw_axes_in_insns(kernel, callables_table):
 
 # {{{ check that atomic ops are used exactly on atomic arrays
 
-def check_that_atomic_ops_are_used_exactly_on_atomic_arrays(kernel):
+def check_that_atomic_ops_are_used_exactly_on_atomic_arrays(
+            kernel: LoopKernel
+        ) -> None:
     from loopy.kernel.data import ArrayBase, Assignment
     from loopy.types import AtomicType
     atomicity_candidates = (
@@ -1488,7 +1518,9 @@ def check_that_atomic_ops_are_used_exactly_on_atomic_arrays(kernel):
 
 # {{{ check that temporaries are defined in subkernels where used
 
-def check_that_temporaries_are_defined_in_subkernels_where_used(kernel):
+def check_that_temporaries_are_defined_in_subkernels_where_used(
+            kernel: LoopKernel
+        ) -> None:
     from loopy.kernel.data import AddressSpace
     from loopy.kernel.tools import get_subkernels
 
@@ -1541,9 +1573,10 @@ def check_that_temporaries_are_defined_in_subkernels_where_used(kernel):
 
 # {{{ check that all instructions are scheduled
 
-def check_that_all_insns_are_scheduled(kernel):
+def check_that_all_insns_are_scheduled(kernel: LoopKernel) -> None:
+    assert kernel.linearization is not None
 
-    all_schedulable_insns = {insn.id for insn in kernel.instructions}
+    all_schedulable_insns = {not_none(insn.id) for insn in kernel.instructions}
     from loopy.schedule import sched_item_to_insn_id
     scheduled_insns = {
         insn_id
@@ -1563,7 +1596,7 @@ def check_that_all_insns_are_scheduled(kernel):
 
 # {{{ check that shapes and strides are arguments
 
-def check_that_shapes_and_strides_are_arguments(kernel):
+def check_that_shapes_and_strides_are_arguments(kernel: LoopKernel) -> None:
     import loopy as lp
     from loopy.kernel.array import ArrayBase, FixedStrideArrayDimTag
     from loopy.kernel.data import ValueArg
@@ -1573,12 +1606,12 @@ def check_that_shapes_and_strides_are_arguments(kernel):
             arg.name
             for arg in kernel.args
             if isinstance(arg, ValueArg)
-            and arg.dtype.is_integral()}
+            and not_none(arg.dtype).is_integral()}
 
     for arg in kernel.args:
         if isinstance(arg, ArrayBase):
             if isinstance(arg.shape, tuple):
-                shape_deps = set()
+                shape_deps: set[str] = set()
                 for shape_axis in arg.shape:
                     if shape_axis is not None:
                         shape_deps.update(get_dependencies(shape_axis))
@@ -1607,14 +1640,21 @@ def check_that_shapes_and_strides_are_arguments(kernel):
 
 # {{{ validate_kernel_call_sites
 
-def _get_sub_array_ref_swept_range(kernel, sar):
+def _get_sub_array_ref_swept_range(
+            kernel: LoopKernel,
+            sar: SubArrayRef
+        ) -> isl.Set:
     from loopy.symbolic import get_access_map
     domain = kernel.get_inames_domain(frozenset({iname_var.name
                                                  for iname_var in sar.swept_inames}))
     return get_access_map(domain, sar.swept_inames, kernel.assumptions).range()
 
 
-def _are_sub_array_refs_equivalent(sar1, sar2, caller):
+def _are_sub_array_refs_equivalent(
+            sar1: SubArrayRef,
+            sar2: SubArrayRef,
+            caller: LoopKernel
+        ) -> bool:
     """
     Returns *True* iff *sar1* and *sar2* are equivalent
     :class:`loopy.SubArrayRef`s.
@@ -1657,7 +1697,11 @@ def _are_sub_array_refs_equivalent(sar1, sar2, caller):
     return True
 
 
-def _validate_kernel_call_insn(caller, call_insn, callee):
+def _validate_kernel_call_insn(
+            caller: LoopKernel,
+            call_insn: CallInstruction,
+            callee: LoopKernel
+        ) -> None:
     assert call_insn.expression.function.name == callee.name
     from loopy.kernel.array import ArrayBase
     from loopy.symbolic import SubArrayRef
@@ -1707,7 +1751,10 @@ def _validate_kernel_call_insn(caller, call_insn, callee):
                                  f" (got {in_val}, {out_val}).")
 
 
-def _validate_kernel_call_sites_inner(kernel, callables):
+def _validate_kernel_call_sites_inner(
+            kernel: LoopKernel,
+            callables: CallablesTable,
+        ) -> None:
     from pymbolic.primitives import Call
 
     from loopy.kernel.function_interface import CallableKernel
@@ -1739,8 +1786,10 @@ def validate_kernel_call_sites(translation_unit: TranslationUnit) -> None:
 
 # {{{ check_all_callees_have_same_index_dtype
 
-def check_all_callees_have_same_index_dtype(epoint: LoopKernel,
-                                            callables_table):
+def check_all_callees_have_same_index_dtype(
+            epoint: LoopKernel,
+            callables_table: CallablesTable
+        ) -> None:
     from loopy.kernel.function_interface import CallableKernel
 
     epoint_clbl = callables_table[epoint.name]
@@ -1757,7 +1806,10 @@ def check_all_callees_have_same_index_dtype(epoint: LoopKernel,
 # }}}
 
 
-def pre_codegen_entrypoint_checks(kernel, callables_table):
+def pre_codegen_entrypoint_checks(
+            kernel: LoopKernel,
+            callables_table: CallablesTable
+        ) -> None:
     logger.debug("pre-codegen entrypoint check %s: start" % kernel.name)
 
     kernel.target.pre_codegen_entrypoint_check(kernel, callables_table)
@@ -1780,7 +1832,7 @@ def pre_codegen_callable_checks(kernel, callables_table):
     logger.debug("pre-codegen callable check %s: done" % kernel.name)
 
 
-def pre_codegen_checks(t_unit):
+def pre_codegen_checks(t_unit: TranslationUnit) -> None:
     from loopy.kernel.function_interface import CallableKernel
 
     try:
@@ -1803,7 +1855,11 @@ def pre_codegen_checks(t_unit):
 
 # {{{ sanity-check for implemented domains of each instruction
 
-def check_implemented_domains(kernel, implemented_domains, code=None):
+def check_implemented_domains(
+            kernel: LoopKernel,
+            implemented_domains: Mapping[str, isl.Set],
+            code: str | None = None,
+        ) -> bool:
     from islpy import align_two, dim_type
 
     last_idomains = None

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -44,6 +44,7 @@ from loopy.kernel.array import (
     SeparateArrayArrayDimTag,
 )
 from loopy.kernel.data import ArrayArg, ArrayDimImplementationTag, auto
+from loopy.kernel.function_interface import CallableKernel
 from loopy.kernel.instruction import (
     CallInstruction,
     CInstruction,
@@ -52,7 +53,7 @@ from loopy.kernel.instruction import (
     _DataObliviousInstruction,
 )
 from loopy.symbolic import CombineMapper, ResolvedFunction, WalkMapper
-from loopy.translation_unit import for_each_kernel
+from loopy.translation_unit import TranslationUnit, for_each_kernel
 from loopy.type_inference import TypeReader
 from loopy.typing import ExpressionT
 
@@ -1725,11 +1726,12 @@ def _validate_kernel_call_sites_inner(kernel, callables):
             raise NotImplementedError(type(insn))
 
 
-def validate_kernel_call_sites(translation_unit):
+def validate_kernel_call_sites(translation_unit: TranslationUnit) -> None:
     for name in translation_unit.callables_table:
-        clbl = translation_unit[name]
-        if isinstance(clbl, LoopKernel):
-            _validate_kernel_call_sites_inner(clbl, translation_unit.callables_table)
+        clbl = translation_unit.callables_table[name]
+        if isinstance(clbl, CallableKernel):
+            _validate_kernel_call_sites_inner(
+                  clbl.subkernel, translation_unit.callables_table)
 
 
 # }}}

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -274,11 +274,11 @@ class LoopKernel(Taggable):
                 | {arg.name for arg in self.args}
                 | set(self.all_inames()))
 
-    def get_var_name_generator(self):
+    def get_var_name_generator(self) -> UniqueNameGenerator:
         return UniqueNameGenerator(self.all_variable_names())
 
-    def get_instruction_id_generator(self, based_on="insn"):
-        used_ids = {insn.id for insn in self.instructions}
+    def get_instruction_id_generator(self, based_on="insn") -> UniqueNameGenerator:
+        used_ids = {insn.id for insn in self.instructions if insn.id is not None}
 
         return UniqueNameGenerator(used_ids)
 

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -74,7 +74,7 @@ from loopy.schedule import ScheduleItem
 from loopy.target import TargetBase
 from loopy.tools import update_persistent_hash
 from loopy.types import LoopyType, NumpyType
-from loopy.typing import ExpressionT
+from loopy.typing import ExpressionT, InameStr
 
 
 if TYPE_CHECKING:
@@ -117,82 +117,25 @@ class LoopKernel(Taggable):
         even if it contains mutable data types. See :meth:`copy` for an easy
         way of producing a modified copy.
 
-    .. attribute:: domains
-
-        a list of :class:`islpy.BasicSet` instances representing the
-        :ref:`domain-tree`.
-
-    .. attribute:: instructions
-
-        A list of :class:`InstructionBase` instances, e.g.
-        :class:`Assignment`. See :ref:`instructions`.
-
-    .. attribute:: args
-
-        A list of :class:`loopy.KernelArgument`
-
-    .. attribute:: schedule
-
-        *None* or a list of :class:`loopy.schedule.ScheduleItem`
-
-    .. attribute:: name
-    .. attribute:: preambles
-    .. attribute:: preamble_generators
-    .. attribute:: assumptions
-
-        A :class:`islpy.BasicSet` parameter domain.
-
-    .. attribute:: temporary_variables
-
-        A :class:`dict` of mapping variable names to
-        :class:`loopy.TemporaryVariable`
-        instances.
-
-    .. attribute:: symbol_manglers
-
-    .. attribute:: substitutions
-
-        a mapping from substitution names to
-        :class:`SubstitutionRule` objects
-
-    .. attribute:: iname_slab_increments
-
-        a dictionary mapping inames to (lower_incr,
-        upper_incr) tuples that will be separated out in the execution to generate
-        'bulk' slabs with fewer conditionals.
-
-    .. attribute:: loop_priority
-
-        A frozenset of priority constraints to the kernel. Each such constraint
-        is a tuple of inames. Inames occurring in such a tuple will be scheduled
-        earlier than any iname following in the tuple. This applies only to inames
-        with non-parallel implementation tags.
-
-    .. attribute:: silenced_warnings
-
-    .. attribute:: applied_iname_rewrites
-
-        A list of past substitution dictionaries that
-        were applied to the kernel. These are stored so that they may be repeated
-        on expressions the user specifies later.
-
-    .. attribute:: options
-
-        An instance of :class:`loopy.Options`
-
-    .. attribute:: state
-
-        A value from :class:`KernelState`.
-
-    .. attribute:: target
-
-        A subclass of :class:`loopy.TargetBase`.
-
-    .. attribute:: inames
-
-        An instance of :class:`dict`, a mapping from the names of kernel's
-        inames to their corresponding instances of :class:`loopy.kernel.data.Iname`.
-        An entry is guaranteed to be present for each iname.
+    .. autoattribute:: domains
+    .. autoattribute:: instructions
+    .. autoattribute:: args
+    .. autoattribute:: schedule
+    .. autoattribute:: name
+    .. autoattribute:: preambles
+    .. autoattribute:: preamble_generators
+    .. autoattribute:: assumptions
+    .. autoattribute:: temporary_variables
+    .. autoattribute:: symbol_manglers
+    .. autoattribute:: substitutions
+    .. autoattribute:: iname_slab_increments
+    .. autoattribute:: loop_priority
+    .. autoattribute:: silenced_warnings
+    .. autoattribute:: applied_iname_rewrites
+    .. autoattribute:: options
+    .. autoattribute:: state
+    .. autoattribute:: target
+    .. autoattribute:: inames
 
     .. automethod:: __call__
     .. automethod:: copy
@@ -201,11 +144,25 @@ class LoopKernel(Taggable):
     .. automethod:: without_tags
     """
     domains: Sequence[isl.BasicSet]
+    """Represents the :ref:`domain-tree`."""
+
     instructions: Sequence[InstructionBase]
+    """
+    See :ref:`instructions`.
+    """
+
     args: Sequence[KernelArgument]
     assumptions: isl.BasicSet
+    """
+    Must be a :class:`islpy.BasicSet` parameter domain.
+    """
+
     temporary_variables: Mapping[str, TemporaryVariable]
-    inames: Mapping[str, Iname]
+    inames: Mapping[InameStr, Iname]
+    """
+    An entry is guaranteed to be present for each iname.
+    """
+
     substitutions: Mapping[str, SubstitutionRule]
     options: Options
     target: TargetBase
@@ -218,11 +175,29 @@ class LoopKernel(Taggable):
     symbol_manglers: Sequence[
             Callable[["LoopKernel", str], Optional[Tuple[LoopyType, str]]]] = ()
     linearization: Optional[Sequence[ScheduleItem]] = None
-    iname_slab_increments: Mapping[str, Tuple[int, int]] = field(
+    iname_slab_increments: Mapping[InameStr, Tuple[int, int]] = field(
             default_factory=Map)
-    loop_priority: FrozenSet[Tuple[str]] = field(
+    """
+    A mapping from inames to (lower_incr,
+    upper_incr) tuples that will be separated out in the execution to generate
+    'bulk' slabs with fewer conditionals.
+    """
+
+    loop_priority: FrozenSet[Tuple[InameStr, ...]] = field(
             default_factory=frozenset)
-    applied_iname_rewrites: Tuple[Dict[str, ExpressionT], ...] = ()
+    """
+    A frozenset of priority constraints to the kernel. Each such constraint
+    is a tuple of inames. Inames occurring in such a tuple will be scheduled
+    earlier than any iname following in the tuple. This applies only to inames
+    with non-parallel implementation tags.
+    """
+
+    applied_iname_rewrites: Tuple[Dict[InameStr, ExpressionT], ...] = ()
+    """
+    A list of past substitution dictionaries that
+    were applied to the kernel. These are stored so that they may be repeated
+    on expressions the user specifies later.
+    """
     index_dtype: NumpyType = NumpyType(np.dtype(np.int32))
     silenced_warnings: FrozenSet[str] = frozenset()
 

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -620,88 +620,14 @@ def _parse_shape_or_strides(x):
 
 class ArrayBase(ImmutableRecord, Taggable):
     """
-    .. attribute :: name
-
-    .. attribute :: dtype
-
-        The :class:`loopy.types.LoopyType` of the array. If this is *None*,
-        :mod:`loopy` will try to continue without knowing the type of this
-        array, where the idea is that precise knowledge of the type will become
-        available at invocation time.  Calling the kernel
-        (via :meth:`loopy.LoopKernel.__call__`)
-        automatically adds this type information based on invocation arguments.
-
-        Note that some transformations, such as :func:`loopy.add_padding`
-        cannot be performed without knowledge of the exact *dtype*.
-
-    .. attribute :: shape
-
-        May be one of the following:
-
-        * *None*. In this case, no shape is intended to be specified,
-          only the strides will be used to access the array. Bounds checking
-          will not be performed.
-
-        * :class:`loopy.auto`. The shape will be determined by finding the
-          access footprint.
-
-        * a tuple like like :attr:`numpy.ndarray.shape`.
-
-          Each entry of the tuple is also allowed to be a :mod:`pymbolic`
-          expression involving kernel parameters, or a (potentially-comma
-          separated) or a string that can be parsed to such an expression.
-
-          Any element of the shape tuple not used to compute strides
-          may be *None*.
-
-    .. attribute:: dim_tags
-
-        See :ref:`data-dim-tags`.
-
-    .. attribute:: offset
-
-        Offset from the beginning of the buffer to the point from
-        which the strides are counted, in units of the :attr:`dtype`.
-        May be one of
-
-            * 0 or None
-            * a string (that is interpreted as an argument name).
-            * a pymbolic expression
-            * :class:`loopy.auto`, in which case an offset argument
-              is added automatically, immediately following this argument.
-
-    .. attribute:: dim_names
-
-        A tuple of strings providing names for the array axes, or *None*.
-        If given, must have the same number of entries as :attr:`dim_tags`
-        and :attr:`dim_tags`. These do not live in any particular namespace
-        (i.e. collide with no other names) and serve a purely
-        informational/documentational purpose. On occasion, they are used
-        to generate more informative names than could be achieved by
-        axis numbers.
-
-    .. attribute:: alignment
-
-        Memory alignment of the array in bytes. For temporary arrays,
-        this ensures they are allocated with this alignment. For arguments,
-        this entails a promise that the incoming array obeys this alignment
-        restriction.
-
-        Defaults to *None*.
-
-        If an integer N is given, the array would be declared
-        with ``__attribute__((aligned(N)))`` in code generation for
-        :class:`loopy.CFamilyTarget`.
-
-        .. versionadded:: 2018.1
-
-    .. attribute:: tags
-
-        A (possibly empty) frozenset of instances of
-        :class:`pytools.tag.Tag` intended for
-        consumption by an application.
-
-        .. versionadded:: 2020.2.2
+    .. autoattribute:: name
+    .. autoattribute:: dtype
+    .. autoattribute:: shape
+    .. autoattribute:: dim_tags
+    .. autoattribute:: offset
+    .. autoattribute:: dim_names
+    .. autoattribute:: alignment
+    .. autoattribute:: tags
 
     .. automethod:: __init__
     .. automethod:: __eq__
@@ -712,13 +638,88 @@ class ArrayBase(ImmutableRecord, Taggable):
     (supports persistent hashing)
     """
     name: str
+
     dtype: Optional[LoopyType]
+    """The :class:`loopy.types.LoopyType` of the array. If this is *None*,
+    :mod:`loopy` will try to continue without knowing the type of this
+    array, where the idea is that precise knowledge of the type will become
+    available at invocation time.  Calling the kernel
+    (via :meth:`loopy.LoopKernel.__call__`)
+    automatically adds this type information based on invocation arguments.
+
+    Note that some transformations, such as :func:`loopy.add_padding`
+    cannot be performed without knowledge of the exact *dtype*.
+    """
+
     shape: Union[ShapeType, Type["auto"], None]
+    """
+    May be one of the following:
+
+    * *None*. In this case, no shape is intended to be specified,
+      only the strides will be used to access the array. Bounds checking
+      will not be performed.
+
+    * :class:`loopy.auto`. The shape will be determined by finding the
+      access footprint.
+
+    * a tuple like like :attr:`numpy.ndarray.shape`.
+
+      Each entry of the tuple is also allowed to be a :mod:`pymbolic`
+      expression involving kernel parameters, or a (potentially-comma
+      separated) or a string that can be parsed to such an expression.
+
+      Any element of the shape tuple not used to compute strides
+      may be *None*.
+      """
+
     dim_tags: Optional[Sequence[ArrayDimImplementationTag]]
+    """See :ref:`data-dim-tags`.
+    """
+
     offset: Union[ExpressionT, str, None]
+    """Offset from the beginning of the buffer to the point from
+    which the strides are counted, in units of the :attr:`dtype`.
+    May be one of
+
+    * 0 or None
+    * a string (that is interpreted as an argument name).
+    * a pymbolic expression
+    * :class:`loopy.auto`, in which case an offset argument
+      is added automatically, immediately following this argument.
+    """
+
     dim_names: Optional[Tuple[str, ...]]
+    """A tuple of strings providing names for the array axes, or *None*.
+    If given, must have the same number of entries as :attr:`dim_tags`
+    and :attr:`dim_tags`. These do not live in any particular namespace
+    (i.e. collide with no other names) and serve a purely
+    informational/documentational purpose. On occasion, they are used
+    to generate more informative names than could be achieved by
+    axis numbers.
+    """
+
     alignment: Optional[int]
+    """Memory alignment of the array in bytes. For temporary arrays,
+    this ensures they are allocated with this alignment. For arguments,
+    this entails a promise that the incoming array obeys this alignment
+    restriction.
+
+    Defaults to *None*.
+
+    If an integer N is given, the array would be declared
+    with ``__attribute__((aligned(N)))`` in code generation for
+    :class:`loopy.CFamilyTarget`.
+
+    .. versionadded:: 2018.1
+    """
+
     tags: FrozenSet[Tag]
+    """A (possibly empty) frozenset of instances of
+    :class:`pytools.tag.Tag` intended for
+    consumption by an application.
+
+    .. versionadded:: 2020.2.2
+    """
 
     # Note that order may also wind up in attributes, if the
     # number of dimensions has not yet been determined.

--- a/loopy/kernel/array.py
+++ b/loopy/kernel/array.py
@@ -1,5 +1,3 @@
-"""Implementation tagging of array axes."""
-
 from __future__ import annotations
 
 
@@ -70,8 +68,6 @@ T = TypeVar("T")
 
 
 __doc__ = """
-.. currentmodule:: loopy.kernel.array
-
 .. autoclass:: ArrayDimImplementationTag
 
 .. autoclass:: _StrideArrayDimTagBase
@@ -85,6 +81,23 @@ __doc__ = """
 .. autoclass:: VectorArrayDimTag
 
 .. autofunction:: parse_array_dim_tags
+
+Cross-references
+----------------
+
+(This section shouldn't exist: Sphinx should be able to resolve these on its own.)
+
+.. class:: ShapeType
+
+    See :class:`loopy.typing.ShapeType`
+
+.. class:: ExpressionT
+
+    See :class:`loopy.typing.ExpressionT`
+
+.. class:: Tag
+
+    See :class:`pytools.tag.Tag`
 """
 
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -26,6 +26,7 @@ THE SOFTWARE.
 import logging
 import re
 from sys import intern
+from typing import Any
 
 import numpy as np
 
@@ -48,7 +49,7 @@ from loopy.kernel.data import (
 )
 from loopy.symbolic import IdentityMapper, SubArrayRef, WalkMapper
 from loopy.tools import Optional, intern_frozenset_of_ids
-from loopy.translation_unit import for_each_kernel
+from loopy.translation_unit import TranslationUnit, for_each_kernel
 
 
 logger = logging.getLogger(__name__)
@@ -2614,7 +2615,7 @@ def make_function(domains, instructions, kernel_data=None, **kwargs):
 
 # {{{ make_kernel
 
-def make_kernel(*args, **kwargs):
+def make_kernel(*args: Any, **kwargs: Any) -> TranslationUnit:
     tunit = make_function(*args, **kwargs)
     name, = tunit.callables_table
     return tunit.with_entrypoints(name)

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -632,48 +632,42 @@ class ValueArg(KernelArgument, Taggable):
 
 class TemporaryVariable(ArrayBase):
     __doc__ = cast(str, ArrayBase.__doc__) + """
-    .. attribute:: storage_shape
-    .. attribute:: base_indices
-    .. attribute:: address_space
-
-        What memory this temporary variable lives in.
-        One of the values in :class:`AddressSpace`,
-        or :class:`loopy.auto` if this is
-        to be automatically determined.
-
-    .. attribute:: base_storage
-
-        The name of a storage array that is to be used to actually
-        hold the data in this temporary, or *None*. If not *None* or the name
-        of an existing variable, a variable of this name and appropriate size
-        will be created.
-
-    .. attribute:: initializer
-
-        *None* or a :class:`numpy.ndarray` of data to be used to initialize the
-        array.
-
-    .. attribute:: read_only
-
-        A :class:`bool` indicating whether the variable may be written during
-        its lifetime. If *True*, *initializer* must be given.
-
-    .. attribute:: _base_storage_access_may_be_aliasing
-
-        Whether the temporary is used to alias the underlying base storage.
-        Defaults to *False*. If *False*, C-based code generators will declare
-        the temporary as a ``restrict`` const pointer to the base storage
-        memory location. If *True*, the restrict part is omitted on this
-        declaration.
+    .. autoattribute:: storage_shape
+    .. autoattribute:: base_indices
+    .. autoattribute:: address_space
+    .. autoattribute:: base_storage
+    .. autoattribute:: initializer
+    .. autoattribute:: read_only
+    .. autoattribute:: _base_storage_access_may_be_aliasing
     """
 
     storage_shape: Optional[ShapeType]
     base_indices: Optional[Tuple[ExpressionT, ...]]
     address_space: Union[AddressSpace, Type[auto]]
     base_storage: Optional[str]
+    """The name of a storage array that is to be used to actually
+    hold the data in this temporary, or *None*. If not *None* or the name
+    of an existing variable, a variable of this name and appropriate size
+    will be created.
+    """
+
     initializer: Optional[np.ndarray]
+    """*None* or a :class:`numpy.ndarray` of data to be used to initialize the
+    array.
+    """
+
     read_only: bool
+    """A :class:`bool` indicating whether the variable may be written during
+    its lifetime. If *True*, *initializer* must be given.
+    """
+
     _base_storage_access_may_be_aliasing: bool
+    """Whether the temporary is used to alias the underlying base storage.
+    Defaults to *False*. If *False*, C-based code generators will declare
+    the temporary as a ``restrict`` const pointer to the base storage
+    memory location. If *True*, the restrict part is omitted on this
+    declaration.
+    """
 
     min_target_axes: ClassVar[int] = 0
     max_target_axes: ClassVar[int] = 1

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -579,15 +579,6 @@ class ImageArg(ArrayBase, KernelArgument):
                 )
 
 
-"""
-    :attribute tags: A (possibly empty) frozenset of instances of
-        :class:`pytools.tag.Tag` intended for consumption by an
-        application.
-
-        ..versionadded: 2020.2.2
-"""
-
-
 class ValueArg(KernelArgument, Taggable):
     def __init__(self, name, dtype=None, approximately=1000, target=None,
             is_output=False, is_input=True, tags=None):

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -862,34 +862,26 @@ class TemporaryVariable(ArrayBase):
 
 # {{{ substitution rule
 
-class SubstitutionRule(ImmutableRecord):
+@dataclass(frozen=True)
+class SubstitutionRule:
     """
-    .. attribute:: name
-    .. attribute:: arguments
-
-        A tuple of strings
-
-    .. attribute:: expression
+    .. autoattribute:: name
+    .. autoattribute:: arguments
+    .. autoattribute:: expression
     """
 
-    def __init__(self, name, arguments, expression):
-        assert isinstance(arguments, tuple)
+    name: str
+    arguments: Sequence[str]
+    expression: ExpressionT
 
-        ImmutableRecord.__init__(self,
-                name=name, arguments=arguments, expression=expression)
-
-    def __str__(self):
-        return "{}({}) := {}".format(
-                self.name, ", ".join(self.arguments), self.expression)
+    def copy(self, **kwargs: Any) -> SubstitutionRule:
+        return replace(self, **kwargs)
 
     def update_persistent_hash(self, key_hash, key_builder):
-        """Custom hash computation function for use with
-        :class:`pytools.persistent_dict.PersistentDict`.
-        """
-
         key_builder.rec(key_hash, self.name)
         key_builder.rec(key_hash, self.arguments)
         key_builder.update_for_pymbolic_expression(key_hash, self.expression)
+
 
 # }}}
 

--- a/loopy/kernel/data.py
+++ b/loopy/kernel/data.py
@@ -41,7 +41,8 @@ from typing import (
     cast,
 )
 
-import numpy as np  # noqa
+import numpy  # FIXME: imported as numpy to allow sphinx to resolve things
+import numpy as np
 from immutables import Map
 
 from pytools import ImmutableRecord
@@ -651,7 +652,7 @@ class TemporaryVariable(ArrayBase):
     will be created.
     """
 
-    initializer: Optional[np.ndarray]
+    initializer: Optional[numpy.ndarray]
     """*None* or a :class:`numpy.ndarray` of data to be used to initialize the
     array.
     """

--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -20,10 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from collections.abc import Set as abc_Set
+from collections.abc import Mapping as MappingABC, Set as abc_Set
+from dataclasses import dataclass
 from functools import cached_property
 from sys import intern
-from typing import FrozenSet
+from typing import FrozenSet, Mapping, Optional, Tuple, Type, Union
 from warnings import warn
 
 import islpy as isl
@@ -31,7 +32,8 @@ from pytools import ImmutableRecord, memoize_method
 from pytools.tag import Tag, Taggable, tag_dataclass
 
 from loopy.diagnostic import LoopyError
-from loopy.tools import Optional
+from loopy.tools import Optional as LoopyOptional
+from loopy.typing import ExpressionT
 
 
 # {{{ instruction tags
@@ -73,6 +75,44 @@ class UseStreamingStoreTag(Tag):
         program-dependent. No promise of safety is made.
     """
     pass
+
+# }}}
+
+
+# {{{ HappensAfter
+
+@dataclass(frozen=True)
+class HappensAfter:
+    """A class representing a "happens-after" relationship between two
+    statements found in a :class:`loopy.LoopKernel`. Used to validate that a
+    given kernel transformation respects the data dependencies in a given
+    program.
+
+    .. attribute:: variable_name
+
+       The name of the variable responsible for the dependency. For
+       backward compatibility purposes, this may be *None*. In this case, the
+       dependency semantics revert to the deprecated, statement-level
+       dependencies of prior versions of :mod:`loopy`.
+
+    .. attribute:: instances_rel
+
+        An :class:`islpy.Map` representing the precise happens-after
+        relationship. The domain and range are sets of statement instances. The
+        instances in the domain are required to execute before the instances in
+        the range.
+
+        Map dimensions are named according to the order of appearance of the
+        inames in a :mod:`loopy` program. The dimension names in the range are
+        appended with a prime to signify that the mapped instances are distinct.
+
+        As a (deprecated) matter of backward compatibility, this may be *None*,
+        in which case the semantics revert to the (underspecified)
+        statement-level dependencies of prior versions of :mod:`loopy`.
+    """
+
+    variable_name: Optional[str]
+    instances_rel: Optional[isl.Map]
 
 # }}}
 
@@ -200,10 +240,20 @@ class InstructionBase(ImmutableRecord, Taggable):
 
     Inherits from :class:`pytools.tag.Taggable`.
     """
+    id: Optional[str]
+    happens_after: Mapping[str, HappensAfter]
+    depends_on_is_final: bool
+    groups: FrozenSet[str]
+    conflicts_with_groups: FrozenSet[str]
+    no_sync_with: FrozenSet[Tuple[str, str]]
+    predicates: FrozenSet[ExpressionT]
+    within_inames: FrozenSet[str]
+    within_inames_is_final: bool
+    priority: int
 
     # within_inames_is_final is deprecated and will be removed in version 2017.x.
 
-    fields = set("id depends_on depends_on_is_final "
+    fields = set("id depends_on_is_final "
             "groups conflicts_with_groups "
             "no_sync_with "
             "predicates "
@@ -216,12 +266,22 @@ class InstructionBase(ImmutableRecord, Taggable):
     # Names of fields that are sets of pymbolic expressions. Needed for key building
     pymbolic_set_fields = {"predicates"}
 
-    def __init__(self, id, depends_on, depends_on_is_final,
-            groups, conflicts_with_groups,
-            no_sync_with,
-            within_inames_is_final, within_inames,
-            priority,
-            predicates, tags):
+    def __init__(self,
+                 id: Optional[str],
+                 happens_after: Union[
+                     Mapping[str, HappensAfter], FrozenSet[str], str, None],
+                 depends_on_is_final: Optional[bool],
+                 groups: Optional[FrozenSet[str]],
+                 conflicts_with_groups: Optional[FrozenSet[str]],
+                 no_sync_with: Optional[FrozenSet[Tuple[str, str]]],
+                 within_inames_is_final: Optional[bool],
+                 within_inames: Optional[FrozenSet[str]],
+                 priority: Optional[int],
+                 predicates: Optional[FrozenSet[str]],
+                 tags: Optional[FrozenSet[Tag]],
+                 *,
+                 depends_on: Union[FrozenSet[str], str, None] = None,
+                 ) -> None:
 
         if predicates is None:
             predicates = frozenset()
@@ -237,8 +297,49 @@ class InstructionBase(ImmutableRecord, Taggable):
         predicates = frozenset(new_predicates)
         del new_predicates
 
-        if depends_on is None:
-            depends_on = frozenset()
+        # {{{ process happens_after/depends_on
+
+        if happens_after is not None and depends_on is not None:
+            raise TypeError("may not pass both happens_after and depends_on")
+        elif depends_on is not None:
+            # FIXME Enable once we realistically check detailed dependencies.
+            # warn("depends_on is deprecated and will stop working in 2026. "
+            #      "Pass happens_after instead.", DeprecationWarning, stacklevel=2)
+            happens_after = depends_on
+
+        del depends_on
+
+        if depends_on_is_final and happens_after is None:
+            raise LoopyError("Setting depends_on_is_final to True requires "
+                    "actually specifying happens_after/depends_on")
+
+        if happens_after is None:
+            happens_after = {}
+        elif isinstance(happens_after, str):
+            warn("Passing a string for happens_after/depends_on is deprecated and "
+                 "will stop working in 2025. Instead, pass a full-fledged "
+                 "happens_after data structure.", DeprecationWarning, stacklevel=2)
+
+            happens_after = {
+                    after_id.strip(): HappensAfter(
+                        variable_name=None,
+                        instances_rel=None)
+                    for after_id in happens_after.split(",")
+                    if after_id.strip()}
+        elif isinstance(happens_after, frozenset):
+            happens_after = {
+                    after_id: HappensAfter(
+                        variable_name=None,
+                        instances_rel=None)
+                    for after_id in happens_after}
+        elif isinstance(happens_after, MappingABC):
+            if isinstance(happens_after, dict):
+                happens_after = happens_after
+        else:
+            raise TypeError("'happens_after' has unexpected type: "
+                            f"{type(happens_after)}")
+
+        # }}}
 
         if groups is None:
             groups = frozenset()
@@ -255,16 +356,12 @@ class InstructionBase(ImmutableRecord, Taggable):
         if within_inames_is_final is None:
             within_inames_is_final = False
 
-        if isinstance(depends_on, str):
-            depends_on = frozenset(
-                    s.strip() for s in depends_on.split(",") if s.strip())
-
         if depends_on_is_final is None:
             depends_on_is_final = False
 
-        if depends_on_is_final and not isinstance(depends_on, abc_Set):
+        if depends_on_is_final and not isinstance(happens_after, MappingABC):
             raise LoopyError("Setting depends_on_is_final to True requires "
-                    "actually specifying depends_on")
+                    "actually specifying happens_after/depends_on")
 
         if tags is None:
             tags = frozenset()
@@ -288,13 +385,13 @@ class InstructionBase(ImmutableRecord, Taggable):
         # assert all(is_interned(pred) for pred in predicates)
 
         assert isinstance(within_inames, abc_Set)
-        assert isinstance(depends_on, abc_Set) or depends_on is None
+        assert isinstance(happens_after, MappingABC) or happens_after is None
         assert isinstance(groups, abc_Set)
         assert isinstance(conflicts_with_groups, abc_Set)
 
         ImmutableRecord.__init__(self,
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 no_sync_with=no_sync_with,
                 groups=groups, conflicts_with_groups=conflicts_with_groups,
@@ -306,6 +403,24 @@ class InstructionBase(ImmutableRecord, Taggable):
                 # Here, we set it so that ImmutableRecord knows about it.
                 # The Taggable constructor call does extra validation.
                 tags=tags)
+
+        Taggable.__init__(self, tags)
+
+    def get_copy_kwargs(self, **kwargs):
+        passed_depends_on = "depends_on" in kwargs
+
+        if passed_depends_on:
+            assert "happens_after" not in kwargs
+
+        kwargs = super().get_copy_kwargs(**kwargs)
+
+        if passed_depends_on:
+            # FIXME Enable once we realistically check detailed dependencies.
+            # warn("depends_on is deprecated and will stop working in 2026. "
+            #      "Instead, use happens_after.", DeprecationWarning, stacklevel=2)
+            del kwargs["happens_after"]
+
+        return kwargs
 
     # {{{ abstract interface
 
@@ -347,6 +462,13 @@ class InstructionBase(ImmutableRecord, Taggable):
         raise NotImplementedError
 
     # }}}
+
+    @property
+    def depends_on(self):
+        # FIXME Enable once we realistically check detailed dependencies.
+        # warn("depends_on is deprecated and will stop working in 2026. "
+        #      "Use happens_after instead.", DeprecationWarning, stacklevel=2)
+        return frozenset(self.happens_after)
 
     @property
     def assignee_name(self):
@@ -456,7 +578,9 @@ class InstructionBase(ImmutableRecord, Taggable):
 
         if self.id is not None:  # pylint:disable=access-member-before-definition
             self.id = intern(self.id)
-        self.depends_on = intern_frozenset_of_ids(self.depends_on)
+        self.happens_after = {
+                intern(after_id): ha
+                for after_id, ha in self.happens_after.items()}
         self.groups = intern_frozenset_of_ids(self.groups)
         self.conflicts_with_groups = (
                 intern_frozenset_of_ids(self.conflicts_with_groups))
@@ -793,30 +917,43 @@ class Assignment(MultiAssignmentBase):
     .. automethod:: __init__
     """
 
+    assignee: ExpressionT
+    expression: ExpressionT
+    temp_var_type: LoopyOptional
+    atomicity: Tuple[VarAtomicity, ...]
+
     fields = MultiAssignmentBase.fields | \
             set("assignee temp_var_type atomicity".split())
     pymbolic_fields = MultiAssignmentBase.pymbolic_fields | {"assignee"}
 
     def __init__(self,
-            assignee, expression,
-            id=None,
-            depends_on=None,
-            depends_on_is_final=None,
-            groups=None,
-            conflicts_with_groups=None,
-            no_sync_with=None,
-            within_inames_is_final=None,
-            within_inames=None,
-            tags=None,
-            temp_var_type=_not_provided, atomicity=(),
-            priority=0, predicates=frozenset()):
+                 assignee: Union[str, ExpressionT],
+                 expression: Union[str, ExpressionT],
+                 id: Optional[str] = None,
+                 happens_after: Union[
+                     Mapping[str, HappensAfter], FrozenSet[str], str, None] = None,
+                 depends_on_is_final: Optional[bool] = None,
+                 groups: Optional[FrozenSet[str]] = None,
+                 conflicts_with_groups: Optional[FrozenSet[str]] = None,
+                 no_sync_with: Optional[FrozenSet[Tuple[str, str]]] = None,
+                 within_inames_is_final: Optional[bool] = None,
+                 within_inames: Optional[FrozenSet[str]] = None,
+                 priority: Optional[int] = None,
+                 predicates: Optional[FrozenSet[str]] = None,
+                 tags: Optional[FrozenSet[Tag]] = None,
+                 temp_var_type: Union[
+                     Type[_not_provided], None, LoopyOptional] = _not_provided,
+                 atomicity: Tuple[VarAtomicity, ...] = (),
+                 *,
+                 depends_on: Union[FrozenSet[str], str, None] = None,
+                 ) -> None:
 
         if temp_var_type is _not_provided:
-            temp_var_type = Optional()
+            temp_var_type = LoopyOptional()
 
         super().__init__(
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 groups=groups,
                 conflicts_with_groups=conflicts_with_groups,
@@ -825,7 +962,8 @@ class Assignment(MultiAssignmentBase):
                 within_inames=within_inames,
                 priority=priority,
                 predicates=predicates,
-                tags=tags)
+                tags=tags,
+                depends_on=depends_on)
 
         from loopy.symbolic import parse
         if isinstance(assignee, str):
@@ -949,7 +1087,7 @@ class CallInstruction(MultiAssignmentBase):
     def __init__(self,
             assignees, expression,
             id=None,
-            depends_on=None,
+            happens_after=None,
             depends_on_is_final=None,
             groups=None,
             conflicts_with_groups=None,
@@ -958,11 +1096,12 @@ class CallInstruction(MultiAssignmentBase):
             within_inames=None,
             tags=None,
             temp_var_types=None,
-            priority=0, predicates=frozenset()):
+            priority=0, predicates=frozenset(),
+            depends_on=None):
 
         super().__init__(
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 groups=groups,
                 conflicts_with_groups=conflicts_with_groups,
@@ -971,7 +1110,8 @@ class CallInstruction(MultiAssignmentBase):
                 within_inames=within_inames,
                 priority=priority,
                 predicates=predicates,
-                tags=tags)
+                tags=tags,
+                depends_on=depends_on)
 
         from pymbolic.primitives import Call
 
@@ -1004,7 +1144,7 @@ class CallInstruction(MultiAssignmentBase):
         self.expression = expression
 
         if temp_var_types is None:
-            self.temp_var_types = (Optional(),) * len(self.assignees)
+            self.temp_var_types = (LoopyOptional(),) * len(self.assignees)
         else:
             self.temp_var_types = tuple(
                     _check_and_fix_temp_var_type(tvt, stacklevel=3)
@@ -1149,7 +1289,7 @@ def modify_assignee_for_array_call(assignee):
 def make_assignment(assignees, expression, temp_var_types=None, **kwargs):
 
     if temp_var_types is None:
-        temp_var_types = (Optional(),) * len(assignees)
+        temp_var_types = (LoopyOptional(),) * len(assignees)
 
     if len(assignees) != 1 or is_array_call(assignees, expression):
         atomicity = kwargs.pop("atomicity", ())
@@ -1251,12 +1391,13 @@ class CInstruction(InstructionBase):
     def __init__(self,
             iname_exprs, code,
             read_variables=frozenset(), assignees=(),
-            id=None, depends_on=None, depends_on_is_final=None,
+            id=None, happens_after=None, depends_on_is_final=None,
             groups=None, conflicts_with_groups=None,
             no_sync_with=None,
             within_inames_is_final=None, within_inames=None,
             priority=0,
-            predicates=frozenset(), tags=None):
+            predicates=frozenset(), tags=None,
+            depends_on=None):
         """
         :arg iname_exprs: Like :attr:`iname_exprs`, but instead of tuples,
             simple strings pepresenting inames are also allowed. A single
@@ -1269,13 +1410,14 @@ class CInstruction(InstructionBase):
 
         InstructionBase.__init__(self,
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 groups=groups, conflicts_with_groups=conflicts_with_groups,
                 no_sync_with=no_sync_with,
                 within_inames_is_final=within_inames_is_final,
                 within_inames=within_inames,
-                priority=priority, predicates=predicates, tags=tags)
+                priority=priority, predicates=predicates, tags=tags,
+                depends_on=depends_on)
 
         # {{{ normalize iname_exprs
 
@@ -1419,15 +1561,15 @@ class NoOpInstruction(_DataObliviousInstruction):
         ... nop
     """
 
-    def __init__(self, id=None, depends_on=None, depends_on_is_final=None,
+    def __init__(self, id=None, happens_after=None, depends_on_is_final=None,
             groups=None, conflicts_with_groups=None,
             no_sync_with=None,
             within_inames_is_final=None, within_inames=None,
             priority=None,
-            predicates=None, tags=None):
+            predicates=None, tags=None, depends_on=None):
         super().__init__(
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 groups=groups,
                 conflicts_with_groups=conflicts_with_groups,
@@ -1436,7 +1578,8 @@ class NoOpInstruction(_DataObliviousInstruction):
                 within_inames=within_inames,
                 priority=priority,
                 predicates=predicates,
-                tags=tags)
+                tags=tags,
+                depends_on=depends_on)
 
     def __str__(self):
         first_line = "%s: ... nop" % self.id
@@ -1478,20 +1621,21 @@ class BarrierInstruction(_DataObliviousInstruction):
     fields = _DataObliviousInstruction.fields | {"synchronization_kind",
                                                      "mem_kind"}
 
-    def __init__(self, id, depends_on=None, depends_on_is_final=None,
+    def __init__(self, id, happens_after=None, depends_on_is_final=None,
             groups=None, conflicts_with_groups=None,
             no_sync_with=None,
             within_inames_is_final=None, within_inames=None,
             priority=None,
             predicates=None, tags=None, synchronization_kind="global",
-            mem_kind="local"):
+            mem_kind="local",
+            depends_on=None):
 
         if predicates:
             raise LoopyError("conditional barriers are not supported")
 
         super().__init__(
                 id=id,
-                depends_on=depends_on,
+                happens_after=happens_after,
                 depends_on_is_final=depends_on_is_final,
                 groups=groups,
                 conflicts_with_groups=conflicts_with_groups,
@@ -1500,8 +1644,8 @@ class BarrierInstruction(_DataObliviousInstruction):
                 within_inames=within_inames,
                 priority=priority,
                 predicates=predicates,
-                tags=tags
-                )
+                tags=tags,
+                depends_on=depends_on)
 
         self.synchronization_kind = synchronization_kind
         self.mem_kind = mem_kind

--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -34,7 +34,7 @@ from pytools.tag import Tag, Taggable, tag_dataclass
 from loopy.diagnostic import LoopyError
 from loopy.tools import Optional as LoopyOptional
 from loopy.types import LoopyType
-from loopy.typing import ExpressionT
+from loopy.typing import ExpressionT, InameStr
 
 
 # {{{ instruction tags
@@ -248,7 +248,7 @@ class InstructionBase(ImmutableRecord, Taggable):
     conflicts_with_groups: FrozenSet[str]
     no_sync_with: FrozenSet[Tuple[str, str]]
     predicates: FrozenSet[ExpressionT]
-    within_inames: FrozenSet[str]
+    within_inames: FrozenSet[InameStr]
     within_inames_is_final: bool
     priority: int
 

--- a/loopy/kernel/instruction.py
+++ b/loopy/kernel/instruction.py
@@ -405,8 +405,6 @@ class InstructionBase(ImmutableRecord, Taggable):
                 # The Taggable constructor call does extra validation.
                 tags=tags)
 
-        Taggable.__init__(self, tags)
-
     def get_copy_kwargs(self, **kwargs):
         passed_depends_on = "depends_on" in kwargs
 
@@ -943,7 +941,8 @@ class Assignment(MultiAssignmentBase):
                  predicates: Optional[FrozenSet[str]] = None,
                  tags: Optional[FrozenSet[Tag]] = None,
                  temp_var_type: Union[
-                     Type[_not_provided], None, LoopyOptional] = _not_provided,
+                     Type[_not_provided], None, LoopyOptional,
+                     LoopyType] = _not_provided,
                  atomicity: Tuple[VarAtomicity, ...] = (),
                  *,
                  depends_on: Union[FrozenSet[str], str, None] = None,

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -34,6 +34,7 @@ import numpy as np
 import islpy as isl
 from islpy import dim_type
 from pytools import memoize_on_first_arg, natsorted
+from pytools.tag import Tag
 
 from loopy.diagnostic import LoopyError, warn_with_kernel
 from loopy.kernel import LoopKernel
@@ -1483,7 +1484,7 @@ def draw_dependencies_as_unicode_arrows(
 
 # {{{ stringify_instruction_list
 
-def stringify_instruction_tag(tag):
+def stringify_instruction_tag(tag: Tag) -> str:
     from loopy.kernel.instruction import LegacyStringInstructionTag
     if isinstance(tag, LegacyStringInstructionTag):
         return f"S({tag.value})"
@@ -1491,7 +1492,7 @@ def stringify_instruction_tag(tag):
         return str(tag)
 
 
-def stringify_instruction_list(kernel):
+def stringify_instruction_list(kernel: LoopKernel) -> list[str]:
     # {{{ topological sort
 
     printed_insn_ids = set()
@@ -1525,7 +1526,7 @@ def stringify_instruction_list(kernel):
 
     leader = " " * uniform_arrow_length
     lines = []
-    current_inames = [set()]
+    current_inames: list[set[str]] = [set()]
 
     if uniform_arrow_length:
         indent_level = [1]
@@ -1536,13 +1537,13 @@ def stringify_instruction_list(kernel):
 
     iname_order = kernel._get_iname_order_for_printing()
 
-    def add_pre_line(s):
+    def add_pre_line(s: str) -> None:
         lines.append(leader + " " * indent_level[0] + s)
 
-    def add_main_line(s):
+    def add_main_line(s: str) -> None:
         lines.append(arrows + " " * indent_level[0] + s)
 
-    def add_post_line(s):
+    def add_post_line(s: str) -> None:
         lines.append(extender + " " * indent_level[0] + s)
 
     def adapt_to_new_inames_list(new_inames):

--- a/loopy/options.py
+++ b/loopy/options.py
@@ -23,6 +23,7 @@ THE SOFTWARE.
 
 import os
 import re
+from typing import Any
 from warnings import warn
 
 from pytools import ImmutableRecord
@@ -214,7 +215,7 @@ class Options(ImmutableRecord):
             # All defaults are further required to be False when cast to bool
             # for the update() functionality to work.
 
-            self, **kwargs):
+            self, **kwargs: Any) -> None:
 
         kwargs = _apply_legacy_map(self._legacy_options_map, kwargs)
 

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from loopy.typing import not_none
+
 
 __copyright__ = "Copyright (C) 2012 Andreas Kloeckner"
 
@@ -713,9 +715,10 @@ def get_insns_in_topologically_sorted_order(
     from pytools.graph import compute_topological_order
 
     rev_dep_map: Dict[str, Set[str]] = {
-            insn.id: set() for insn in kernel.instructions}
+            not_none(insn.id): set() for insn in kernel.instructions}
     for insn in kernel.instructions:
         for dep in insn.depends_on:
+            assert insn.id is not None
             rev_dep_map[dep].add(insn.id)
 
     # For breaking ties, we compare the features of an instruction
@@ -2102,7 +2105,7 @@ def _generate_loop_schedules_inner(
 
             schedule=(),
 
-            unscheduled_insn_ids={insn.id for insn in kernel.instructions},
+            unscheduled_insn_ids={not_none(insn.id) for insn in kernel.instructions},
             scheduled_insn_ids=frozenset(),
             within_subkernel=kernel.state != KernelState.LINEARIZED,
             may_schedule_global_barriers=True,

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -65,12 +65,11 @@ logger = logging.getLogger(__name__)
 
 
 __doc__ = """
-.. currentmodule:: loopy.schedule
-
 .. autoclass:: ScheduleItem
 .. autoclass:: BeginBlockItem
 .. autoclass:: EndBlockItem
 .. autoclass:: CallKernel
+.. autoclass:: ReturnFromKernel
 .. autoclass:: Barrier
 .. autoclass:: RunInstruction
 

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -42,7 +42,7 @@ from loopy.typing import InameStr, not_none
 
 # {{{ block boundary finder
 
-def get_block_boundaries(schedule):
+def get_block_boundaries(schedule: Sequence[ScheduleItem]) -> Mapping[int, int]:
     """
     Return a dictionary mapping indices of
     :class:`loopy.schedule.BlockBeginItem`s to
@@ -309,7 +309,7 @@ def get_subkernel_arg_info(
 
 # {{{ get_return_from_kernel_mapping
 
-def get_return_from_kernel_mapping(kernel):
+def get_return_from_kernel_mapping(kernel: LoopKernel) -> Mapping[int, int | None]:
     """
     Returns a mapping from schedule index of every schedule item (S) in
     *kernel* to the schedule index of :class:`loopy.schedule.ReturnFromKernel`
@@ -326,8 +326,8 @@ def get_return_from_kernel_mapping(kernel):
     )
     assert isinstance(kernel, LoopKernel)
     assert isinstance(kernel.linearization, list)
-    return_from_kernel_idxs = {}
-    current_return_from_kernel = None
+    return_from_kernel_idxs: dict[int, int | None] = {}
+    current_return_from_kernel: int | None = None
     for sched_idx, sched_item in list(enumerate(kernel.linearization))[::-1]:
         if isinstance(sched_item, CallKernel):
             return_from_kernel_idxs[sched_idx] = current_return_from_kernel

--- a/loopy/schedule/tools.py
+++ b/loopy/schedule/tools.py
@@ -21,15 +21,23 @@ THE SOFTWARE.
 """
 
 import enum
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
-from functools import cached_property
-from typing import Dict, FrozenSet, List, Sequence, Set, Tuple
+from functools import cached_property, reduce
+from typing import AbstractSet, Dict, FrozenSet, List, Sequence, Set, Tuple
+
+from immutables import Map
+from typing_extensions import TypeAlias
 
 import islpy as isl
-from pytools import memoize_method
+from pytools import memoize_method, memoize_on_first_arg
 
+from loopy.diagnostic import LoopyError
 from loopy.kernel import LoopKernel
 from loopy.kernel.data import AddressSpace, ArrayArg, TemporaryVariable
+from loopy.schedule import ScheduleItem
+from loopy.schedule.tree import Tree
+from loopy.typing import InameStr, not_none
 
 
 # {{{ block boundary finder
@@ -621,4 +629,436 @@ class WriteRaceChecker:
 
 # }}}
 
-# vim: foldmethod=marker
+
+InameStrSet: TypeAlias = FrozenSet[InameStr]
+LoopNestTree: TypeAlias = Tree[InameStrSet]
+LoopTree: TypeAlias = Tree[InameStr]
+
+
+class V2SchedulerNotImplementedError(LoopyError):
+    pass
+
+
+def _pull_out_loop_nest(
+            tree: LoopNestTree,
+            loop_nests: Collection[InameStrSet],
+            inames_to_pull_out: InameStrSet
+        ) -> tuple[LoopNestTree, InameStrSet, InameStrSet | None]:
+    """
+    Returns a copy of *tree* that realizes *inames_to_pull_out* as loop
+    nesting.
+
+    :arg tree: A :class:`loopy.tools.Tree`, where each node is
+        :class:`frozenset` of inames representing a loop nest.
+
+    :arg loop_nests: A collection of nodes in *tree* that cover
+        *inames_to_pull_out*.
+
+    :returns: a :class:`tuple` ``(new_tree, outer_loop_nest, inner_loop_nest)``,
+        where outer_loop_nest is the identifier for the new outer and inner
+        loop nests so that *inames_to_pull_out* is a valid nesting.
+
+    .. note::
+
+        We could compute *loop_nests* within this routine's implementation, but
+        computing would be expensive and hence we ask the caller for this info.
+
+    Example::
+       *tree*: frozenset()
+               └── frozenset({'j', 'i'})
+                   └── frozenset({'k', 'l'})
+
+       *inames_to_pull_out*: frozenset({'k', 'i', 'j'})
+       *loop_nests*: {frozenset({'j', 'i'}), frozenset({'k', 'l'})}
+
+       Returns:
+
+       *new_tree*: frozenset()
+                   └── frozenset({'j', 'i'})
+                       └── frozenset({'k'})
+                           └── frozenset({'l'})
+
+       *outer_loop_nest*: frozenset({'k'})
+       *inner_loop_nest*: frozenset({'l'})
+    """
+    assert all(isinstance(loop_nest, frozenset) for loop_nest in loop_nests)
+
+    # annotation to avoid https://github.com/python/mypy/issues/17693
+    emptyset: InameStrSet = frozenset()
+
+    assert inames_to_pull_out <= reduce(frozenset.union, loop_nests, emptyset)
+
+    # {{{ sanity check to ensure the loop nest *inames_to_pull_out* is possible
+
+    loop_nests = sorted(loop_nests, key=lambda nest: tree.depth(nest))
+
+    for outer, inner in zip(loop_nests[:-1], loop_nests[1:]):
+        if outer != tree.parent(inner):
+            raise LoopyError(f"Cannot schedule loop nest {inames_to_pull_out} "
+                             f" in the nesting tree:\n{tree}")
+
+    assert tree.depth(loop_nests[0]) == 0
+
+    # }}}
+
+    innermost_loop_nest = loop_nests[-1]
+    # separate variable to avoid https://github.com/python/mypy/issues/17694
+    outerer_loops = reduce(frozenset.union, loop_nests[:-1], emptyset)
+    new_outer_loop_nest = inames_to_pull_out - outerer_loops
+    new_inner_loop_nest = innermost_loop_nest - inames_to_pull_out
+
+    if new_outer_loop_nest == innermost_loop_nest:
+        # such a loop nesting already exists => do nothing
+        return tree, new_outer_loop_nest, None
+
+    # add the outer loop to our loop nest tree
+    tree = tree.add_node(new_outer_loop_nest,
+                         parent=not_none(tree.parent(innermost_loop_nest)))
+
+    # rename the old loop to the inner loop
+    tree = tree.replace_node(innermost_loop_nest,
+                            new_node=new_inner_loop_nest)
+
+    # set the parent of inner loop to be the outer loop
+    tree = tree.move_node(new_inner_loop_nest, new_parent=new_outer_loop_nest)
+
+    return tree, new_outer_loop_nest, new_inner_loop_nest
+
+
+def _add_inner_loops(tree, outer_loop_nest, inner_loop_nest):
+    """
+    Returns a copy of *tree* that nests *inner_loop_nest* inside *outer_loop_nest*.
+    """
+    # add the outer loop to our loop nest tree
+    return tree.add_node(inner_loop_nest, parent=outer_loop_nest)
+
+
+def _order_loop_nests(
+            loop_nest_tree: LoopNestTree,
+            strict_priorities: FrozenSet[Tuple[InameStr, ...]],
+            relaxed_priorities: FrozenSet[Tuple[InameStr, ...]],
+            iname_to_tree_node_id: Mapping[InameStr, InameStrSet],
+          ) -> LoopTree:
+    """
+    Returns a loop nest where all nodes in the tree are instances of
+    :class:`str` denoting inames. Unlike *loop_nest_tree* which corresponds to
+    multiple loop nesting, this routine returns a unique loop nest that is
+    obtained after constraining *loop_nest_tree* with the constraints enforced
+    by *priorities*.
+
+    :arg strict_priorities: Expresses strict nesting constraints similar to
+        :attr:`loopy.LoopKernel.loop_priorities`. These priorities are imposed
+        strictly i.e. if these conditions cannot be met a
+        :class:`loopy.diagnostic.LoopyError` is raised.
+
+    :arg relaxed_priorities: Expresses strict nesting constraints similar to
+        :attr:`loopy.LoopKernel.loop_priorities`. These nesting constraints are
+        treated as options.
+
+    :arg iname_to_tree_node_id: A mapping from iname to the loop nesting its a
+        part of.
+    """
+    from warnings import warn
+
+    from pytools.graph import compute_topological_order as toposort
+
+    loop_nests = set(iname_to_tree_node_id.values())
+
+    # flow_requirements: A mapping from the loop nest level to the nesting
+    # constraints applicable to it.
+    # Each nesting constraint is represented as a DAG. In the DAG, if there
+    # exists an edge from from iname 'i' -> iname 'j' => 'j' should be nested
+    # inside 'i'.
+    flow_requirements: dict[InameStrSet, dict[InameStr, InameStrSet]] = {
+        loop_nest: {iname: frozenset() for iname in loop_nest}
+        for loop_nest in loop_nests}
+
+    # The plan here is populate DAGs in *flow_requirements* and then perform a
+    # toposort for each loop nest.
+
+    def _update_flow_requirements(priorities, cannot_satisfy_callback):
+        """
+        Records *priorities* in *flow_requirements* and calls
+        *cannot_satisfy_callback* with an appropriate error message if the
+        priorities cannot be met.
+        """
+        for priority in priorities:
+            for outer_iname, inner_iname in zip(priority[:-1], priority[1:]):
+                if inner_iname not in iname_to_tree_node_id:
+                    cannot_satisfy_callback(f"Cannot enforce the constraint:"
+                                            f" {inner_iname} to be nested within"
+                                            f" {outer_iname}, as {inner_iname}"
+                                            f" is either a parallel loop or"
+                                            f" not an iname.")
+                    continue
+
+                if outer_iname not in iname_to_tree_node_id:
+                    cannot_satisfy_callback(f"Cannot enforce the constraint:"
+                                            f" {inner_iname} to be nested within"
+                                            f" {outer_iname}, as {outer_iname}"
+                                            f" is either a parallel loop or"
+                                            f" not an iname.")
+                    continue
+
+                inner_iname_nest = iname_to_tree_node_id[inner_iname]
+                outer_iname_nest = iname_to_tree_node_id[outer_iname]
+
+                if inner_iname_nest == outer_iname_nest:
+                    flow_requirements[inner_iname_nest][outer_iname] |= {inner_iname}
+                else:
+                    ancestors_of_inner_iname = (loop_nest_tree
+                                                .ancestors(inner_iname_nest))
+                    ancestors_of_outer_iname = (loop_nest_tree
+                                                .ancestors(outer_iname_nest))
+                    if outer_iname in ancestors_of_inner_iname:
+                        # nesting constraint already satisfied => do nothing
+                        pass
+                    elif inner_iname in ancestors_of_outer_iname:
+                        cannot_satisfy_callback("Cannot satisfy constraint that"
+                                                f" iname '{inner_iname}' must be"
+                                                f" nested within '{outer_iname}''.")
+                    else:
+                        # inner iname and outer iname are indirect family members
+                        # => must be realized via dependencies in the linearization
+                        # phase, not implemented in v2-scheduler yet.
+                        raise V2SchedulerNotImplementedError("cannot"
+                                " schedule kernels with priority dependencies"
+                                " between sibling loop nests")
+
+    def _raise_loopy_err(x):
+        raise LoopyError(x)
+
+    # record strict priorities
+    _update_flow_requirements(strict_priorities, _raise_loopy_err)
+    # record relaxed priorities
+    _update_flow_requirements(relaxed_priorities, warn)
+
+    # ordered_loop_nests: A mapping from the unordered loop nests to their
+    # ordered couterparts. For example. If we had only one loop nest
+    # `frozenset({"i", "j", "k"})`, and the prioirities said added the
+    # constraint that "i" must be nested within "k", then `ordered_loop_nests`
+    # would be: `{frozenset({"i", "j", "k"}): ["j", "k", "i"]}` i.e. the loop
+    # nests would now have an order.
+    ordered_loop_nests = {unordered_nest: toposort(flow,
+                                                   key=lambda x: x)
+                          for unordered_nest, flow in flow_requirements.items()}
+
+    # {{{ combine 'loop_nest_tree' along with 'ordered_loop_nest_tree'
+
+    assert loop_nest_tree.root == frozenset()
+
+    new_tree = Tree.from_root("")
+
+    old_to_new_parent = {}
+
+    old_to_new_parent[loop_nest_tree.root] = ""
+
+    # traversing 'tree' in an BFS fashion to create 'new_tree'
+    queue = list(loop_nest_tree.children(loop_nest_tree.root))
+
+    while queue:
+        current_nest = queue.pop(0)
+
+        ordered_nest = ordered_loop_nests[current_nest]
+        new_tree = new_tree.add_node(ordered_nest[0],
+                                     parent=old_to_new_parent[not_none(loop_nest_tree
+                                                              .parent(current_nest))])
+        for new_parent, new_child in zip(ordered_nest[:-1], ordered_nest[1:]):
+            new_tree = new_tree.add_node(node=new_child, parent=new_parent)
+
+        old_to_new_parent[current_nest] = ordered_nest[-1]
+
+        queue.extend(list(loop_nest_tree.children(current_nest)))
+
+    # }}}
+
+    return new_tree
+
+
+@memoize_on_first_arg
+def _get_parallel_inames(kernel: LoopKernel) -> AbstractSet[str]:
+    from loopy.kernel.data import ConcurrentTag, IlpBaseTag, VectorizeTag
+
+    concurrent_inames = {iname for iname in kernel.all_inames()
+                         if kernel.iname_tags_of_type(iname, ConcurrentTag)}
+    ilp_inames = {iname for iname in kernel.all_inames()
+                  if kernel.iname_tags_of_type(iname, IlpBaseTag)}
+    vec_inames = {iname for iname in kernel.all_inames()
+                  if kernel.iname_tags_of_type(iname, VectorizeTag)}
+    return (concurrent_inames - ilp_inames - vec_inames)
+
+
+def _get_partial_loop_nest_tree(kernel: LoopKernel) -> LoopNestTree:
+    """
+    Returns :class:`loopy.Tree` representing the *kernel*'s loop-nests.
+
+    Each node of the returned tree has a :class:`frozenset` of inames.
+    All the inames in the identifier of a parent node of a loop nest in the
+    tree must be nested outside all the iname in identifier of the loop nest.
+
+    .. note::
+
+        This routine only takes into account the nesting dependency
+        constraints of :attr:`loopy.InstructionBase.within_inames` of all the
+        *kernel*'s instructions and the iname tags. This routine does *NOT*
+        include the nesting constraints imposed by the dependencies between the
+        instructions and the dependencies imposed by the kernel's domain tree.
+    """
+    from loopy.kernel.data import IlpBaseTag
+
+    # figuring the possible loop nestings minus the concurrent_inames as they
+    # are never realized as actual loops
+    iname_chains = {insn.within_inames - _get_parallel_inames(kernel)
+                     for insn in kernel.instructions}
+
+    root: InameStrSet = frozenset()
+    tree = Tree.from_root(root)
+
+    # mapping from iname to the innermost loop nest they are part of in *tree*.
+    iname_to_tree_node_id: Dict[InameStr, InameStrSet] = {}
+
+    # if there were any loop with no inames, those have been already account
+    # for as the root.
+    iname_chains = iname_chains - {root}
+
+    for iname_chain in iname_chains:
+        not_seen_inames = frozenset(iname for iname in iname_chain
+                                    if iname not in iname_to_tree_node_id)
+        seen_inames = iname_chain - not_seen_inames
+
+        all_nests = {iname_to_tree_node_id[iname] for iname in seen_inames}
+
+        tree, outer_loop, inner_loop = _pull_out_loop_nest(tree,
+                                                           (all_nests
+                                                            | {frozenset()}),
+                                                           seen_inames)
+        if not_seen_inames:
+            # make '_not_seen_inames' nest inside the seen ones.
+            # example: if there is already a loop nesting "i,j,k"
+            # and the current iname chain is "i,j,l". Only way this is possible
+            # is if "l" is nested within "i,j"-loops.
+            tree = _add_inner_loops(tree, outer_loop, not_seen_inames)
+
+        # {{{ update iname to node id
+
+        for iname in outer_loop:
+            iname_to_tree_node_id[iname] = outer_loop
+
+        if inner_loop is not None:
+            for iname in inner_loop:
+                iname_to_tree_node_id[iname] = inner_loop
+
+        for iname in not_seen_inames:
+            iname_to_tree_node_id[iname] = not_seen_inames
+
+        # }}}
+
+    # {{{ make ILP tagged inames innermost
+
+    ilp_inames = {iname for iname in kernel.all_inames()
+                  if kernel.iname_tags_of_type(iname, IlpBaseTag)}
+
+    for iname_chain in iname_chains:
+        for ilp_iname in (ilp_inames & iname_chains):
+            # pull out other loops so that ilp_iname is the innermost
+            all_nests = {iname_to_tree_node_id[iname] for iname in seen_inames}
+            tree, outer_loop, inner_loop = _pull_out_loop_nest(tree,
+                                                               (all_nests
+                                                                | {frozenset()}),
+                                                               (iname_chain
+                                                                - {ilp_iname}))
+
+            for iname in outer_loop:
+                iname_to_tree_node_id[iname] = outer_loop
+
+            if inner_loop is not None:
+                for iname in inner_loop:
+                    iname_to_tree_node_id[iname] = inner_loop
+
+    # }}}
+
+    return tree
+
+
+def _get_iname_to_tree_node_id_from_partial_loop_nest_tree(
+            tree: LoopNestTree,
+        ) -> Mapping[str, frozenset[str]]:
+    """
+    Returns the mapping from the iname to the *tree*'s node that it was a part
+    of.
+
+    :arg tree: A partial loop nest tree.
+    """
+    iname_to_tree_node_id = {}
+    for node in tree.nodes():
+        assert isinstance(node, frozenset)
+        for iname in node:
+            iname_to_tree_node_id[iname] = node
+
+    return Map(iname_to_tree_node_id)
+
+
+def get_loop_tree(kernel: LoopKernel) -> LoopTree:
+    """
+    Returns ```tree``` (an instance of :class:`Tree`) representing the loop
+    nesting for *kernel*. Each node of ``tree`` is an instance of :class:`str`
+    corresponding to the inames of *kernel* that are realized as concrete
+    ``for-loops``. A parent node in `tree` is always nested outside all its
+    children.
+
+    .. note::
+
+        Multiple loop nestings might exist for *kernel*, but this routine returns
+        one valid loop nesting.
+    """
+    from islpy import dim_type
+
+    tree = _get_partial_loop_nest_tree(kernel)
+    iname_to_tree_node_id = (
+        _get_iname_to_tree_node_id_from_partial_loop_nest_tree(tree))
+
+    strict_loop_priorities: FrozenSet[Tuple[InameStr, ...]] = frozenset()
+
+    # {{{ impose constraints by the domain tree
+
+    # FIXME: These three could be one statement if it weren't for
+    # - https://github.com/python/mypy/issues/17693
+    # - https://github.com/python/mypy/issues/17694
+    emptyset: InameStrSet = frozenset()
+    loop_inames = reduce(frozenset.union,
+                          (insn.within_inames
+                           for insn in kernel.instructions),
+                          emptyset)
+    loop_inames = loop_inames - _get_parallel_inames(kernel)
+
+    for dom in kernel.domains:
+        for outer_iname in set(dom.get_var_names(dim_type.param)):
+            if outer_iname not in loop_inames:
+                continue
+
+            for inner_iname in dom.get_var_names(dim_type.set):
+                if inner_iname not in loop_inames:
+                    continue
+
+                # either outer_iname and inner_iname should belong to the same
+                # loop nest level or outer should be strictly outside inner
+                # iname
+                inner_iname_nest = iname_to_tree_node_id[inner_iname]
+                outer_iname_nest = iname_to_tree_node_id[outer_iname]
+
+                if inner_iname_nest == outer_iname_nest:
+                    strict_loop_priorities |= {(outer_iname, inner_iname)}
+                else:
+                    ancestors_of_inner_iname = tree.ancestors(inner_iname_nest)
+                    if outer_iname_nest not in ancestors_of_inner_iname:
+                        raise LoopyError(f"Loop '{outer_iname}' cannot be nested"
+                                         f" outside '{inner_iname}'.")
+
+    # }}}
+
+    return _order_loop_nests(tree,
+                             strict_loop_priorities,
+                             kernel.loop_priority,
+                             iname_to_tree_node_id)
+
+# vim: fdm=marker

--- a/loopy/schedule/tree.py
+++ b/loopy/schedule/tree.py
@@ -8,6 +8,12 @@ Copyright (C) 2022 Kaushik Kulkarni
 Copyright (C) 2022-24 University of Illinois Board of Trustees
 """
 
+
+__doc__ = """
+.. autoclass:: NodeT
+.. autoclass:: Tree
+"""
+
 __license__ = """
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/loopy/schedule/tree.py
+++ b/loopy/schedule/tree.py
@@ -1,0 +1,279 @@
+# mypy: disallow-untyped-defs
+
+from __future__ import annotations
+
+
+__copyright__ = """
+Copyright (C) 2022 Kaushik Kulkarni
+Copyright (C) 2022-24 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Generic, Hashable, Iterator, List, Optional, Sequence, Tuple, TypeVar
+
+from immutables import Map
+
+from pytools import memoize_method
+
+
+# {{{ tree data structure
+
+NodeT = TypeVar("NodeT", bound=Hashable)
+
+
+@dataclass(frozen=True)
+class Tree(Generic[NodeT]):
+    """
+    An immutable tree containing nodes of type :class:`NodeT`.
+
+    .. automethod:: ancestors
+    .. automethod:: parent
+    .. automethod:: children
+    .. automethod:: add_node
+    .. automethod:: depth
+    .. automethod:: replace_node
+    .. automethod:: move_node
+
+    .. automethod:: __contains__
+
+    .. note::
+
+       Almost all the operations are implemented recursively. NOT suitable for
+       deep trees. At the very least if the Python implementation is CPython
+       this allocates a new stack frame for each iteration of the operation.
+    """
+
+    _parent_to_children: Map[NodeT, Tuple[NodeT, ...]]
+    _child_to_parent: Map[NodeT, Optional[NodeT]]
+
+    @staticmethod
+    def from_root(root: NodeT) -> "Tree[NodeT]":
+        return Tree(Map({root: ()}),
+                    Map({root: None}))
+
+    @cached_property
+    def root(self) -> NodeT:
+        guess = set(self._child_to_parent).pop()
+        parent_of_guess = self.parent(guess)
+        while parent_of_guess is not None:
+            guess = parent_of_guess
+            parent_of_guess = self.parent(guess)
+
+        return guess
+
+    @memoize_method
+    def ancestors(self, node: NodeT) -> Tuple[NodeT, ...]:
+        """
+        Returns a :class:`tuple` of nodes that are ancestors of *node*.
+        """
+        assert node in self
+
+        if self.is_root(node):
+            # => root
+            return ()
+
+        parent = self._child_to_parent[node]
+        assert parent is not None
+
+        return (parent,) + self.ancestors(parent)
+
+    def parent(self, node: NodeT) -> Optional[NodeT]:
+        """
+        Returns the parent of *node*.
+        """
+        assert node in self
+
+        return self._child_to_parent[node]
+
+    def children(self, node: NodeT) -> Tuple[NodeT, ...]:
+        """
+        Returns the children of *node*.
+        """
+        assert node in self
+
+        return self._parent_to_children[node]
+
+    @memoize_method
+    def depth(self, node: NodeT) -> int:
+        """
+        Returns the depth of *node*, with the root having depth 0.
+        """
+        assert node in self
+
+        if self.is_root(node):
+            # => None
+            return 0
+
+        parent_of_node = self.parent(node)
+        assert parent_of_node is not None
+
+        return 1 + self.depth(parent_of_node)
+
+    def is_root(self, node: NodeT) -> bool:
+        assert node in self
+
+        return self.parent(node) is None
+
+    def is_leaf(self, node: NodeT) -> bool:
+        assert node in self
+
+        return len(self.children(node)) == 0
+
+    def __contains__(self, node: NodeT) -> bool:
+        """Return *True* if *node* is a node in the tree."""
+        return node in self._child_to_parent
+
+    def add_node(self, node: NodeT, parent: NodeT) -> "Tree[NodeT]":
+        """
+        Returns a :class:`Tree` with added node *node* having a parent
+        *parent*.
+        """
+        if node in self:
+            raise ValueError(f"'{node}' already present in tree.")
+
+        siblings = self._parent_to_children[parent]
+
+        return Tree((self._parent_to_children
+                     .set(parent, siblings + (node,))
+                     .set(node, ())),
+                    self._child_to_parent.set(node, parent))
+
+    def replace_node(self, node: NodeT, new_node: NodeT) -> "Tree[NodeT]":
+        """
+        Returns a copy of *self* with *node* replaced with *new_node*.
+        """
+        if node not in self:
+            raise ValueError(f"'{node}' not present in tree.")
+
+        if new_node in self:
+            raise ValueError(f"cannot replace with '{new_node}', as its already a part"
+                             " of the tree.")
+
+        parent = self.parent(node)
+        children = self.children(node)
+
+        # {{{ update child to parent
+
+        child_to_parent_mut = self._child_to_parent.mutate()
+        del child_to_parent_mut[node]
+        child_to_parent_mut[new_node] = parent
+
+        for child in children:
+            child_to_parent_mut[child] = new_node
+
+        # }}}
+
+        # {{{ update parent_to_children
+
+        parent_to_children_mut = self._parent_to_children.mutate()
+        del parent_to_children_mut[node]
+        parent_to_children_mut[new_node] = children
+
+        if parent is not None:
+            # update the child's name in the parent's children
+            parent_to_children_mut[parent] = (
+                            *(frozenset(self.children(parent)) - frozenset([node])),
+                            new_node,)
+
+        # }}}
+
+        return Tree(parent_to_children_mut.finish(),
+                    child_to_parent_mut.finish())
+
+    def move_node(self, node: NodeT, new_parent: Optional[NodeT]) -> "Tree[NodeT]":
+        """
+        Returns a copy of *self* with node *node* as a child of *new_parent*.
+        """
+        if node not in self:
+            raise ValueError(f"'{node}' not a part of the tree => cannot move.")
+
+        if self.is_root(node):
+            if new_parent is None:
+                return self
+            else:
+                raise ValueError("Moving root not allowed.")
+
+        if new_parent is None:
+            raise ValueError("Making multiple roots not allowed")
+
+        if new_parent not in self:
+            raise ValueError(f"Cannot move to '{new_parent}' as it's not in tree.")
+
+        parent = self.parent(node)
+        assert parent is not None  # parent=root handled as a special case
+        siblings = self.children(parent)
+        parents_new_children = tuple(frozenset(siblings) - frozenset([node]))
+        new_parents_children = self.children(new_parent) + (node,)
+
+        new_child_to_parent = self._child_to_parent.set(node, new_parent)
+        new_parent_to_children = (self._parent_to_children
+                                  .set(parent, parents_new_children)
+                                  .set(new_parent, new_parents_children))
+
+        return Tree(new_parent_to_children,
+                    new_child_to_parent)
+
+    def __str__(self) -> str:
+        """
+        Stringifies the tree by using the box-drawing unicode characters.
+
+        .. doctest::
+
+            >>> from loopy.schedule.tree import Tree
+            >>> tree = (Tree.from_root("Root")
+            ...         .add_node("A", "Root")
+            ...         .add_node("B", "Root")
+            ...         .add_node("D", "B")
+            ...         .add_node("E", "B")
+            ...         .add_node("C", "A"))
+
+            >>> print(tree)
+            Root
+            ├── A
+            │   └── C
+            └── B
+                ├── D
+                └── E
+        """
+        def rec(node: NodeT) -> List[str]:
+            children_result = [rec(c) for c in self.children(node)]
+
+            def post_process_non_last_child(children: Sequence[str]) -> list[str]:
+                return ["├── " + children[0]] + [f"│   {c}" for c in children[1:]]
+
+            def post_process_last_child(children: Sequence[str]) -> list[str]:
+                return ["└── " + children[0]] + [f"    {c}" for c in children[1:]]
+
+            children_result = ([post_process_non_last_child(c)
+                                for c in children_result[:-1]]
+                            + [post_process_last_child(c)
+                                for c in children_result[-1:]])
+            return [str(node)] + sum(children_result, start=[])
+
+        return "\n".join(rec(self.root))
+
+    def nodes(self) -> Iterator[NodeT]:
+        return iter(self._child_to_parent.keys())
+
+# }}}

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -709,7 +709,7 @@ class MemAccess(ImmutableRecord):
     .. attribute:: variable_tags
 
        A :class:`frozenset` of subclasses of :class:`~pytools.tag.Tag`
-       that reflects :attr:`~loopy.symbolic.TaggedVariable.tags` of
+       that reflects :attr:`~loopy.TaggedVariable.tags` of
        an accessed variable.
 
     .. attribute:: count_granularity

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -888,7 +888,7 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
                     struct_overflow_arg_names)
 
             py_passed_args = []
-            struct_pack_types = []
+            struct_pack_types: list[str] = []
             struct_pack_args = []
 
             for arg_name in skai.passed_names:

--- a/loopy/transform/add_barrier.py
+++ b/loopy/transform/add_barrier.py
@@ -91,7 +91,7 @@ def add_barrier(kernel, insn_before="", insn_after="", id_based_on=None,
 
     new_kernel = kernel.copy(instructions=kernel.instructions + [barrier_to_add])
     if insn_after is not None:
-        new_kernel = add_dependency(kernel=new_kernel,
+        new_kernel = add_dependency(new_kernel,
                                  insn_match=insn_after,
                                  depends_on="id:"+id)
 

--- a/loopy/transform/concatenate.py
+++ b/loopy/transform/concatenate.py
@@ -85,6 +85,9 @@ def concatenate_arrays(
         axis_length += ary.shape[axis_nr]
 
     new_ary = arrays[0]
+    if not isinstance(new_ary.shape, tuple):
+        raise ValueError("one of the arrays has indeterminate shape")
+
     new_shape = list(new_ary.shape)
     new_shape[axis_nr] = axis_length
     new_ary = new_ary.copy(shape=tuple(new_shape))

--- a/loopy/transform/instruction.py
+++ b/loopy/transform/instruction.py
@@ -267,6 +267,7 @@ def replace_instruction_ids_in_insn(
     new_no_sync_with: List[Tuple[str, str]] = []
 
     if insn.id in replacements:
+        assert isinstance(insn.id, str)
         insn = insn.copy(id=replacements[insn.id][0])
 
     new_depends_on = list(insn.depends_on)

--- a/loopy/transform/realize_reduction.py
+++ b/loopy/transform/realize_reduction.py
@@ -2019,7 +2019,7 @@ def realize_reduction_for_single_kernel(kernel, callables_table,
                         | red_realize_ctx.surrounding_insn_add_within_inames))
 
             kwargs.pop("id")
-            kwargs.pop("depends_on")
+            kwargs.pop("happens_after")
             kwargs.pop("expression")
             kwargs.pop("assignee", None)
             kwargs.pop("assignees", None)

--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -88,6 +88,7 @@ __doc__ = """
 
 .. autofunction:: for_each_kernel
 
+.. autoclass:: TUnitOrKernelT
 """
 
 

--- a/loopy/translation_unit.py
+++ b/loopy/translation_unit.py
@@ -735,6 +735,9 @@ class CallablesInferenceContext:
 # }}}
 
 
+TUnitOrKernelT = TypeVar("TUnitOrKernelT", LoopKernel, TranslationUnit)
+
+
 # {{{ helper functions
 
 def make_program(kernel: LoopKernel) -> TranslationUnit:

--- a/loopy/typing.py
+++ b/loopy/typing.py
@@ -51,6 +51,8 @@ ExpressionT: TypeAlias = Union[IntegralT, FloatT, Expression]
 ShapeType: TypeAlias = Tuple[ExpressionT, ...]
 StridesType: TypeAlias = ShapeType
 
+InameStr: TypeAlias = str
+
 
 class auto:  # noqa
     """A generic placeholder object for something that should be automatically

--- a/loopy/typing.py
+++ b/loopy/typing.py
@@ -1,3 +1,15 @@
+"""
+.. autoclass:: IntegralT
+.. autoclass:: FloatT
+.. autoclass:: ExpressionT
+.. autoclass:: ShapeType
+.. autoclass:: auto
+"""
+
+
+from __future__ import annotations
+
+
 __copyright__ = "Copyright (C) 2022 University of Illinois Board of Trustees"
 
 __license__ = """
@@ -24,25 +36,26 @@ THE SOFTWARE.
 from typing import Optional, Tuple, TypeVar, Union
 
 import numpy as np
+from typing_extensions import TypeAlias
 
 from pymbolic.primitives import Expression
 
 
-IntegralT = Union[int, np.int8, np.int16, np.int32, np.int64, np.uint8,
+IntegralT: TypeAlias = Union[int, np.int8, np.int16, np.int32, np.int64, np.uint8,
                   np.uint16, np.uint32, np.uint64]
-FloatT = Union[float, complex, np.float32, np.float64, np.complex64,
+FloatT: TypeAlias = Union[float, complex, np.float32, np.float64, np.complex64,
         np.complex128]
 
 
-ExpressionT = Union[IntegralT, FloatT, Expression]
-ShapeType = Tuple[ExpressionT, ...]
-StridesType = ShapeType
+ExpressionT: TypeAlias = Union[IntegralT, FloatT, Expression]
+ShapeType: TypeAlias = Tuple[ExpressionT, ...]
+StridesType: TypeAlias = ShapeType
 
 
 class auto:  # noqa
     """A generic placeholder object for something that should be automatically
     determined.  See, for example, the *shape* or *strides* argument of
-    :class:`ArrayArg`.
+    :class:`~loopy.ArrayArg`.
     """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pyrsistent",
     "immutables",
 
-    # for Self
+    # for Self, TypeAlias
     "typing-extensions>=4; python_version<'3.12'",
 ]
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
     "Mako",
     "pyrsistent",
     "immutables",
-    "typing_extensions",
+
+    # for Self
+    "typing-extensions>=4; python_version<'3.12'",
 ]
 [project.optional-dependencies]
 pyopencl = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ known-local-folder = [
 lines-after-imports = 2
 
 [tool.mypy]
-python_version = 3.8
+python_version = "3.10"
 warn_unused_ignores = true
 
 # TODO

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -314,10 +314,7 @@ def test_ispc_streaming_stores():
     knl = lp.split_iname(knl, "i_inner", 8, inner_tag="l.0")
     knl = lp.tag_instructions(knl, "!streaming_store")
 
-    knl = lp.add_and_infer_dtypes(knl, {
-        var: stream_dtype
-        for var in vars
-        })
+    knl = lp.add_and_infer_dtypes(knl, dict.fromkeys(vars, stream_dtype))
 
     knl = lp.set_argument_order(knl, vars + ["n"])
 

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -1720,6 +1720,7 @@ def test_duplicate_iname_not_read_only_nested(ctx_factory):
         """,
         [lp.GlobalArg("A,x,y", shape=lp.auto, dtype=np.float32),
          ...],
+         seq_dependencies=True,
     )
     ref_t_unit = t_unit
 

--- a/test/test_tree.py
+++ b/test/test_tree.py
@@ -1,0 +1,50 @@
+__copyright__ = "Copyright (C) 2022 University of Illinois Board of Trustees"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from pyopencl.tools import (  # noqa: F401
+    pytest_generate_tests_for_pyopencl as pytest_generate_tests,
+)
+
+from loopy.schedule.tree import Tree
+
+
+def test_tree_simple():
+    tree = Tree.from_root("")
+
+    tree = tree.add_node("bar", parent="")
+    tree = tree.add_node("baz", parent="bar")
+
+    assert tree.depth("") == 0
+    assert tree.depth("bar") == 1
+    assert tree.depth("baz") == 2
+
+    assert "" in tree
+    assert "bar" in tree
+    assert "baz" in tree
+    assert "foo" not in tree
+
+    tree = tree.replace_node("bar", "foo")
+    assert "bar" not in tree
+    assert "foo" in tree
+
+    tree = tree.move_node("baz", new_parent="")
+    assert tree.depth("baz") == 1


### PR DESCRIPTION
A big, mostly unrelated pile of cleanups that started with what was needed to get depending packages to be happy with the types in loopy, after #863 declared loopy "typed" towards external packages. Best read commit-by-commit, if at all. :slightly_smiling_face: 

- Includes `HappensAfter` and `InstructionBase` typing from #785 by @a-alveyblanc 
- Includes #690 by @kaushikcfd and @matthiasdiener 