### PR TITLE
Handle type casting in op counter

### DIFF
--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1003,6 +1003,9 @@ class ExpressionOpCounter(CounterBase):
                                 + self.rec(expr.base) \
                                 + self.rec(expr.exponent)
 
+    def map_type_cast(self, expr):
+        return self.new_zero_poly_map()
+
     def map_left_shift(self, expr):
         return self.new_poly_map({Op(dtype=self.type_inf(expr),
                               name="shift",

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1004,7 +1004,8 @@ class ExpressionOpCounter(CounterBase):
                                 + self.rec(expr.exponent)
 
     def map_type_cast(self, expr):
-        return self.new_zero_poly_map()
+        # Treats type casting as free
+        return self.rec(expr.child)
 
     def map_left_shift(self, expr):
         return self.new_poly_map({Op(dtype=self.type_inf(expr),


### PR DESCRIPTION
Counting ops currently fails when a type cast operation is encountered. This considers the cost of type casting to be free.