### PR TITLE
Handle reductions in `get_insn_access_map`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -20876,22 +20876,6 @@
                     "endColumn": 47,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
             }
         ],
         "./loopy/library/function.py": [
@@ -55766,6 +55750,24 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 45,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./loopy/transform/loop_fusion.py": [
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             }

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -28,7 +28,6 @@ import dataclasses
 import itertools
 import logging
 import sys
-from collections.abc import Set as AbstractSet
 from functools import reduce
 from sys import intern
 from typing import (
@@ -47,7 +46,7 @@ import islpy as isl
 import pymbolic.primitives as p
 from islpy import dim_type
 from pymbolic import Expression
-from pytools import fset_union, memoize_on_first_arg, natsorted, set_union
+from pytools import fset_union, memoize_on_first_arg, natsorted
 
 from loopy.diagnostic import LoopyError, warn_with_kernel
 from loopy.kernel import LoopKernel
@@ -59,7 +58,7 @@ from loopy.kernel.instruction import (
     MultiAssignmentBase,
     _DataObliviousInstruction,
 )
-from loopy.symbolic import CombineMapper
+from loopy.symbolic import CombineMapper, Reduction
 from loopy.translation_unit import (
     CallableId,
     CallablesTable,
@@ -70,7 +69,14 @@ from loopy.translation_unit import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+    from collections.abc import (
+        Callable,
+        Collection,
+        Iterable,
+        Mapping,
+        Sequence,
+        Set as AbstractSet,
+    )
 
     from pymbolic import ArithmeticExpression
     from pytools.tag import Tag
@@ -2305,68 +2311,87 @@ def get_hw_axis_base_for_codegen(kernel: LoopKernel, iname: str) -> isl.Aff:
 
 # {{{ get access map from an instruction
 
+def union_amaps(amaps: Sequence[isl.Map]):
+    import islpy as isl
+    return reduce(isl.Map.union, amaps[1:], amaps[0])
+
+
 @dataclasses.dataclass
-class _IndexCollector(CombineMapper[AbstractSet[tuple[Expression, ...]], []]):
+class _InstructionAccessMapCollector(
+        CombineMapper[dict[frozenset[str], isl.Map], [isl.Set]]):
+    knl: LoopKernel
     var: str
 
     def __post_init__(self) -> None:
         super().__init__()
 
     @override
-    def combine(self,
-                values: Iterable[AbstractSet[tuple[Expression, ...]]]
-            ) -> AbstractSet[tuple[Expression, ...]]:
-        return set_union(values)
+    def combine(
+            self,
+            values: Iterable[dict[frozenset[str], isl.Map]]
+            ) -> dict[frozenset[str], isl.Map]:
+        result: dict[frozenset[str], isl.Map] = {}
+        for value in values:
+            for inames, amap in value.items():
+                try:
+                    old_amap = result[inames]
+                except KeyError:
+                    result[inames] = amap
+                else:
+                    result[inames] = union_amaps((old_amap, amap))
+        return result
 
     @override
-    def map_subscript(self, expr: p.Subscript) -> AbstractSet[tuple[Expression, ...]]:
+    def map_reduction(
+            self, expr: Reduction, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
+        new_domain = self.knl.get_inames_domain(
+            frozenset(domain.get_var_dict(dim_type.set))
+            | frozenset(expr.inames)).to_set()
+        return super().map_reduction(expr, new_domain)
+
+    @override
+    def map_subscript(
+            self, expr: p.Subscript, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
+        from loopy.symbolic import get_access_map
         assert isinstance(expr.aggregate, p.Variable)
         if expr.aggregate.name == self.var:
-            return (super().map_subscript(expr) | frozenset([expr.index_tuple]))
+            inames = frozenset(domain.get_var_dict(dim_type.set).keys())
+            amap = get_access_map(
+                domain, expr.index_tuple, self.knl.assumptions)
+            return self.combine([
+                super().map_subscript(expr, domain), {inames: amap}])
         else:
-            return super().map_subscript(expr)
+            return super().map_subscript(expr, domain)
 
     @override
     def map_algebraic_leaf(
-                    self, expr: p.AlgebraicLeaf,
-                ) -> frozenset[tuple[Expression, ...]]:
-        return frozenset()
+                self, expr: p.AlgebraicLeaf, domain: isl.Set,
+            ) -> dict[frozenset[str], isl.Map]:
+        return {}
 
     @override
     def map_constant(
-                    self, expr: object
-                ) -> frozenset[tuple[Expression, ...]]:
-        return frozenset()
+            self, expr: object, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
+        return {}
 
 
-def _union_amaps(amaps: Sequence[isl.Map]):
-    import islpy as isl
-    return reduce(isl.Map.union, amaps[1:], amaps[0])
-
-
-def get_insn_access_map(kernel: LoopKernel, insn_id: str, var: str):
+def get_insn_access_maps(
+        kernel: LoopKernel, insn_id: str, var: str) -> list[isl.Map]:
     from loopy.match import Id
-    from loopy.symbolic import get_access_map
     from loopy.transform.subst import expand_subst
 
-    insn = kernel.id_to_insn[insn_id]
-
     kernel = expand_subst(kernel, within=Id(insn_id))
-    indices = tuple(
-        _IndexCollector(var)(
-            (insn.expression, insn.assignees, tuple(insn.predicates))
-        )
-    )
 
-    amaps = [
-        get_access_map(
-            kernel.get_inames_domain(insn.within_inames).to_set(),
-            idx, kernel.assumptions
-        )
-        for idx in indices
-    ]
+    insn = kernel.id_to_insn[insn_id]
+    insn_inames = kernel.insn_inames(insn)
+    inames_domain = kernel.get_inames_domain(insn_inames)
+    domain = inames_domain.project_out_except(
+        insn_inames, [dim_type.set]).to_set()
 
-    return _union_amaps(amaps)
+    inames_to_amap = _InstructionAccessMapCollector(kernel, var)(
+        (insn.expression, insn.assignees, tuple(insn.predicates)), domain)
+
+    return list(inames_to_amap.values())
 
 # }}}
 

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -29,7 +29,6 @@ import itertools
 import logging
 import operator
 import sys
-from collections.abc import Set as AbstractSet
 from functools import reduce
 from sys import intern
 from typing import (
@@ -44,8 +43,9 @@ from typing_extensions import override
 
 import namedisl as nisl
 import pymbolic.primitives as p
+from namedisl import DimType
 from pymbolic import Expression
-from pytools import fset_union, memoize_on_first_arg, natsorted, set_union
+from pytools import fset_union, memoize_on_first_arg, natsorted
 
 from loopy.diagnostic import LoopyError, warn_with_kernel
 from loopy.kernel import LoopKernel
@@ -57,7 +57,7 @@ from loopy.kernel.instruction import (
     MultiAssignmentBase,
     _DataObliviousInstruction,
 )
-from loopy.symbolic import CombineMapper, get_access_map_storage_names
+from loopy.symbolic import CombineMapper, Reduction, get_access_map_storage_names
 from loopy.translation_unit import (
     CallableId,
     CallablesTable,
@@ -68,7 +68,13 @@ from loopy.translation_unit import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Mapping, Sequence
+    from collections.abc import (
+        Collection,
+        Iterable,
+        Mapping,
+        Sequence,
+        Set as AbstractSet,
+    )
 
     from pymbolic import ArithmeticExpression
     from pytools.tag import Tag
@@ -2155,67 +2161,86 @@ def get_hw_axis_base_for_codegen(kernel: LoopKernel, iname: str) -> nisl.Aff:
 
 # {{{ get access map from an instruction
 
+def union_amaps(amaps: Sequence[nisl.Map]):
+    return reduce(operator.or_, amaps[1:], amaps[0])
+
+
 @dataclasses.dataclass
-class _IndexCollector(CombineMapper[AbstractSet[tuple[Expression, ...]], []]):
+class _InstructionAccessMapCollector(
+        CombineMapper[dict[frozenset[str], nisl.Map], [nisl.Set]]):
+    knl: LoopKernel
     var: str
 
     def __post_init__(self) -> None:
         super().__init__()
 
     @override
-    def combine(self,
-                values: Iterable[AbstractSet[tuple[Expression, ...]]]
-            ) -> AbstractSet[tuple[Expression, ...]]:
-        return set_union(values)
+    def combine(
+            self,
+            values: Iterable[dict[frozenset[str], nisl.Map]]
+            ) -> dict[frozenset[str], nisl.Map]:
+        result: dict[frozenset[str], nisl.Map] = {}
+        for value in values:
+            for inames, amap in value.items():
+                try:
+                    old_amap = result[inames]
+                except KeyError:
+                    result[inames] = amap
+                else:
+                    result[inames] = union_amaps((old_amap, amap))
+        return result
 
     @override
-    def map_subscript(self, expr: p.Subscript) -> AbstractSet[tuple[Expression, ...]]:
+    def map_reduction(
+            self, expr: Reduction, domain: nisl.Set
+            ) -> dict[frozenset[str], nisl.Map]:
+        new_domain = self.knl.get_inames_domain(
+            domain.space.set_names | frozenset(expr.inames))
+        return super().map_reduction(expr, new_domain)
+
+    @override
+    def map_subscript(
+            self, expr: p.Subscript, domain: nisl.Set
+            ) -> dict[frozenset[str], nisl.Map]:
+        from loopy.symbolic import get_access_map
         assert isinstance(expr.aggregate, p.Variable)
         if expr.aggregate.name == self.var:
-            return (super().map_subscript(expr) | frozenset([expr.index_tuple]))
+            inames = domain.space.set_names
+            amap = get_access_map(
+                domain, expr.index_tuple, self.knl.assumptions)
+            return self.combine([
+                super().map_subscript(expr, domain), {inames: amap}])
         else:
-            return super().map_subscript(expr)
+            return super().map_subscript(expr, domain)
 
     @override
     def map_algebraic_leaf(
-                    self, expr: p.AlgebraicLeaf,
-                ) -> frozenset[tuple[Expression, ...]]:
-        return frozenset()
+                self, expr: p.AlgebraicLeaf, domain: nisl.Set,
+            ) -> dict[frozenset[str], nisl.Map]:
+        return {}
 
     @override
     def map_constant(
-                    self, expr: object
-                ) -> frozenset[tuple[Expression, ...]]:
-        return frozenset()
+            self, expr: object, domain: nisl.Set) -> dict[frozenset[str], nisl.Map]:
+        return {}
 
 
-def _union_amaps(amaps: Sequence[nisl.Map]):
-    return reduce(operator.or_, amaps[1:], amaps[0])
-
-
-def get_insn_access_map(kernel: LoopKernel, insn_id: str, var: str):
+def get_insn_access_maps(
+        kernel: LoopKernel, insn_id: str, var: str) -> list[nisl.Map]:
     from loopy.match import Id
-    from loopy.symbolic import get_access_map
     from loopy.transform.subst import expand_subst
 
-    insn = kernel.id_to_insn[insn_id]
-
     kernel = expand_subst(kernel, within=Id(insn_id))
-    indices = tuple(
-        _IndexCollector(var)(
-            (insn.expression, insn.assignees, tuple(insn.predicates))
-        )
-    )
 
-    amaps = [
-        get_access_map(
-            kernel.get_inames_domain(insn.within_inames),
-            idx, kernel.assumptions
-        )
-        for idx in indices
-    ]
+    insn = kernel.id_to_insn[insn_id]
+    insn_inames = kernel.insn_inames(insn)
+    inames_domain = kernel.get_inames_domain(insn_inames)
+    domain = inames_domain.project_out_except(insn_inames, dim_type=DimType.out)
 
-    return _union_amaps(amaps)
+    inames_to_amap = _InstructionAccessMapCollector(kernel, var)(
+        (insn.expression, insn.assignees, tuple(insn.predicates)), domain)
+
+    return list(inames_to_amap.values())
 
 # }}}
 

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -24,12 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import dataclasses
 import itertools
 import logging
-import operator
 import sys
-from functools import reduce
 from sys import intern
 from typing import (
     TYPE_CHECKING,
@@ -42,9 +39,6 @@ import numpy as np
 from typing_extensions import override
 
 import namedisl as nisl
-import pymbolic.primitives as p
-from namedisl import DimType
-from pymbolic import Expression
 from pytools import fset_union, memoize_on_first_arg, natsorted
 
 from loopy.diagnostic import LoopyError, warn_with_kernel
@@ -57,7 +51,7 @@ from loopy.kernel.instruction import (
     MultiAssignmentBase,
     _DataObliviousInstruction,
 )
-from loopy.symbolic import CombineMapper, Reduction, get_access_map_storage_names
+from loopy.symbolic import CombineMapper, get_access_map_storage_names
 from loopy.translation_unit import (
     CallableId,
     CallablesTable,
@@ -65,6 +59,7 @@ from loopy.translation_unit import (
     TUnitOrKernelT,
     for_each_kernel,
 )
+from loopy.typing import not_none
 
 
 if TYPE_CHECKING:
@@ -76,7 +71,8 @@ if TYPE_CHECKING:
         Set as AbstractSet,
     )
 
-    from pymbolic import ArithmeticExpression
+    import pymbolic.primitives as p
+    from pymbolic import ArithmeticExpression, Expression
     from pytools.tag import Tag
 
     from loopy.types import ToLoopyTypeConvertible
@@ -2161,70 +2157,6 @@ def get_hw_axis_base_for_codegen(kernel: LoopKernel, iname: str) -> nisl.Aff:
 
 # {{{ get access map from an instruction
 
-def union_amaps(amaps: Sequence[nisl.Map]):
-    return reduce(operator.or_, amaps[1:], amaps[0])
-
-
-@dataclasses.dataclass
-class _InstructionAccessMapCollector(
-        CombineMapper[dict[frozenset[str], nisl.Map], [nisl.Set]]):
-    knl: LoopKernel
-    var: str
-
-    def __post_init__(self) -> None:
-        super().__init__()
-
-    @override
-    def combine(
-            self,
-            values: Iterable[dict[frozenset[str], nisl.Map]]
-            ) -> dict[frozenset[str], nisl.Map]:
-        result: dict[frozenset[str], nisl.Map] = {}
-        for value in values:
-            for inames, amap in value.items():
-                try:
-                    old_amap = result[inames]
-                except KeyError:
-                    result[inames] = amap
-                else:
-                    result[inames] = union_amaps((old_amap, amap))
-        return result
-
-    @override
-    def map_reduction(
-            self, expr: Reduction, domain: nisl.Set
-            ) -> dict[frozenset[str], nisl.Map]:
-        new_domain = self.knl.get_inames_domain(
-            domain.space.set_names | frozenset(expr.inames))
-        return super().map_reduction(expr, new_domain)
-
-    @override
-    def map_subscript(
-            self, expr: p.Subscript, domain: nisl.Set
-            ) -> dict[frozenset[str], nisl.Map]:
-        from loopy.symbolic import get_access_map
-        assert isinstance(expr.aggregate, p.Variable)
-        if expr.aggregate.name == self.var:
-            inames = domain.space.set_names
-            amap = get_access_map(
-                domain, expr.index_tuple, self.knl.assumptions)
-            return self.combine([
-                super().map_subscript(expr, domain), {inames: amap}])
-        else:
-            return super().map_subscript(expr, domain)
-
-    @override
-    def map_algebraic_leaf(
-                self, expr: p.AlgebraicLeaf, domain: nisl.Set,
-            ) -> dict[frozenset[str], nisl.Map]:
-        return {}
-
-    @override
-    def map_constant(
-            self, expr: object, domain: nisl.Set) -> dict[frozenset[str], nisl.Map]:
-        return {}
-
-
 def get_insn_access_maps(
         kernel: LoopKernel, insn_id: str, var: str) -> list[nisl.Map]:
     from loopy.match import Id
@@ -2234,13 +2166,19 @@ def get_insn_access_maps(
 
     insn = kernel.id_to_insn[insn_id]
     insn_inames = kernel.insn_inames(insn)
-    inames_domain = kernel.get_inames_domain(insn_inames)
-    domain = inames_domain.project_out_except(insn_inames, dim_type=DimType.out)
 
-    inames_to_amap = _InstructionAccessMapCollector(kernel, var)(
-        (insn.expression, insn.assignees, tuple(insn.predicates)), domain)
+    from loopy.symbolic import BatchedAccessMapMapper
+    bamm = BatchedAccessMapMapper(kernel, [var])
+    bamm((insn.expression, insn.assignees, tuple(insn.predicates)), insn_inames)
 
-    return list(inames_to_amap.values())
+    if var in bamm.bad_subscripts:
+        from loopy.diagnostic import UnableToDetermineAccessRangeError
+        raise UnableToDetermineAccessRangeError(
+            f"cannot determine access range for '{var}' in '{insn_id}'")
+
+    return [
+        not_none(amap)
+        for amap in bamm.access_maps[var].values()]
 
 # }}}
 

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -24,11 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import dataclasses
 import itertools
 import logging
 import sys
-from functools import reduce
 from sys import intern
 from typing import (
     TYPE_CHECKING,
@@ -43,9 +41,7 @@ import numpy as np
 from typing_extensions import override
 
 import islpy as isl
-import pymbolic.primitives as p
 from islpy import dim_type
-from pymbolic import Expression
 from pytools import fset_union, memoize_on_first_arg, natsorted
 
 from loopy.diagnostic import LoopyError, warn_with_kernel
@@ -58,7 +54,7 @@ from loopy.kernel.instruction import (
     MultiAssignmentBase,
     _DataObliviousInstruction,
 )
-from loopy.symbolic import CombineMapper, Reduction
+from loopy.symbolic import CombineMapper
 from loopy.translation_unit import (
     CallableId,
     CallablesTable,
@@ -66,6 +62,7 @@ from loopy.translation_unit import (
     TUnitOrKernelT,
     for_each_kernel,
 )
+from loopy.typing import not_none
 
 
 if TYPE_CHECKING:
@@ -78,7 +75,8 @@ if TYPE_CHECKING:
         Set as AbstractSet,
     )
 
-    from pymbolic import ArithmeticExpression
+    import pymbolic.primitives as p
+    from pymbolic import ArithmeticExpression, Expression
     from pytools.tag import Tag
 
     from loopy.types import ToLoopyTypeConvertible
@@ -2311,70 +2309,6 @@ def get_hw_axis_base_for_codegen(kernel: LoopKernel, iname: str) -> isl.Aff:
 
 # {{{ get access map from an instruction
 
-def union_amaps(amaps: Sequence[isl.Map]):
-    import islpy as isl
-    return reduce(isl.Map.union, amaps[1:], amaps[0])
-
-
-@dataclasses.dataclass
-class _InstructionAccessMapCollector(
-        CombineMapper[dict[frozenset[str], isl.Map], [isl.Set]]):
-    knl: LoopKernel
-    var: str
-
-    def __post_init__(self) -> None:
-        super().__init__()
-
-    @override
-    def combine(
-            self,
-            values: Iterable[dict[frozenset[str], isl.Map]]
-            ) -> dict[frozenset[str], isl.Map]:
-        result: dict[frozenset[str], isl.Map] = {}
-        for value in values:
-            for inames, amap in value.items():
-                try:
-                    old_amap = result[inames]
-                except KeyError:
-                    result[inames] = amap
-                else:
-                    result[inames] = union_amaps((old_amap, amap))
-        return result
-
-    @override
-    def map_reduction(
-            self, expr: Reduction, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
-        new_domain = self.knl.get_inames_domain(
-            frozenset(domain.get_var_dict(dim_type.set))
-            | frozenset(expr.inames)).to_set()
-        return super().map_reduction(expr, new_domain)
-
-    @override
-    def map_subscript(
-            self, expr: p.Subscript, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
-        from loopy.symbolic import get_access_map
-        assert isinstance(expr.aggregate, p.Variable)
-        if expr.aggregate.name == self.var:
-            inames = frozenset(domain.get_var_dict(dim_type.set).keys())
-            amap = get_access_map(
-                domain, expr.index_tuple, self.knl.assumptions)
-            return self.combine([
-                super().map_subscript(expr, domain), {inames: amap}])
-        else:
-            return super().map_subscript(expr, domain)
-
-    @override
-    def map_algebraic_leaf(
-                self, expr: p.AlgebraicLeaf, domain: isl.Set,
-            ) -> dict[frozenset[str], isl.Map]:
-        return {}
-
-    @override
-    def map_constant(
-            self, expr: object, domain: isl.Set) -> dict[frozenset[str], isl.Map]:
-        return {}
-
-
 def get_insn_access_maps(
         kernel: LoopKernel, insn_id: str, var: str) -> list[isl.Map]:
     from loopy.match import Id
@@ -2384,14 +2318,19 @@ def get_insn_access_maps(
 
     insn = kernel.id_to_insn[insn_id]
     insn_inames = kernel.insn_inames(insn)
-    inames_domain = kernel.get_inames_domain(insn_inames)
-    domain = inames_domain.project_out_except(
-        insn_inames, [dim_type.set]).to_set()
 
-    inames_to_amap = _InstructionAccessMapCollector(kernel, var)(
-        (insn.expression, insn.assignees, tuple(insn.predicates)), domain)
+    from loopy.symbolic import BatchedAccessMapMapper
+    bamm = BatchedAccessMapMapper(kernel, [var])
+    bamm((insn.expression, insn.assignees, tuple(insn.predicates)), insn_inames)
 
-    return list(inames_to_amap.values())
+    if var in bamm.bad_subscripts:
+        from loopy.diagnostic import UnableToDetermineAccessRangeError
+        raise UnableToDetermineAccessRangeError(
+            f"cannot determine access range for '{var}' in '{insn_id}'")
+
+    return [
+        not_none(amap)
+        for amap in bamm.access_maps[var].values()]
 
 # }}}
 

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -2956,6 +2956,11 @@ class BatchedAccessMapMapper(WalkMapper[[AbstractSet[str]]]):
         self._var_names = set(var_names)
         super().__init__()
 
+    @memoize_method
+    def _get_inames_domain_strict(self, inames: AbstractSet[str]) -> isl.BasicSet:
+        return self.kernel.get_inames_domain(inames).project_out_except(
+            inames, [isl.dim_type.set])
+
     def get_access_range(self, var_name: str) -> isl.Set | None:
         loops_to_amaps = self.access_maps[var_name]
         if not loops_to_amaps:
@@ -2968,7 +2973,7 @@ class BatchedAccessMapMapper(WalkMapper[[AbstractSet[str]]]):
 
     @override
     def map_subscript(self, expr: p.Subscript, /, inames: AbstractSet[str]) -> None:
-        domain = self.kernel.get_inames_domain(inames)
+        domain = self._get_inames_domain_strict(inames)
         super().map_subscript(expr, inames)
 
         assert isinstance(expr.aggregate, p.Variable)

--- a/loopy/symbolic.py
+++ b/loopy/symbolic.py
@@ -2935,6 +2935,11 @@ class BatchedAccessMapMapper(WalkMapper[[AbstractSet[str]]]):
         self._var_names = set(var_names)
         super().__init__()
 
+    @memoize_method
+    def _get_inames_domain_strict(self, inames: AbstractSet[str]) -> nisl.Set:
+        return self.kernel.get_inames_domain(inames).project_out_except(
+            inames, dim_type=DimType.out)
+
     def get_access_range(self, var_name: str) -> nisl.Set | None:
         loops_to_amaps = self.access_maps[var_name]
         if not loops_to_amaps:
@@ -2947,7 +2952,7 @@ class BatchedAccessMapMapper(WalkMapper[[AbstractSet[str]]]):
 
     @override
     def map_subscript(self, expr: p.Subscript, /, inames: AbstractSet[str]) -> None:
-        domain = self.kernel.get_inames_domain(inames)
+        domain = self._get_inames_domain_strict(inames)
         super().map_subscript(expr, inames)
 
         assert isinstance(expr.aggregate, p.Variable)

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -390,23 +390,31 @@ def _compute_isinfusible_via_access_map(
     import pymbolic.primitives as prim
 
     from loopy.diagnostic import UnableToDetermineAccessRangeError
-    from loopy.kernel.tools import get_insn_access_map
+    from loopy.kernel.tools import get_insn_access_maps
     from loopy.symbolic import isl_set_from_expr
 
     try:
-        amap_pred = get_insn_access_map(kernel, insn_pred, var)
-        amap_succ = get_insn_access_map(kernel, insn_succ, var)
+        amaps_pred = get_insn_access_maps(kernel, insn_pred, var)
+        amaps_succ = get_insn_access_maps(kernel, insn_succ, var)
     except UnableToDetermineAccessRangeError:
         # either predecessors or successors has a non-affine access i.e.
         # fallback to the safer option => infusible
         return True
 
-    amap_pred = amap_pred.project_out_except(
-        outer_inames | {candidate_pred}, [isl.dim_type.param, isl.dim_type.in_]
-    )
-    amap_succ = amap_succ.project_out_except(
-        outer_inames | {candidate_succ}, [isl.dim_type.param, isl.dim_type.in_]
-    )
+    amaps_pred = [
+        amap.project_out_except(
+            outer_inames | {candidate_pred}, [isl.dim_type.param, isl.dim_type.in_])
+        for amap in amaps_pred]
+    amaps_succ = [
+        amap.project_out_except(
+            outer_inames | {candidate_succ}, [isl.dim_type.param, isl.dim_type.in_])
+        for amap in amaps_succ]
+
+    # amaps should have the same space after projecting out the inner loops, so they
+    # can safely be unioned
+    from loopy.kernel.tools import union_amaps
+    amap_pred = union_amaps(amaps_pred)
+    amap_succ = union_amaps(amaps_succ)
 
     # move outer inames to param
     for outer_iname in sorted(outer_inames):

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -391,24 +391,33 @@ def _compute_isinfusible_via_access_map(
     """
 
     from loopy.diagnostic import UnableToDetermineAccessRangeError
-    from loopy.kernel.tools import get_insn_access_map
+    from loopy.kernel.tools import get_insn_access_maps, union_amaps
 
     try:
-        amap_pred = get_insn_access_map(kernel, insn_pred, var)
-        amap_succ = get_insn_access_map(kernel, insn_succ, var)
+        amaps_pred = get_insn_access_maps(kernel, insn_pred, var)
+        amaps_succ = get_insn_access_maps(kernel, insn_succ, var)
     except UnableToDetermineAccessRangeError:
         # either predecessors or successors has a non-affine access i.e.
         # fallback to the safer option => infusible
         return True
 
+    amaps_pred = [
+        amap.project_out_except(
+            outer_inames | {candidate_pred}, dim_type=DimType.in_)
+        for amap in amaps_pred]
+    amaps_succ = [
+        amap.project_out_except(
+            outer_inames | {candidate_succ}, dim_type=DimType.in_)
+        for amap in amaps_succ]
+
+    # amaps should have the same space after projecting out the inner loops, so they
+    # can safely be unioned
+    amap_pred = union_amaps(amaps_pred)
+    amap_succ = union_amaps(amaps_succ)
+
     storage_dim_names = get_access_map_storage_names(amap_pred)
     assert set(storage_dim_names) == amap_pred.space.out_names
     assert set(storage_dim_names) == amap_succ.space.out_names
-
-    amap_pred = amap_pred.project_out_except(
-        outer_inames | {candidate_pred}, dim_type=DimType.in_)
-    amap_succ = amap_succ.project_out_except(
-        outer_inames | {candidate_succ}, dim_type=DimType.in_)
 
     amap_pred = amap_pred.move_dims(outer_inames, DimType.param)
     amap_succ = amap_succ.move_dims(outer_inames, DimType.param)

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -412,7 +412,10 @@ def _compute_isinfusible_via_access_map(
 
     # amaps should have the same space after projecting out the inner loops, so they
     # can safely be unioned
-    from loopy.kernel.tools import union_amaps
+    def union_amaps(amaps: Sequence[isl.Map]) -> isl.Map:
+        from functools import reduce
+        return reduce(isl.Map.union, amaps[1:], amaps[0])
+
     amap_pred = union_amaps(amaps_pred)
     amap_succ = union_amaps(amaps_succ)
 

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -391,7 +391,7 @@ def _compute_isinfusible_via_access_map(
     """
 
     from loopy.diagnostic import UnableToDetermineAccessRangeError
-    from loopy.kernel.tools import get_insn_access_maps, union_amaps
+    from loopy.kernel.tools import get_insn_access_maps
 
     try:
         amaps_pred = get_insn_access_maps(kernel, insn_pred, var)
@@ -412,6 +412,11 @@ def _compute_isinfusible_via_access_map(
 
     # amaps should have the same space after projecting out the inner loops, so they
     # can safely be unioned
+    def union_amaps(amaps: Sequence[nisl.Map]) -> nisl.Map:
+        import operator
+        from functools import reduce
+        return reduce(operator.or_, amaps[1:], amaps[0])
+
     amap_pred = union_amaps(amaps_pred)
     amap_succ = union_amaps(amaps_succ)
 

--- a/test/test_loop_fusion.py
+++ b/test/test_loop_fusion.py
@@ -497,6 +497,39 @@ def test_reduction_loop_fusion_with_multiple_redn_in_same_insn(
     lp.auto_test_vs_ref(ref_t_unit, ctx, t_unit.with_kernel(knl))
 
 
+def test_loop_fusion_with_inner_reduction(ctx_factory: cl.CtxFactory):
+    ctx = ctx_factory()
+
+    t_unit = lp.make_kernel(
+        ["{[i0, j0]: 0 <= i0, j0 < 10}",
+         "{[i1]: 0 <= i1 < 10}",
+         # Intentionally keeping j1 separate from i1 to test for regression. See
+         # https://github.com/inducer/loopy/pull/1009 for details.
+         "{[j1]: 0 <= j1 < 10}"],
+        """
+        a[i0, j0] = j0 * 1.0                  {id=insn1}
+        out[i1] = sum(j1, a[i1, j1])           {id=insn2}
+        """,
+    )
+    ref_t_unit = t_unit
+
+    knl = t_unit.default_entrypoint
+
+    fused_chunks = lp.get_kennedy_unweighted_fusion_candidates(
+        knl, frozenset(["i0", "i1"])
+    )
+    knl = lp.rename_inames_in_batch(knl, fused_chunks)
+
+    assert (
+        len(
+            knl.id_to_insn["insn1"].within_inames
+            & knl.id_to_insn["insn2"].within_inames
+        ) == 1
+    )
+
+    lp.auto_test_vs_ref(ref_t_unit, ctx, t_unit.with_kernel(knl))
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         exec(sys.argv[1])


### PR DESCRIPTION
Currently, `get_insn_access_map` only passes the inames from `within_inames` in the call to `get_access_map`. As a result, if reductions are present `get_access_map` ~~will~~ may (_edit:_ it only happens if the reduction domain is separate from the element domain, otherwise `knl.get_inames_domain()` picks up the reduction) fail, e.g.:

```
unable to determine access range of subscript: [_pt_temp_12_dim0, _pt_sum_r0_8] (encountered ExpressionToAffineConversionError: could not convert expression '_pt_sum_r0_8' to affine representation: UnknownVariableError: cannot find '_pt_sum_r0_8' in context (pass it in on evaluation))
```

This causes `_compute_isinfusible_via_access_map` to return `True` whenever reductions are present ([code](https://github.com/inducer/loopy/blob/76035bfb3b42ee4f2893b6dc733025fa39540600/loopy/transform/loop_fusion.py#L396-L402)), which subsequently prevents `get_kennedy_unweighted_fusion_candidates` from fusing loops that it potentially could.

A real world example of this can be seen in the generated code for a DG operator [here](https://gist.github.com/majosm/cfa4180bbfa6c7d5ebfd5d339f6f5ad1). I've annotated with `# DESCRIPTION:` what DG operations are being done in each loop in the device code. The first 3 loop nests are performing face-local work on the interior faces (the `iel` loop with 5641 iterations). Since the operations are face-local, the `iel` loops should be able to be fused, but the reductions over the `idof` axes are preventing that from happening due to this issue.

This PR changes `get_insn_access_map` to `get_insn_access_maps`. It now computes separate access maps for accesses outside of reductions + each different reduction level present, by traversing the instruction and updating the domain for reductions accordingly (AFAIK, they cannot all be unioned together due to the different spaces involved). It additionally modifies `compute_isinfusible_via_access_map` to do the unioning after projection once it's safe to do so.

With this change, I'm now seeing fusion of the element loops as expected: [code](https://gist.github.com/majosm/62b5a0c949ce60dbcc69dd46ba584baf).