### PR TITLE
ignore proto-tests/ for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,3 +202,5 @@ extend-exclude = [
   "notes/*/*.eps",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--ignore=proto-tests"


### PR DESCRIPTION
With this change, one can run `pytest` directly in the main directory of loopy (without specifying the `test/` dir).

cf. https://github.com/inducer/loopy/pull/804