### PR TITLE
feat: replace use of deprecated logger.warn

### DIFF
--- a/loopy/target/c/c_execution.py
+++ b/loopy/target/c/c_execution.py
@@ -285,7 +285,7 @@ class CCompiler:
                 # missing compiler python was built with (likely, Conda)
                 # use a default GCCToolchain
                 logger = logging.getLogger(__name__)
-                logger.warn("Default toolchain guessed from python config "
+                logger.warning("Default toolchain guessed from python config "
                             "not found, replacing with default GCCToolchain.")
                 # this is ugly, but I'm not sure there's a clean way to copy the
                 # default args


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warning coming from `logger.warn`:
```python
The 'warn' method is deprecated, use 'warning' instead
```