### PR TITLE
Pass immutable arg_id_to_dtype to InKernelCallables

### DIFF
--- a/examples/python/call-external.py
+++ b/examples/python/call-external.py
@@ -1,4 +1,5 @@
 import numpy as np
+from constantdict import constantdict
 
 import loopy as lp
 from loopy.diagnostic import LoopyError
@@ -30,9 +31,10 @@ class CBLASGEMV(lp.ScalarCallable):
                              "types")
 
         return (self.copy(name_in_target=name_in_target,
-                          arg_id_to_dtype={0: vec_dtype,
-                                           1: vec_dtype,
-                                           -1: vec_dtype}),
+                          arg_id_to_dtype=constantdict({
+                              0: vec_dtype,
+                              1: vec_dtype,
+                              -1: vec_dtype})),
                 callables_table)
 
     def with_descrs(self, arg_id_to_descr, callables_table):

--- a/loopy/library/random123.py
+++ b/loopy/library/random123.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 import numpy as np
+from constantdict import constantdict
 from mako.template import Template
 
 from pymbolic.typing import not_none
@@ -221,8 +222,8 @@ class Random123Callable(ScalarCallable):
             new_arg_id_to_dtype = {-1: ctr_dtype, -2: ctr_dtype, 0: ctr_dtype, 1:
                     key_dtype}
             return (
-                    self.copy(arg_id_to_dtype=new_arg_id_to_dtype,
-                        name_in_target=fn+"_gen"),
+                    self.copy(arg_id_to_dtype=constantdict(new_arg_id_to_dtype),
+                              name_in_target=fn+"_gen"),
                     callables_table)
 
         elif name == fn + "_f32":
@@ -230,18 +231,22 @@ class Random123Callable(ScalarCallable):
                 rng_variant.width),
                     -2: ctr_dtype, 0: ctr_dtype, 1:
                     key_dtype}
-            return self.copy(arg_id_to_dtype=new_arg_id_to_dtype,
-                    name_in_target=name), callables_table
+            return (
+                    self.copy(arg_id_to_dtype=constantdict(new_arg_id_to_dtype),
+                              name_in_target=name),
+                    callables_table)
 
         elif name == fn + "_f64":
             new_arg_id_to_dtype = {-1: target.vector_dtype(NumpyType(np.float64),
                 rng_variant.width),
                     -2: ctr_dtype, 0: ctr_dtype, 1:
                     key_dtype}
-            return self.copy(arg_id_to_dtype=new_arg_id_to_dtype,
-                    name_in_target=name), callables_table
+            return (
+                    self.copy(arg_id_to_dtype=constantdict(new_arg_id_to_dtype),
+                              name_in_target=name),
+                    callables_table)
 
-        return (self.copy(arg_id_to_dtype=arg_id_to_dtype),
+        return (self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                 callables_table)
 
     def generate_preambles(self, target):

--- a/loopy/library/reduction.py
+++ b/loopy/library/reduction.py
@@ -27,6 +27,7 @@ THE SOFTWARE.
 from typing import TYPE_CHECKING
 
 import numpy as np
+from constantdict import constantdict
 
 from pymbolic import var
 from pymbolic.primitives import expr_dataclass
@@ -580,21 +581,25 @@ class ReductionCallable(ScalarCallable):
         index_dtype = arg_id_to_dtype[1]
         result_dtypes = self.name.reduction_op.result_dtypes(scalar_dtype,  # pylint: disable=no-member
                 index_dtype)
-        new_arg_id_to_dtype = arg_id_to_dtype.copy()
+
+        new_arg_id_to_dtype = constantdict(arg_id_to_dtype).mutate()
         new_arg_id_to_dtype[-1] = result_dtypes[0]
         new_arg_id_to_dtype[-2] = result_dtypes[1]
         name_in_target = self.name.reduction_op.prefix(scalar_dtype,  # pylint: disable=no-member
                 index_dtype) + "_op"
 
-        return self.copy(arg_id_to_dtype=new_arg_id_to_dtype,
-                name_in_target=name_in_target), callables_table
+        return (self.copy(arg_id_to_dtype=new_arg_id_to_dtype.finish(),
+                          name_in_target=name_in_target),
+                callables_table)
 
     def with_descrs(self, arg_id_to_descr, callables_table):
         from loopy.kernel.function_interface import ValueArgDescriptor
-        new_arg_id_to_descr = arg_id_to_descr.copy()
+
+        new_arg_id_to_descr = constantdict(arg_id_to_descr).mutate()
         new_arg_id_to_descr[-1] = ValueArgDescriptor()
+
         return (
-                self.copy(arg_id_to_descr=arg_id_to_descr),
+                self.copy(arg_id_to_descr=new_arg_id_to_descr.finish()),
                 callables_table)
 
 

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -28,6 +28,7 @@ import re
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import numpy as np
+from constantdict import constantdict
 
 import pymbolic.primitives as p
 from cgen import (
@@ -530,7 +531,7 @@ class CMathCallable(ScalarCallable):
                 # the types provided aren't mature enough to specialize the
                 # callable
                 return (
-                        self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                        self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                         callables_table)
 
             dtype = arg_id_to_dtype[0].numpy_dtype
@@ -563,9 +564,9 @@ class CMathCallable(ScalarCallable):
 
             return (
                     self.copy(name_in_target=name,
-                        arg_id_to_dtype={
+                        arg_id_to_dtype=constantdict({
                             0: NumpyType(dtype),
-                            -1: NumpyType(result_dtype)}),
+                            -1: NumpyType(result_dtype)})),
                     callables_table)
 
         # binary functions
@@ -580,7 +581,7 @@ class CMathCallable(ScalarCallable):
                 # the types provided aren't mature enough to specialize the
                 # callable
                 return (
-                        self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                        self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                         callables_table)
 
             dtype = np.result_type(*[
@@ -607,7 +608,7 @@ class CMathCallable(ScalarCallable):
             dtype = NumpyType(dtype)
             return (
                     self.copy(name_in_target=name,
-                        arg_id_to_dtype={-1: dtype, 0: dtype, 1: dtype}),
+                        arg_id_to_dtype=constantdict({-1: dtype, 0: dtype, 1: dtype})),
                     callables_table)
         elif name in ["max", "min"]:
 
@@ -620,7 +621,7 @@ class CMathCallable(ScalarCallable):
                 # the types provided aren't resolved enough to specialize the
                 # callable
                 return (
-                        self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                        self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                         callables_table)
 
             dtype = np.result_type(*[
@@ -632,9 +633,10 @@ class CMathCallable(ScalarCallable):
 
             return (
                     self.copy(name_in_target=f"lpy_{name}_{dtype.name}",
-                              arg_id_to_dtype={-1: NumpyType(dtype),
-                                               0: NumpyType(dtype),
-                                               1: NumpyType(dtype)}),
+                              arg_id_to_dtype=constantdict({
+                                  -1: NumpyType(dtype),
+                                  0: NumpyType(dtype),
+                                  1: NumpyType(dtype)})),
                     callables_table)
         elif name == "isnan":
             for id in arg_id_to_dtype:
@@ -645,7 +647,7 @@ class CMathCallable(ScalarCallable):
                 # the types provided aren't mature enough to specialize the
                 # callable
                 return (
-                        self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                        self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                         callables_table)
 
             dtype = arg_id_to_dtype[0].numpy_dtype
@@ -662,9 +664,9 @@ class CMathCallable(ScalarCallable):
             return (
                     self.copy(
                         name_in_target=name,
-                        arg_id_to_dtype={
+                        arg_id_to_dtype=constantdict({
                             0: NumpyType(dtype),
-                            -1: NumpyType(np.int32)}),
+                            -1: NumpyType(np.int32)})),
                     callables_table)
 
     def generate_preambles(self, target):
@@ -713,7 +715,7 @@ class GNULibcCallable(ScalarCallable):
                 # the types provided aren't mature enough to specialize the
                 # callable
                 return (
-                        self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                        self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                         callables_table)
 
             if not arg_id_to_dtype[0].is_integral():
@@ -738,9 +740,10 @@ class GNULibcCallable(ScalarCallable):
 
             return (
                     self.copy(name_in_target=name_in_target,
-                              arg_id_to_dtype={-1: arg_id_to_dtype[1],
-                                               0: NumpyType(np.int32),
-                                               1: arg_id_to_dtype[1]}),
+                              arg_id_to_dtype=constantdict({
+                                  -1: arg_id_to_dtype[1],
+                                  0: NumpyType(np.int32),
+                                  1: arg_id_to_dtype[1]})),
                     callables_table)
         else:
             raise NotImplementedError(f"with_types for '{name}'")

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Sequence, cast
 from warnings import warn
 
 import numpy as np
+from constantdict import constantdict
 
 import pymbolic.primitives as p
 from cgen import (
@@ -98,7 +99,7 @@ class PyOpenCLCallable(ScalarCallable):
             # the types provided aren't mature enough to specialize the
             # callable
             return (
-                    self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                    self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                     callables_table)
 
         dtype = arg_id_to_dtype[0]
@@ -114,8 +115,10 @@ class PyOpenCLCallable(ScalarCallable):
 
                 return (
                         self.copy(name_in_target=f"{tpname}_{name}",
-                            arg_id_to_dtype={0: dtype, -1: NumpyType(
-                                np.dtype(dtype.numpy_dtype.type(0).real))}),
+                            arg_id_to_dtype=constantdict({
+                                0: dtype,
+                                -1: NumpyType(np.dtype(dtype.numpy_dtype.type(0).real))
+                                })),
                         callables_table)
 
         if name in ["real", "imag", "conj"]:
@@ -124,7 +127,7 @@ class PyOpenCLCallable(ScalarCallable):
                 return (
                         self.copy(
                             name_in_target=f"_lpy_{name}_{tpname}",
-                            arg_id_to_dtype={0: dtype, -1: dtype}),
+                            arg_id_to_dtype=constantdict({0: dtype, -1: dtype})),
                         callables_table)
 
         if name in ["sqrt", "exp", "log",
@@ -142,7 +145,7 @@ class PyOpenCLCallable(ScalarCallable):
 
                 return (
                         self.copy(name_in_target=f"{tpname}_{name}",
-                            arg_id_to_dtype={0: dtype, -1: dtype}),
+                            arg_id_to_dtype=constantdict({0: dtype, -1: dtype})),
                         callables_table)
 
             # fall back to pure OpenCL for real-valued arguments

--- a/test/library_for_test.py
+++ b/test/library_for_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+from constantdict import constantdict
 
 import loopy as lp
 
@@ -8,7 +9,7 @@ class NoRetFunction(lp.ScalarCallable):
         if len(arg_id_to_dtype) != 0:
             raise RuntimeError("'f' cannot take any inputs.")
 
-        return (self.copy(arg_id_to_dtype=arg_id_to_dtype,
+        return (self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype),
                          name_in_target="f"),
                 callables)
 
@@ -16,7 +17,7 @@ class NoRetFunction(lp.ScalarCallable):
         if len(arg_id_to_descr) != 0:
             raise RuntimeError("'f' cannot take any inputs.")
 
-        return (self.copy(arg_id_to_descr=arg_id_to_descr),
+        return (self.copy(arg_id_to_descr=constantdict(arg_id_to_descr)),
                 callables)
 
     def generate_preambles(self, target):
@@ -39,7 +40,7 @@ class SingleArgNoRetFunction(lp.ScalarCallable):
         if input_dtype.numpy_dtype != np.float32:
             raise RuntimeError("'f' only supports f32.")
 
-        return (self.copy(arg_id_to_dtype=arg_id_to_dtype,
+        return (self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype),
                           name_in_target="f"),
                 callables)
 

--- a/test/testlib.py
+++ b/test/testlib.py
@@ -1,4 +1,5 @@
 import numpy as np
+from constantdict import constantdict
 
 import loopy as lp
 
@@ -28,7 +29,7 @@ class Log2Callable(lp.ScalarCallable):
             # the types provided aren't mature enough to specialize the
             # callable
             return (
-                    self.copy(arg_id_to_dtype=arg_id_to_dtype),
+                    self.copy(arg_id_to_dtype=constantdict(arg_id_to_dtype)),
                     callables_table)
 
         dtype = arg_id_to_dtype[0].numpy_dtype
@@ -48,8 +49,10 @@ class Log2Callable(lp.ScalarCallable):
         from loopy.types import NumpyType
         return (
                 self.copy(name_in_target=name_in_target,
-                    arg_id_to_dtype={0: NumpyType(dtype), -1:
-                        NumpyType(dtype)}),
+                    arg_id_to_dtype=constantdict({
+                        0: NumpyType(dtype),
+                        -1: NumpyType(dtype)
+                        })),
                 callables_table)
 
 


### PR DESCRIPTION
This uses `immutabledict` whenever possible. It's not exactly clear to me if some of these should be passed in as immutable higher up the stack, so someone more knowledgeable should have a serious look.

Fixes #905.