### PR TITLE
(chore) Add publish.yaml.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,43 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+     - main
+  release:
+    types:
+      - published
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          submodules: "recursive"
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: ".test-conda-env-py3.yml"
+          activate-environment: "test-conda-env"
+          auto-activate-base: false
+          auto-update-conda: true
+
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip
+          pip install hatchling hatch
+
+      - name: Build package
+        run: hatch build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release' && github.event.action == 'published'
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
This will allow easy publishing to pypi. To cut a release, simply cut a new release on Github and this action will get triggered.

Expects the secret `PYPI_PASSWORD`, the pypi API token, under `Settings->Secrets and Variables->Actions`, and click "New repository secret".

(Feel free to close this if you already have an automated workflow.)