### PR TITLE
Adapt to changes to firedrake-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,7 @@ jobs:
                 # patch so exception messages get shown
                 curl -L https://gist.githubusercontent.com/inducer/17d7134ace215f0df1f3627eac4195c7/raw/ec5470a7d8587b6e1f336f3ef1d0ece5e26f236a/firedrake-debug-patch.diff | patch -p1
 
-                sed -i 's/@mpiexec/@mpiexec --oversubscribe/' Makefile
-                make check
+                firedrake-check --mpiexec 'mpiexec --oversubscribe -n'
 
     validate_cff:
             name: Validate CITATION.cff


### PR DESCRIPTION
We just [merged some tweaks](https://github.com/firedrakeproject/firedrake/pull/4391) to `firedrake-check` that will break your current workflow as soon as we make another release. I've done what I think should be the necessary changes.

This will not work until we make another release and rebuild our containers.