### PR TITLE
Remove kernel.schedule (deprecated)

### DIFF
--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -121,7 +121,7 @@ class LoopKernel(Taggable):
     .. autoattribute:: domains
     .. autoattribute:: instructions
     .. autoattribute:: args
-    .. autoattribute:: schedule
+    .. autoattribute:: linearization
     .. autoattribute:: name
     .. autoattribute:: preambles
     .. autoattribute:: preamble_generators

--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -530,14 +530,6 @@ class LoopKernel(Taggable):
 
     # }}}
 
-    @property
-    def schedule(self):
-        warn(
-                "'LoopKernel.schedule' is deprecated and will be removed in 2022. "
-                "Call 'LoopKernel.linearization' instead.",
-                DeprecationWarning, stacklevel=2)
-        return self.linearization
-
     # {{{ iname wrangling
 
     def iname_tags(self, iname):

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -923,7 +923,7 @@ def _generate_loop_schedules_v2(kernel: LoopKernel) -> Sequence[ScheduleItem]:
         raise V2SchedulerNotImplementedError("v2 scheduler cannot schedule"
                 " kernels with instruction priorities set.")
 
-    if kernel.schedule is not None:
+    if kernel.linearization is not None:
         # cannot handle preschedule yet
         raise V2SchedulerNotImplementedError("v2 scheduler cannot schedule"
                 " prescheduled kernels.")


### PR DESCRIPTION
This was raising a large number of warnings in our CI.

I assume that it is fine to remove code slated for removal nearly 3 years ago.