### PR TITLE
Run parallel Firedrake tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
                 # patch so exception messages get shown
                 curl -L https://gist.githubusercontent.com/inducer/17d7134ace215f0df1f3627eac4195c7/raw/ec5470a7d8587b6e1f336f3ef1d0ece5e26f236a/firedrake-debug-patch.diff | patch -p1
 
-                pytest --tb=native -rsxw --durations=10 -m 'not parallel' tests/firedrake/multigrid/
+                pytest --tb=native -rsxw --durations=10 tests/firedrake/regression -k "poisson_strong or stokes_mini or dg_advection"
 
     validate_cff:
             name: Validate CITATION.cff


### PR DESCRIPTION
Closes #891 

In this change we switch to running the "smoke tests" that Firedrake encourages users to do: https://www.firedrakeproject.org/firedrake/download.html#testing-the-installation

Note that tests are currently failing because of the reason [discussed here](https://github.com/inducer/loopy/pull/886#issuecomment-2507860688). This PR can probably follow any other fixes to loopy/Firedrake.