### PR TITLE
Tree: various speedups

### DIFF
--- a/loopy/schedule/tree.py
+++ b/loopy/schedule/tree.py
@@ -50,9 +50,9 @@ from pytools import memoize_method
 NodeT = TypeVar("NodeT", bound=Hashable)
 
 
-# Not frozen because it is slower. Tree objects are immutable, and offer no
-# way to mutate the tree.
-@dataclass(frozen=False)
+# Not frozen when optimizations are enabled because it is slower.
+# Tree objects are immutable, and offer no way to mutate the tree.
+@dataclass(frozen=__debug__)  # type: ignore[literal-required]
 class Tree(Generic[NodeT]):
     """
     An immutable tree containing nodes of type :class:`NodeT`.
@@ -128,11 +128,9 @@ class Tree(Generic[NodeT]):
             return 0
 
         parent_of_node = self.parent(node)
+        assert parent_of_node is not None
 
-        from typing import cast
-
-        # cast-reason: parent_of_node can not be None (as per is_root check)
-        return 1 + self.depth(cast(NodeT, parent_of_node))
+        return 1 + self.depth(parent_of_node)
 
     def is_root(self, node: NodeT) -> bool:
         """Return *True* if *node* is the root of the tree."""

--- a/loopy/schedule/tree.py
+++ b/loopy/schedule/tree.py
@@ -123,12 +123,9 @@ class Tree(Generic[NodeT]):
         """
         Returns the depth of *node*, with the root having depth 0.
         """
-        if self.is_root(node):
-            # => None
-            return 0
-
         parent_of_node = self.parent(node)
-        assert parent_of_node is not None
+        if parent_of_node is None:
+            return 0
 
         return 1 + self.depth(parent_of_node)
 

--- a/loopy/schedule/tree.py
+++ b/loopy/schedule/tree.py
@@ -97,12 +97,10 @@ class Tree(Generic[NodeT]):
         """
         Returns a :class:`tuple` of nodes that are ancestors of *node*.
         """
-        if self.is_root(node):
+        parent = self.parent(node)
+        if parent is None:
             # => root
             return ()
-
-        parent = self._child_to_parent[node]
-        assert parent is not None
 
         return (parent, *self.ancestors(parent))
 


### PR DESCRIPTION
- make dataclass non-frozen
- use mutate() for cases where a Map is modified multiple times
- remove asserts for cases that would fail immediately anyway

---

For the following microbenchmark:

```python
from loopy.schedule.tree import Tree

def run_t():
    tree = Tree.from_root(-1)

    for i in range(100):
        tree = tree.add_node(i, i-1)

    for i in range(100):
        tree = tree.replace_node(i, 101+i)

    for i in range(100):
        tree = tree.move_node(101+i, -1)

from timeit import timeit

print(timeit(run_t, number=1000))
```

, this PR results in performance improvements:

| Branch       | Without -O | With -O |
|----------------|-------------|--------|
| main           | 0.495       | 0.435  |
| tree-speedups ([78c19c8](https://github.com/inducer/loopy/pull/887/commits/78c19c8d973dcdd47b466f1c5d0cf634f6fa4c70)) | 0.408       | 0.347  |