### PR TITLE
Un-type `symbolic.flatten`

### DIFF
--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -37,8 +37,6 @@ from typing import (
     Mapping,
     Sequence,
     Tuple,
-    TypeVar,
-    cast,
 )
 
 import immutables
@@ -49,7 +47,6 @@ import pymbolic.primitives  # FIXME: also import by full name to allow sphinx to
 import pymbolic.primitives as p
 import pytools.lex
 from islpy import dim_type
-from pymbolic import ArithmeticExpressionT
 from pymbolic.mapper import (
     CachedCombineMapper as CombineMapperBase,
     CachedIdentityMapper as IdentityMapperBase,
@@ -211,14 +208,8 @@ class FlattenMapper(FlattenMapperBase, IdentityMapperMixin):
     pass
 
 
-ArithmeticOrExpressionT = TypeVar(
-                "ArithmeticOrExpressionT",
-                ArithmeticExpressionT,
-                ExpressionT)
-
-
-def flatten(expr: ArithmeticOrExpressionT) -> ArithmeticOrExpressionT:
-    return cast(ArithmeticOrExpressionT, FlattenMapper()(expr))
+def flatten(expr):
+    return FlattenMapper()(expr)
 
 
 class IdentityMapper(IdentityMapperBase, IdentityMapperMixin):


### PR DESCRIPTION
This restores compatibility with pymbolic 2022.2.

x-ref: https://github.com/firedrakeproject/loopy/issues/27

Mypy failure is expected, won't be fixed until #868 goes in.

cc @connorjward 