### PR TITLE
Sort predicates in codegen so they are consistent in parallel

### DIFF
--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -475,7 +475,7 @@ def build_loop_nest(codegen_state, schedule_index):
                     condition_exprs = ([
                             constraint_to_cond_expr(cns)
                             for cns in bounds_checks]
-                            + list(sorted(pred_checks, key=lambda pred: repr(pred))))
+                            + sorted(pred_checks, key=lambda pred: repr(pred)))
 
                     prev_result = prev_gen_code(inner_codegen_state)
 

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -472,9 +472,10 @@ def build_loop_nest(codegen_state, schedule_index):
                 prev_gen_code = gen_code
 
                 def gen_code(inner_codegen_state):  # pylint: disable=function-redefined
-                    condition_exprs = [
+                    condition_exprs = ([
                             constraint_to_cond_expr(cns)
-                            for cns in bounds_checks] + list(pred_checks)
+                            for cns in bounds_checks]
+                            + list(sorted(pred_checks, key=lambda pred: repr(pred))))
 
                     prev_result = prev_gen_code(inner_codegen_state)
 


### PR DESCRIPTION
We have been generating slightly different code on different ranks because predicates are stored as a frozenset.