### PR TITLE
Use default_rng in tests

### DIFF
--- a/loopy/transform/diff.py
+++ b/loopy/transform/diff.py
@@ -390,8 +390,8 @@ def diff_kernel(kernel, diff_outputs, by, diff_iname_prefix="diff_i",
 
     if isinstance(diff_outputs, str):
         diff_outputs = [
-                dout.strip() for dout in diff_outputs.split(",")
-                if dout.strip()]
+                d_out.strip() for d_out in diff_outputs.split(",")
+                if d_out.strip()]
 
     by_arg = kernel.arg_dict[by]
     additional_shape = by_arg.shape
@@ -405,8 +405,8 @@ def diff_kernel(kernel, diff_outputs, by, diff_iname_prefix="diff_i",
             additional_shape=additional_shape)
 
     result = {}
-    for dout in diff_outputs:
-        result = diff_context.get_diff_var(dout)
+    for d_out in diff_outputs:
+        result = diff_context.get_diff_var(d_out)
 
     for cout in copy_outputs:
         diff_context.import_output_var(cout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ extend-ignore = [
     "N817", # CamelCase `SubstitutionRuleMappingContext` imported as acronym `SRMC`
 
     # FIXME
-    "NPY002", # numpy rng
     "UP031", # .format instead of %s
     "UP032", # .format instead of %s
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,16 +190,12 @@ extend-ignore-re = [
 arange = "arange"
 # N-Dimensional
 ND = "ND"
-# used for 'diff_output'
-dout = "dout"
 # an element-wise slice of array u
 ue = "ue"
 # used in an ordering context, "ab" / "ba"
 ba = "ba"
 # Fortran Loopy
 floopy = "floopy"
-
-"dependees" = "dependees"
 
 [tool.typos.files]
 extend-exclude = [

--- a/test/test_callables.py
+++ b/test/test_callables.py
@@ -39,10 +39,11 @@ from loopy.version import LOOPY_USE_LANGUAGE_VERSION_2018_2  # noqa: F401
 def test_register_function_lookup(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     from testlib import Log2Callable
 
-    x = np.random.rand(10)
+    x = rng.random(size=10)
     queue = cl.CommandQueue(ctx)
 
     prog = lp.make_kernel(
@@ -61,10 +62,11 @@ def test_register_function_lookup(ctx_factory):
 def test_register_knl(ctx_factory, inline):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
-    n = 4
+    rng = np.random.default_rng(seed=42)
 
-    x = np.random.rand(n, n, n, n, n)
-    y = np.random.rand(n, n, n, n, n)
+    n = 4
+    x = rng.random(size=(n, n, n, n, n))
+    y = rng.random(size=(n, n, n, n, n))
 
     grandchild_knl = lp.make_function(
             "{[i, j]:0<= i, j< 4}",
@@ -108,10 +110,11 @@ def test_register_knl(ctx_factory, inline):
 def test_slices_with_negative_step(ctx_factory, inline):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
-    n = 4
+    rng = np.random.default_rng(seed=42)
 
-    x = np.random.rand(n, n, n, n, n)
-    y = np.random.rand(n, n, n, n, n)
+    n = 4
+    x = rng.random(size=(n, n, n, n, n))
+    y = rng.random(size=(n, n, n, n, n))
 
     child_knl = lp.make_function(
             "{[i, j]:0<=i, j < 4}",
@@ -245,12 +248,16 @@ def test_shape_translation_through_sub_array_ref(ctx_factory, inline):
 def test_multi_arg_array_call(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
+
     import pymbolic.primitives as p
+
     n = 10
     acc_i = p.Variable("acc_i")
     i = p.Variable("i")
     index = p.Variable("index")
     a_i = p.Subscript(p.Variable("a"), p.Variable("i"))
+
     argmin_kernel = lp.make_function(
             "{[i]: 0 <= i < n}",
             [
@@ -281,9 +288,9 @@ def test_multi_arg_array_call(ctx_factory):
 
     knl = lp.fix_parameters(knl, n=n)
     knl = lp.set_options(knl, return_dict=True)
-
     knl = lp.merge([knl, argmin_kernel])
-    b = np.random.randn(n)
+
+    b = rng.normal(size=n)
     _evt, out_dict = knl(queue, b=b)
     tol = 1e-15
     from numpy.linalg import norm
@@ -346,9 +353,10 @@ def test_empty_sub_array_refs(ctx_factory, inline):
     # See: https://github.com/OP2/PyOP2/pull/559#discussion_r272208618
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
-    x = np.random.randn(10)
-    y = np.random.randn(10)
+    x = rng.normal(size=10)
+    y = rng.normal(size=10)
 
     callee = lp.make_function(
             "{[d]:0<=d<1}",
@@ -375,10 +383,11 @@ def test_empty_sub_array_refs(ctx_factory, inline):
 def test_array_inputs_to_callee_kernels(ctx_factory, inline):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
-    n = 2 ** 3
+    rng = np.random.default_rng(seed=42)
 
-    x = np.random.rand(n, n)
-    y = np.random.rand(n, n)
+    n = 2 ** 3
+    x = rng.normal(size=(n, n))
+    y = rng.normal(size=(n, n))
 
     child_knl = lp.make_function(
             "{[i, j]:0<=i, j < 8}",
@@ -469,6 +478,8 @@ def test_unknown_stride_to_callee(ctx_factory):
 def test_argument_matching_for_inplace_update(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
+
     twice = lp.make_function(
             "{[i]: 0<=i<10}",
             """
@@ -483,7 +494,7 @@ def test_argument_matching_for_inplace_update(ctx_factory):
 
     knl = lp.merge([knl, twice])
 
-    x = np.random.randn(10)
+    x = rng.normal(size=10)
     _evt, (out, ) = knl(queue, x=np.copy(x))
 
     assert np.allclose(2*x, out)
@@ -492,6 +503,8 @@ def test_argument_matching_for_inplace_update(ctx_factory):
 def test_non_zero_start_in_subarray_ref(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
+
     twice = lp.make_function(
             "{[i]: 0<=i<10}",
             """
@@ -503,10 +516,9 @@ def test_non_zero_start_in_subarray_ref(ctx_factory):
             """
             [i]:y[i+5] = twice([j]: x[j])
             """, [lp.GlobalArg("x, y", shape=(10,), dtype=np.float64)])
-
     knl = lp.merge([knl, twice])
 
-    x = np.random.randn(10)
+    x = rng.normal(size=10)
     _evt, (out, ) = knl(queue, x=np.copy(x))
 
     assert np.allclose(2*x, out)
@@ -710,7 +722,7 @@ def test_passing_and_getting_scalar_in_clbl_knl(ctx_factory, inline):
 def test_passing_scalar_as_indexed_subcript_in_clbl_knl(ctx_factory, inline):
     ctx = cl.create_some_context()
     cq = cl.CommandQueue(ctx)
-    x_in = np.random.rand()
+    rng = np.random.default_rng(seed=42)
 
     twice = lp.make_function(
         "{ : }",
@@ -731,6 +743,7 @@ def test_passing_scalar_as_indexed_subcript_in_clbl_knl(ctx_factory, inline):
     if inline:
         knl = lp.inline_callable_kernel(knl, "twice")
 
+    x_in = rng.random()
     _evt, (out,) = knl(cq, X=x_in)
 
     np.testing.assert_allclose(out.get(), 2*x_in)
@@ -1312,8 +1325,7 @@ def test_c_instruction_in_callee(ctx_factory, inline):
 
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
-
-    n = np.random.randint(3, 8)
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_function(
         "{[i]: 0<=i<10}",
@@ -1338,6 +1350,7 @@ def test_c_instruction_in_callee(ctx_factory, inline):
     if inline:
         t_unit = lp.inline_callable_kernel(t_unit, "circuit_breaker")
 
+    n = rng.integers(3, 8)
     _, (out,) = t_unit(cq, N=n)
 
     assert out.get() == (n-1)

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -56,6 +56,7 @@ from loopy.version import LOOPY_USE_LANGUAGE_VERSION_2018_2  # noqa
 def test_diff(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_kernel(
          """{ [i,j]: 0<=i,j<n }""",
@@ -78,10 +79,10 @@ def test_diff(ctx_factory):
     print(dknl)
 
     n = 50
-    x = np.random.randn(n)
-    y = np.random.randn(n)
+    x = rng.normal(size=n)
+    y = rng.normal(size=n)
 
-    dx = np.random.randn(n)
+    dx = rng.normal(size=n)
 
     fac = 1e-1
     h1 = 1e-4

--- a/test/test_einsum.py
+++ b/test/test_einsum.py
@@ -51,9 +51,10 @@ def test_make_einsum_error_handling():
 def test_einsum_array_manipulation(ctx_factory, spec):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 4
-    a = np.random.rand(n, n)
+    a = rng.random(size=(n, n))
     arg_names = ("a",)
 
     knl = lp.make_einsum(spec, arg_names)
@@ -69,10 +70,11 @@ def test_einsum_array_manipulation(ctx_factory, spec):
 def test_einsum_array_matvec(ctx_factory, spec):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 4
-    a = np.random.rand(n, n)
-    b = np.random.rand(n)
+    a = rng.random(size=(n, n))
+    b = rng.random(size=n)
     arg_names = ("a", "b")
 
     knl = lp.make_einsum(spec, arg_names)
@@ -90,10 +92,11 @@ def test_einsum_array_matvec(ctx_factory, spec):
 def test_einsum_array_ops_same_dims(ctx_factory, spec):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 4
-    a = np.random.rand(n, n)
-    b = np.random.rand(n, n)
+    a = rng.random(size=(n, n))
+    b = rng.random(size=(n, n))
     arg_names = ("a", "b")
 
     knl = lp.make_einsum(spec, arg_names)
@@ -109,12 +112,13 @@ def test_einsum_array_ops_same_dims(ctx_factory, spec):
 def test_einsum_array_ops_diff_dims(ctx_factory, spec):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 4
     m = 3
     o = 5
-    a = np.random.rand(n, m)
-    b = np.random.rand(m, o)
+    a = rng.random(size=(n, m))
+    b = rng.random(size=(m, o))
     arg_names = ("a", "b")
 
     knl = lp.make_einsum(spec, arg_names)
@@ -130,11 +134,12 @@ def test_einsum_array_ops_diff_dims(ctx_factory, spec):
 def test_einsum_array_ops_triple_prod(ctx_factory, spec):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 3
-    a = np.random.rand(n, n)
-    b = np.random.rand(n, n)
-    c = np.random.rand(n, n)
+    a = rng.random(size=(n, n))
+    b = rng.random(size=(n, n))
+    c = rng.random(size=(n, n))
     arg_names = ("a", "b", "c")
 
     knl = lp.make_einsum(spec, arg_names)
@@ -147,13 +152,14 @@ def test_einsum_array_ops_triple_prod(ctx_factory, spec):
 def test_einsum_with_variable_strides(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     spec = "ijk,jl->il"
     knl = lp.make_einsum(spec, ("a", "b"),
                          default_order=lp.auto, default_offset=lp.auto)
 
-    a_untransposed = np.random.randn(3, 5, 4)
-    b = np.random.randn(4, 5)
+    a_untransposed = rng.normal(size=(3, 5, 4))
+    b = rng.normal(size=(4, 5))
 
     a = a_untransposed.transpose((0, 2, 1))
     a_dev = cl.array.to_device(queue, a_untransposed).transpose((0, 2, 1))

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -557,9 +557,10 @@ def test_complex_support(ctx_factory, target):
     knl = lp.set_options(knl, return_dict=True)
 
     n = 10
+    rng = np.random.default_rng(seed=42)
 
-    in1 = np.random.rand(n)
-    in2 = np.random.rand(n)
+    in1 = rng.random(n)
+    in2 = rng.random(n)
 
     kwargs = {"in1": in1, "in2": in2}
 

--- a/test/test_fusion.py
+++ b/test/test_fusion.py
@@ -67,6 +67,7 @@ def test_write_block_matrix_fusion(ctx_factory):
 
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     def init_global_mat_prg():
         return lp.make_kernel(
@@ -124,8 +125,8 @@ def test_write_block_matrix_fusion(ctx_factory):
     # and zeros elsewhere
     n = 10
     block_n = 5
-    mat1 = np.random.randn(block_n, block_n)
-    mat2 = np.random.randn(block_n, block_n)
+    mat1 = rng.normal(size=(block_n, block_n))
+    mat2 = rng.normal(size=(block_n, block_n))
     answer = np.block([[mat1, np.zeros((block_n, block_n))],
                       [np.zeros((block_n, block_n)), mat2]])
     kwargs = {"n": n, "m": n}

--- a/test/test_reduction.py
+++ b/test/test_reduction.py
@@ -297,9 +297,9 @@ def test_global_mc_parallel_reduction(ctx_factory, size):
 def test_argmax(ctx_factory):
     logging.basicConfig(level=logging.INFO)
 
-    dtype = np.dtype(np.float32)
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     n = 10000
 
@@ -313,7 +313,7 @@ def test_argmax(ctx_factory):
     print(lp.preprocess_kernel(knl))
     knl = lp.set_options(knl, write_code=True, allow_terminal_colors=True)
 
-    a = np.random.randn(10000).astype(dtype)
+    a = rng.normal(size=10000).astype(np.float32)
     _evt, (max_idx, max_val) = knl(queue, a=a, out_host=True)
     assert max_val == np.max(np.abs(a))
     assert max_idx == np.where(np.abs(a) == max_val)[-1]
@@ -349,6 +349,7 @@ def test_simul_reduce(ctx_factory):
 def test_reduction_library(ctx_factory, op_name, np_op):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_kernel(
             "{[i,j]: 0<=i<n and 0<=j<m }",
@@ -357,7 +358,7 @@ def test_reduction_library(ctx_factory, op_name, np_op):
                 ],
             assumptions="n>=1")
 
-    a = np.random.randn(20, 10)
+    a = rng.normal(size=(20, 10))
     _evt, (res,) = knl(queue, a=a)
 
     assert np.allclose(res, np_op(a, axis=1))
@@ -412,9 +413,10 @@ def test_parallel_multi_output_reduction(ctx_factory):
     knl = lp.add_dtypes(knl, {"a": np.float64})
 
     ctx = ctx_factory()
+    rng = np.random.default_rng(seed=42)
 
     with cl.CommandQueue(ctx) as queue:
-        a = np.random.rand(128)
+        a = rng.random(128)
         _out, (max_index, max_val) = knl(queue, a=a)
 
         assert max_val == np.max(a)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -684,15 +684,16 @@ def test_empty_array_output(ctx_factory):
 def test_empty_array_stride_check(ctx_factory):
     ctx = ctx_factory()
     cq = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     einsum = lp.make_einsum("mij,j->mi", ["a", "x"])
-    einsum(cq, a=np.random.randn(3, 0, 5), x=np.random.randn(5))
+    einsum(cq, a=rng.normal(size=(3, 0, 5)), x=rng.normal(size=5))
 
     if einsum.default_entrypoint.options.skip_arg_checks:
         pytest.skip("args checks disabled, cannot check")
 
     with pytest.raises(ValueError):
-        einsum(cq, a=np.random.randn(3, 2, 5).copy(order="F"), x=np.random.randn(5))
+        einsum(cq, a=rng.normal(size=(3, 2, 5)).copy(order="F"), x=rng.normal(size=5))
 
 
 def test_no_op_with_predicate(ctx_factory):

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -124,6 +124,7 @@ def test_collect_common_factors(ctx_factory):
 def test_to_batched(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_kernel(
          """ { [i,j]: 0<=i,j<n } """,
@@ -141,8 +142,8 @@ def test_to_batched(ctx_factory):
                                                     "x": np.float32,
                                                     "a": np.float32})
 
-    a = np.random.randn(5, 5).astype(np.float32)
-    x = np.random.randn(7, 5).astype(np.float32)
+    a = rng.normal(size=(5, 5)).astype(np.float32)
+    x = rng.normal(size=(7, 5)).astype(np.float32)
 
     # Running both the kernels
     _evt, (out1, ) = bknl(queue, a=a, x=x, n=5, nbatches=7)
@@ -154,6 +155,7 @@ def test_to_batched(ctx_factory):
 
 def test_to_batched_temp(ctx_factory):
     ctx = ctx_factory()
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_kernel(
          """ { [i,j]: 0<=i,j<n } """,
@@ -180,8 +182,8 @@ def test_to_batched_temp(ctx_factory):
     # checking that cnst is not being bathced
     assert bknl["loopy_kernel"].temporary_variables["cnst"].shape == ()
 
-    a = np.random.randn(5, 5)
-    x = np.random.randn(7, 5)
+    a = rng.normal(size=(5, 5))
+    x = rng.normal(size=(7, 5))
 
     # Checking that the program compiles and the logic is correct
     lp.auto_test_vs_ref(
@@ -192,6 +194,8 @@ def test_to_batched_temp(ctx_factory):
 def test_add_barrier(ctx_factory):
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
+
     knl = lp.make_kernel(
             "{[i, j, ii, jj]: 0<=i,j, ii, jj<n}",
             """
@@ -203,7 +207,8 @@ def test_add_barrier(ctx_factory):
                 ...
             ]
     )
-    a = np.random.randn(16, 16)
+
+    a = rng.normal(size=(16, 16))
     knl = lp.add_barrier(knl, "id:transpose", "id:double", "gb1")
 
     knl = lp.split_iname(knl, "i", 2, outer_tag="g.0", inner_tag="l.0")
@@ -1139,6 +1144,7 @@ def test_rename_argument_with_auto_stride(ctx_factory):
 
     ctx = ctx_factory()
     queue = cl.CommandQueue(ctx)
+    rng = np.random.default_rng(seed=42)
 
     knl = lp.make_kernel(
             "{[i]: 0<=i<10}",
@@ -1154,7 +1160,7 @@ def test_rename_argument_with_auto_stride(ctx_factory):
     assert code_str.find("double const *__restrict__ x_new,") != -1
     assert code_str.find("double const *__restrict__ x,") == -1
 
-    _evt, (_out, ) = knl(queue, x_new=np.random.rand(10))
+    _evt, (_out, ) = knl(queue, x_new=rng.random(10))
 
 
 def test_rename_argument_with_assumptions():


### PR DESCRIPTION
Enables `NPY002` and uses `np.random.default_rng()` with a seed everywhere.