### PR TITLE
Add dynamic temporary allocation and deallocation

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -1078,10 +1078,12 @@ Tagged prefetching
 Temporaries in global memory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:mod:`loopy` supports using temporaries with global storage duration. As with
-local and private temporaries, the runtime allocates storage for global
-temporaries when the kernel gets executed. The user must explicitly specify that
-a temporary is global. To specify that a temporary is global, use
+:mod:`loopy` supports using temporaries with global storage duration. Note that
+these temporaries will in fact be dynamically allocated before the first usage,
+and deallocated after the last. As with local and private temporaries, the
+runtime allocates storage for global temporaries when the kernel gets executed.
+The user must explicitly specify that a temporary is global. To specify that a
+temporary is global, use
 :func:`loopy.set_temporary_address_space`.
 
 Substitution rules
@@ -1276,15 +1278,17 @@ put those instructions into the schedule.
    ...
    ---------------------------------------------------------------------------
    LINEARIZATION:
-      0: CALL KERNEL rotate_v2
-      1:     tmp = arr[i_inner + i_outer*16]  {id=maketmp}
-      2:     tmp_save_slot[tmp_save_hw_dim_0_rotate_v2, tmp_save_hw_dim_1_rotate_v2] = tmp  {id=tmp.save}
-      3: RETURN FROM KERNEL rotate_v2
-      4: ... gbarrier
-      5: CALL KERNEL rotate_v2_0
-      6:     tmp = tmp_save_slot[tmp_reload_hw_dim_0_rotate_v2_0, tmp_reload_hw_dim_1_rotate_v2_0]  {id=tmp.reload}
-      7:     arr[(i_inner + i_outer*16 + 1) % n] = tmp  {id=rotate}
-      8: RETURN FROM KERNEL rotate_v2_0
+      0: ALLOCATE tmp_save_slot
+      1: CALL KERNEL rotate_v2
+      2:     tmp = arr[i_inner + i_outer*16]  {id=maketmp}
+      3:     tmp_save_slot[tmp_save_hw_dim_0_rotate_v2, tmp_save_hw_dim_1_rotate_v2] = tmp  {id=tmp.save}
+      4: RETURN FROM KERNEL rotate_v2
+      5: ... gbarrier
+      6: CALL KERNEL rotate_v2_0
+      7:     tmp = tmp_save_slot[tmp_reload_hw_dim_0_rotate_v2_0, tmp_reload_hw_dim_1_rotate_v2_0]  {id=tmp.reload}
+      8:     arr[(i_inner + i_outer*16 + 1) % n] = tmp  {id=rotate}
+      9: RETURN FROM KERNEL rotate_v2_0
+     10: DEALLOCATE tmp_save_slot
    ---------------------------------------------------------------------------
 
 Here's an overview of what :func:`loopy.save_and_reload_temporaries` actually
@@ -1294,7 +1298,8 @@ does in more detail:
    variables' live ranges cross a global barrier.
 
 2. For each temporary, :mod:`loopy` creates a storage slot for the temporary in
-   global memory (see :ref:`global_temporaries`).
+   global memory (see :ref:`global_temporaries`). Note that, as a global variable, the storage
+   slot will be dynamically allocated before its first usage and deallocated after its last.
 
 3. :mod:`loopy` saves the temporary into its global storage slot whenever it
    detects the temporary is live-out from a kernel, and reloads the temporary

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -1394,8 +1394,10 @@ def _check_for_unused_hw_axes_in_kernel_chunk(
             sched_index: int | None = None
         ) -> int:
     from loopy.schedule import (
+        AllocTemp,
         Barrier,
         CallKernel,
+        DeallocTemp,
         EnterLoop,
         LeaveLoop,
         ReturnFromKernel,
@@ -1490,7 +1492,8 @@ def _check_for_unused_hw_axes_in_kernel_chunk(
                         "Calling loopy.add_inames_for_unused_hw_axes(...) "
                         "might help.")
 
-        elif isinstance(sched_item, (Barrier, EnterLoop, LeaveLoop)):
+        elif isinstance(sched_item, (Barrier, EnterLoop, LeaveLoop,
+                                     AllocTemp, DeallocTemp)):
             i += 1
             continue
 

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -1373,8 +1373,10 @@ def _check_for_unused_hw_axes_in_kernel_chunk(
             sched_index: int | None = None
         ) -> int:
     from loopy.schedule import (
+        AllocTemp,
         Barrier,
         CallKernel,
+        DeallocTemp,
         EnterLoop,
         LeaveLoop,
         ReturnFromKernel,
@@ -1469,7 +1471,8 @@ def _check_for_unused_hw_axes_in_kernel_chunk(
                         "Calling loopy.add_inames_for_unused_hw_axes(...) "
                         "might help.")
 
-        elif isinstance(sched_item, (Barrier, EnterLoop, LeaveLoop)):
+        elif isinstance(sched_item, (Barrier, EnterLoop, LeaveLoop,
+                                     AllocTemp, DeallocTemp)):
             i += 1
             continue
 

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -33,8 +33,10 @@ import islpy as isl
 from loopy.codegen.result import CodeGenerationResult, merge_codegen_results, wrap_in_if
 from loopy.diagnostic import LoopyError
 from loopy.schedule import (
+    AllocTemp,
     Barrier,
     CallKernel,
+    DeallocTemp,
     EnterLoop,
     LeaveLoop,
     RunInstruction,
@@ -185,6 +187,12 @@ def generate_code_for_sched_index(
                 "instruction %s" % insn.id,
                 lambda inner_cgs: generate_instruction_code(inner_cgs, insn))
 
+    elif isinstance(sched_item, AllocTemp):
+        return codegen_state.ast_builder.emit_alloc_temp(codegen_state, sched_item.temp)
+    elif isinstance(sched_item, DeallocTemp):
+        return codegen_state.ast_builder.emit_dealloc_temp(
+            codegen_state, sched_item.temp)
+
     else:
         raise RuntimeError("unexpected schedule item type: %s"
                 % type(sched_item))
@@ -198,7 +206,7 @@ def get_required_predicates(
 
     result = None
     for _, sched_item in generate_sub_sched_items(kernel.linearization, sched_index):
-        if isinstance(sched_item, Barrier):
+        if isinstance(sched_item, (Barrier, AllocTemp, DeallocTemp)):
             my_preds = frozenset()
         elif isinstance(sched_item, RunInstruction):
             my_preds = kernel.id_to_insn[sched_item.insn_id].predicates
@@ -279,7 +287,7 @@ def build_loop_nest(
             assert i <= codegen_state.schedule_index_end, \
                     "schedule block extends beyond schedule_index_end"
 
-        elif isinstance(sched_item, (Barrier, RunInstruction)):
+        elif isinstance(sched_item, (Barrier, RunInstruction, AllocTemp, DeallocTemp)):
             i += 1
         else:
             raise RuntimeError("unexpected schedule item type: %s"

--- a/loopy/codegen/control.py
+++ b/loopy/codegen/control.py
@@ -31,8 +31,10 @@ from typing import TYPE_CHECKING, Any, TypeVar, final
 from loopy.codegen.result import CodeGenerationResult, merge_codegen_results, wrap_in_if
 from loopy.diagnostic import LoopyError
 from loopy.schedule import (
+    AllocTemp,
     Barrier,
     CallKernel,
+    DeallocTemp,
     EnterLoop,
     LeaveLoop,
     RunInstruction,
@@ -184,6 +186,12 @@ def generate_code_for_sched_index(
                 "instruction %s" % insn.id,
                 lambda inner_cgs: generate_instruction_code(inner_cgs, insn))
 
+    elif isinstance(sched_item, AllocTemp):
+        return codegen_state.ast_builder.emit_alloc_temp(codegen_state, sched_item.temp)
+    elif isinstance(sched_item, DeallocTemp):
+        return codegen_state.ast_builder.emit_dealloc_temp(
+            codegen_state, sched_item.temp)
+
     else:
         raise RuntimeError("unexpected schedule item type: %s"
                 % type(sched_item))
@@ -197,7 +205,7 @@ def get_required_predicates(
 
     result = None
     for _, sched_item in generate_sub_sched_items(kernel.linearization, sched_index):
-        if isinstance(sched_item, Barrier):
+        if isinstance(sched_item, (Barrier, AllocTemp, DeallocTemp)):
             my_preds = frozenset()
         elif isinstance(sched_item, RunInstruction):
             my_preds = kernel.id_to_insn[sched_item.insn_id].predicates
@@ -278,7 +286,7 @@ def build_loop_nest(
             assert i <= codegen_state.schedule_index_end, \
                     "schedule block extends beyond schedule_index_end"
 
-        elif isinstance(sched_item, (Barrier, RunInstruction)):
+        elif isinstance(sched_item, (Barrier, RunInstruction, AllocTemp, DeallocTemp)):
             i += 1
         else:
             raise RuntimeError("unexpected schedule item type: %s"

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 import logging
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import (
     TYPE_CHECKING,
@@ -40,13 +41,13 @@ from pytools import MinRecursionLimit, ProcessLogger
 from pytools.persistent_dict import WriteOncePersistentDict
 
 from loopy.diagnostic import LoopyError, ScheduleDebugInputError, warn_with_kernel
+from loopy.kernel.data import AddressSpace
 from loopy.tools import LoopyKeyBuilder, caches
 from loopy.typing import not_none as not_none
 from loopy.version import DATA_MODEL_VERSION
 
 
 if TYPE_CHECKING:
-    from collections import defaultdict
     from collections.abc import (
         Collection,
         Hashable,
@@ -112,6 +113,16 @@ class LeaveLoop(EndBlockItem):
 @dataclass(frozen=True)
 class RunInstruction(ScheduleItem):
     insn_id: str
+
+
+@dataclass(frozen=True)
+class AllocTemp(ScheduleItem):
+    temp: str
+
+
+@dataclass(frozen=True)
+class DeallocTemp(ScheduleItem):
+    temp: str
 
 
 @dataclass(frozen=True)
@@ -514,6 +525,10 @@ def dump_schedule(kernel: LoopKernel, schedule: Sequence[ScheduleItem]):
         elif isinstance(sched_item, Barrier):
             lines.append(indent + "... %sbarrier" %
                          sched_item.synchronization_kind[0])
+        elif isinstance(sched_item, AllocTemp):
+            lines.append(indent + "ALLOCATE %s" % sched_item.temp)
+        elif isinstance(sched_item, DeallocTemp):
+            lines.append(indent + "DEALLOCATE %s" % sched_item.temp)
         else:
             raise AssertionError()
 
@@ -2160,7 +2175,9 @@ def insert_barriers(
                 dep_tracker.add_source(sched_item.insn_id)
                 i += 1
 
-            elif isinstance(sched_item, (CallKernel, ReturnFromKernel)):
+            # TODO: check if this is correct
+            elif isinstance(sched_item, (CallKernel, ReturnFromKernel,
+                                         AllocTemp, DeallocTemp)):
                 result.append(sched_item)
                 i += 1
 
@@ -2190,7 +2207,8 @@ def insert_barriers(
             i = new_i
 
         elif isinstance(sched_item,
-                (Barrier, RunInstruction, CallKernel, ReturnFromKernel)):
+                (Barrier, RunInstruction, CallKernel,
+                 ReturnFromKernel, AllocTemp, DeallocTemp)):
             result.append(sched_item)
             i += 1
 
@@ -2276,7 +2294,99 @@ def _postprocess_schedule(
         # Device mapper only gets run once.
         new_kernel = map_schedule_onto_host_or_device(new_kernel)
 
+    new_kernel = insert_temporary_alloc_dealloc(new_kernel)
     return new_kernel
+
+
+def insert_temporary_alloc_dealloc(kernel: LoopKernel):
+    schedule = kernel.linearization
+    inserted_allocs = set()
+    inserted_deallocs = set()
+
+    kernel_entry_idx = -1
+    loops_entry_idxs = []
+
+    insert_alloc_idxs = defaultdict(frozenset)
+    for idx, sched_item in enumerate(schedule):
+        if isinstance(sched_item, EnterLoop):
+            loops_entry_idxs.append(idx)
+        elif isinstance(sched_item, LeaveLoop):
+            loops_entry_idxs.pop()
+        elif isinstance(sched_item, CallKernel):
+            kernel_entry_idx = idx
+        elif isinstance(sched_item, ReturnFromKernel):
+            kernel_entry_idx = -1
+        elif isinstance(sched_item, RunInstruction):
+            insn = kernel.id_to_insn[sched_item.insn_id]
+            for var_name in set(insn.assignee_var_names()):
+                if var_name not in kernel.temporary_variables:
+                    continue
+                tv = kernel.temporary_variables[var_name]
+                if tv.base_storage:
+                    var_name = tv.base_storage
+                    tv = kernel.temporary_variables[var_name]
+                if var_name in inserted_allocs:
+                    continue
+                if tv.address_space == AddressSpace.GLOBAL:
+                    inserted_allocs.add(var_name)
+                    target_idx = idx
+                    if (kernel_entry_idx != -1):
+                        # lift the alloc out of ALL loops
+                        target_idx = min(idx, kernel_entry_idx, *loops_entry_idxs)
+                    else:
+                        target_idx = min(idx, *loops_entry_idxs)
+                    insert_alloc_idxs[target_idx] |= {var_name}
+
+    kernel_entry_idx = -1
+    loops_entry_idxs = []
+    insert_dealloc_idxs = defaultdict(frozenset)
+    for idx, sched_item in enumerate(reversed(schedule)):
+        idx = len(schedule) - idx - 1
+        if isinstance(sched_item, LeaveLoop):
+            loops_entry_idxs.append(idx)
+        elif isinstance(sched_item, EnterLoop):
+            loops_entry_idxs.pop()
+        elif isinstance(sched_item, ReturnFromKernel):
+            kernel_entry_idx = idx
+        elif isinstance(sched_item, CallKernel):
+            kernel_entry_idx = -1
+        elif isinstance(sched_item, RunInstruction):
+            insn = kernel.id_to_insn[sched_item.insn_id]
+            for var_name in set(insn.read_dependency_names()):
+                if var_name not in kernel.temporary_variables:
+                    continue
+                tv = kernel.temporary_variables[var_name]
+                if tv.base_storage:
+                    var_name = tv.base_storage
+                    tv = kernel.temporary_variables[var_name]
+                if var_name in inserted_deallocs:
+                    continue
+                if tv.address_space != AddressSpace.GLOBAL:
+                    continue
+                if var_name in inserted_allocs:
+                    inserted_deallocs.add(var_name)
+                    target_idx = idx
+                    if (kernel_entry_idx != -1):
+                        # lift the dealloc out of ALL loops
+                        target_idx = max(idx, kernel_entry_idx, *loops_entry_idxs)
+                    else:
+                        target_idx = max(idx, *loops_entry_idxs)
+                    insert_dealloc_idxs[target_idx] |= {var_name}
+
+    insert_dealloc_idxs[len(schedule)-1] |= (inserted_allocs - inserted_deallocs)
+
+    new_schedule = []
+    for idx, sched_item in enumerate(schedule):
+        if idx in insert_alloc_idxs:
+            for var_name in insert_alloc_idxs[idx]:
+                new_schedule.append(AllocTemp(var_name))
+        new_schedule.append(sched_item)
+
+        if idx in insert_dealloc_idxs:
+            for var_name in insert_dealloc_idxs[idx]:
+                new_schedule.append(DeallocTemp(var_name))
+
+    return kernel.copy(linearization=new_schedule)
 
 
 def _generate_loop_schedules_inner(

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -2298,6 +2298,7 @@ def _postprocess_schedule(
 
 def insert_temporary_alloc_dealloc(kernel: LoopKernel):
     schedule = kernel.linearization
+    assert schedule is not None
     inserted_allocs = set()
     inserted_deallocs = set()
 

--- a/loopy/schedule/__init__.py
+++ b/loopy/schedule/__init__.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 import logging
 import sys
+from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import (
     TYPE_CHECKING,
@@ -39,13 +40,13 @@ from pytools import MinRecursionLimit, ProcessLogger
 from pytools.persistent_dict import WriteOncePersistentDict
 
 from loopy.diagnostic import LoopyError, ScheduleDebugInputError, warn_with_kernel
+from loopy.kernel.data import AddressSpace
 from loopy.tools import LoopyKeyBuilder, caches
 from loopy.typing import not_none as not_none
 from loopy.version import DATA_MODEL_VERSION
 
 
 if TYPE_CHECKING:
-    from collections import defaultdict
     from collections.abc import (
         Collection,
         Hashable,
@@ -111,6 +112,16 @@ class LeaveLoop(EndBlockItem):
 @dataclass(frozen=True)
 class RunInstruction(ScheduleItem):
     insn_id: str
+
+
+@dataclass(frozen=True)
+class AllocTemp(ScheduleItem):
+    temp: str
+
+
+@dataclass(frozen=True)
+class DeallocTemp(ScheduleItem):
+    temp: str
 
 
 @dataclass(frozen=True)
@@ -513,6 +524,10 @@ def dump_schedule(kernel: LoopKernel, schedule: Sequence[ScheduleItem]):
         elif isinstance(sched_item, Barrier):
             lines.append(indent + "... %sbarrier" %
                          sched_item.synchronization_kind[0])
+        elif isinstance(sched_item, AllocTemp):
+            lines.append(indent + "ALLOCATE %s" % sched_item.temp)
+        elif isinstance(sched_item, DeallocTemp):
+            lines.append(indent + "DEALLOCATE %s" % sched_item.temp)
         else:
             raise AssertionError()
 
@@ -2158,7 +2173,9 @@ def insert_barriers(
                 dep_tracker.add_source(sched_item.insn_id)
                 i += 1
 
-            elif isinstance(sched_item, (CallKernel, ReturnFromKernel)):
+            # TODO: check if this is correct
+            elif isinstance(sched_item, (CallKernel, ReturnFromKernel,
+                                         AllocTemp, DeallocTemp)):
                 result.append(sched_item)
                 i += 1
 
@@ -2188,7 +2205,8 @@ def insert_barriers(
             i = new_i
 
         elif isinstance(sched_item,
-                (Barrier, RunInstruction, CallKernel, ReturnFromKernel)):
+                (Barrier, RunInstruction, CallKernel,
+                 ReturnFromKernel, AllocTemp, DeallocTemp)):
             result.append(sched_item)
             i += 1
 
@@ -2274,7 +2292,99 @@ def _postprocess_schedule(
         # Device mapper only gets run once.
         new_kernel = map_schedule_onto_host_or_device(new_kernel)
 
+    new_kernel = insert_temporary_alloc_dealloc(new_kernel)
     return new_kernel
+
+
+def insert_temporary_alloc_dealloc(kernel: LoopKernel):
+    schedule = kernel.linearization
+    inserted_allocs = set()
+    inserted_deallocs = set()
+
+    kernel_entry_idx = -1
+    loops_entry_idxs = []
+
+    insert_alloc_idxs = defaultdict(frozenset)
+    for idx, sched_item in enumerate(schedule):
+        if isinstance(sched_item, EnterLoop):
+            loops_entry_idxs.append(idx)
+        elif isinstance(sched_item, LeaveLoop):
+            loops_entry_idxs.pop()
+        elif isinstance(sched_item, CallKernel):
+            kernel_entry_idx = idx
+        elif isinstance(sched_item, ReturnFromKernel):
+            kernel_entry_idx = -1
+        elif isinstance(sched_item, RunInstruction):
+            insn = kernel.id_to_insn[sched_item.insn_id]
+            for var_name in set(insn.assignee_var_names()):
+                if var_name not in kernel.temporary_variables:
+                    continue
+                tv = kernel.temporary_variables[var_name]
+                if tv.base_storage:
+                    var_name = tv.base_storage
+                    tv = kernel.temporary_variables[var_name]
+                if var_name in inserted_allocs:
+                    continue
+                if tv.address_space == AddressSpace.GLOBAL:
+                    inserted_allocs.add(var_name)
+                    target_idx = idx
+                    if (kernel_entry_idx != -1):
+                        # lift the alloc out of ALL loops
+                        target_idx = min(idx, kernel_entry_idx, *loops_entry_idxs)
+                    else:
+                        target_idx = min(idx, *loops_entry_idxs)
+                    insert_alloc_idxs[target_idx] |= {var_name}
+
+    kernel_entry_idx = -1
+    loops_entry_idxs = []
+    insert_dealloc_idxs = defaultdict(frozenset)
+    for idx, sched_item in enumerate(reversed(schedule)):
+        idx = len(schedule) - idx - 1
+        if isinstance(sched_item, LeaveLoop):
+            loops_entry_idxs.append(idx)
+        elif isinstance(sched_item, EnterLoop):
+            loops_entry_idxs.pop()
+        elif isinstance(sched_item, ReturnFromKernel):
+            kernel_entry_idx = idx
+        elif isinstance(sched_item, CallKernel):
+            kernel_entry_idx = -1
+        elif isinstance(sched_item, RunInstruction):
+            insn = kernel.id_to_insn[sched_item.insn_id]
+            for var_name in set(insn.read_dependency_names()):
+                if var_name not in kernel.temporary_variables:
+                    continue
+                tv = kernel.temporary_variables[var_name]
+                if tv.base_storage:
+                    var_name = tv.base_storage
+                    tv = kernel.temporary_variables[var_name]
+                if var_name in inserted_deallocs:
+                    continue
+                if tv.address_space != AddressSpace.GLOBAL:
+                    continue
+                if var_name in inserted_allocs:
+                    inserted_deallocs.add(var_name)
+                    target_idx = idx
+                    if (kernel_entry_idx != -1):
+                        # lift the dealloc out of ALL loops
+                        target_idx = max(idx, kernel_entry_idx, *loops_entry_idxs)
+                    else:
+                        target_idx = max(idx, *loops_entry_idxs)
+                    insert_dealloc_idxs[target_idx] |= {var_name}
+
+    insert_dealloc_idxs[len(schedule)-1] |= (inserted_allocs - inserted_deallocs)
+
+    new_schedule = []
+    for idx, sched_item in enumerate(schedule):
+        if idx in insert_alloc_idxs:
+            for var_name in insert_alloc_idxs[idx]:
+                new_schedule.append(AllocTemp(var_name))
+        new_schedule.append(sched_item)
+
+        if idx in insert_dealloc_idxs:
+            for var_name in insert_dealloc_idxs[idx]:
+                new_schedule.append(DeallocTemp(var_name))
+
+    return kernel.copy(linearization=new_schedule)
 
 
 def _generate_loop_schedules_inner(

--- a/loopy/target/__init__.py
+++ b/loopy/target/__init__.py
@@ -323,6 +323,11 @@ class ASTBuilderBase(ABC, Generic[ASTType]):
     def emit_noop_with_comment(self, s):
         raise NotImplementedError()
 
+    def emit_alloc_temp(self, codegen_state, var_name):
+        raise NotImplementedError()
+
+    def emit_dealloc_temp(self, codegen_state, var_name):
+        raise NotImplementedError()
     # }}}
 
     def process_ast(self, node: ASTType):

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -67,6 +67,7 @@ from loopy.kernel.instruction import (
     CallInstruction,
     VarAtomicity,
 )
+from loopy.schedule import CallKernel
 from loopy.symbolic import IdentityMapper
 from loopy.target import ASTBuilderBase, DummyHostASTBuilder, TargetBase
 from loopy.tools import remove_common_indentation
@@ -83,7 +84,6 @@ if TYPE_CHECKING:
     from loopy.codegen.result import CodeGenerationResult
     from loopy.kernel import LoopKernel
     from loopy.kernel.instruction import MultiAssignmentBase
-    from loopy.schedule import CallKernel
     from loopy.target.execution import ExecutorBase
     from loopy.translation_unit import (
         CallableId,
@@ -1010,6 +1010,9 @@ class CFamilyASTBuilder(ASTBuilderBase[Generable]):
         kernel = codegen_state.kernel
 
         assert codegen_state.kernel.linearization is not None
+        while not isinstance(kernel.linearization[schedule_index], CallKernel):
+            schedule_index += 1
+            assert schedule_index < len(kernel.linearization)
         subkernel_name = cast(
                         "CallKernel",
                         codegen_state.kernel.linearization[schedule_index]
@@ -1105,6 +1108,11 @@ class CFamilyASTBuilder(ASTBuilderBase[Generable]):
             temporaries_read_in_subkernel,
             temporaries_written_in_subkernel,
         )
+
+        while not isinstance(kernel.linearization[schedule_index], CallKernel):
+            schedule_index += 1
+            assert schedule_index < len(kernel.linearization)
+
         subkernel_name = kernel.linearization[schedule_index].kernel_name
         sub_knl_temps = (
                 temporaries_read_in_subkernel(kernel, subkernel_name)
@@ -1143,6 +1151,16 @@ class CFamilyASTBuilder(ASTBuilderBase[Generable]):
             result.append(Line())
 
         return result
+
+    @override
+    def emit_alloc_temp(self, codegen_state, var_name):
+        from cgen import Line
+        return Line()
+
+    @override
+    def emit_dealloc_temp(self, codegen_state, var_name):
+        from cgen import Line
+        return Line()
 
     @property
     @override

--- a/loopy/target/c/__init__.py
+++ b/loopy/target/c/__init__.py
@@ -1009,13 +1009,13 @@ class CFamilyASTBuilder(ASTBuilderBase[Generable]):
             ) -> tuple[Sequence[tuple[str, str]], Generable]:
         kernel = codegen_state.kernel
 
-        assert codegen_state.kernel.linearization is not None
+        assert kernel.linearization is not None
         while not isinstance(kernel.linearization[schedule_index], CallKernel):
             schedule_index += 1
             assert schedule_index < len(kernel.linearization)
         subkernel_name = cast(
                         "CallKernel",
-                        codegen_state.kernel.linearization[schedule_index]
+                        kernel.linearization[schedule_index]
                         ).kernel_name
 
         from cgen import FunctionDeclaration, Value

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -798,24 +798,13 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
                 ["_lpy_cl_kernels", "queue", *kai.passed_arg_names,
                     "wait_for=None", "allocator=None"])
 
-        from genpy import For, Function, Line, Return, Statement as S, Suite
+        from genpy import Function, Line, Return, Suite
         return Function(
                 codegen_result.current_program(codegen_state).name,
                 args,
                 Suite([
                     Line(),
-                    ] + [
-                    Line(),
                     function_body,
-                    Line(),
-                    ] + ([
-                        For("_tv", "_global_temporaries",
-                            # Free global temporaries.
-                            # Zero-size temporaries allocate as None, tolerate that.
-                            # https://documen.tician.de/pyopencl/tools.html#pyopencl.tools.ImmediateAllocator
-                            S("if _tv is not None: _tv.release()"))
-                        ] if self._get_global_temporaries(codegen_state) else []
-                    ) + [
                     Line(),
                     Return("_lpy_evt"),
                     ]))
@@ -843,41 +832,36 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
                 codegen_state: CodeGenerationState,
                 schedule_index: int
             ) -> list[genpy.Generable]:
-        from genpy import Assign, Comment, Line
+        return []
+
+    @override
+    def emit_alloc_temp(self, codegen_state, var_name):
+        from genpy import Assign
         from pymbolic.mapper.stringifier import PREC_NONE
         ecm = self.get_expression_to_code_mapper(codegen_state)
 
         global_temporaries = self._get_global_temporaries(codegen_state)
-        if not global_temporaries:
-            return []
-
-        allocated_var_names: list[str] = []
-        code_lines: list[genpy.Generable] = []
-        code_lines.append(Line())
-        code_lines.append(Comment("{{{ allocate global temporaries"))
-        code_lines.append(Line())
 
         for tv in global_temporaries:
-            if not tv.base_storage:
-                if tv.nbytes:
-                    # NB: This does not prevent all zero-size allocations,
-                    # as sizes are parametric, and allocation size
-                    # could turn out to be zero at runtime.
-                    nbytes_str = ecm(tv.nbytes, PREC_NONE, type_context="i")
-                    allocated_var_names.append(tv.name)
-                    code_lines.append(Assign(tv.name,
-                                             f"allocator({nbytes_str})"))
-                else:
-                    code_lines.append(Assign(tv.name, "None"))
+            if tv.name == var_name:
+                if not tv.base_storage:
+                    if tv.nbytes:
+                        # NB: This does not prevent all zero-size allocations,
+                        # as sizes are parametric, and allocation size
+                        # could turn out to be zero at runtime.
+                        nbytes_str = ecm(tv.nbytes, PREC_NONE, type_context="i")
+                        return Assign(tv.name, f"allocator({nbytes_str})")
+                    else:
+                        return Assign(tv.name, "None")
 
-        code_lines.append(Assign("_global_temporaries", "[{tvs}]".format(
-            tvs=", ".join(tv for tv in allocated_var_names))))
+        # return Comment("Var %s not found" % var_name)
+        return Line()
 
-        code_lines.append(Line())
-        code_lines.append(Comment("}}}"))
-        code_lines.append(Line())
+    @override
+    def emit_dealloc_temp(self, codegen_state, var_name):
+        from genpy import Statement
 
-        return code_lines
+        return Statement("if %s is not None: %s.release()" % (var_name, var_name))
 
     def get_kernel_call(
             self, codegen_state: CodeGenerationState,

--- a/loopy/target/pyopencl.py
+++ b/loopy/target/pyopencl.py
@@ -835,8 +835,10 @@ class PyOpenCLPythonASTBuilder(PythonASTBuilderBase):
         return []
 
     @override
-    def emit_alloc_temp(self, codegen_state, var_name):
-        from genpy import Assign
+    def emit_alloc_temp(self,
+                codegen_state: CodeGenerationState,
+                var_name: str) -> genpy.Generable:
+        from genpy import Assign, Line
         from pymbolic.mapper.stringifier import PREC_NONE
         ecm = self.get_expression_to_code_mapper(codegen_state)
 

--- a/loopy/target/python.py
+++ b/loopy/target/python.py
@@ -220,14 +220,21 @@ class PythonASTBuilderBase(ASTBuilderBase[Generable]):
     def get_temporary_decls(self,
                 codegen_state: CodeGenerationState,
                 schedule_index: int) -> Sequence[Generable]:
+        return []
+
+    @override
+    def emit_alloc_temp(self,
+                codegen_state: CodeGenerationState,
+                var_name: str) -> Generable:
         kernel = codegen_state.kernel
         ecm = codegen_state.expression_to_code_mapper
 
         from genpy import Assign
         from pymbolic.mapper.stringifier import PREC_NONE
 
-        return [Assign(
-                            tv.name,
+        tv = kernel.temporary_variables[var_name]
+
+        return Assign(tv.name,
                             "_lpy_np.empty(%s, dtype=%s)"
                             % (
                                 ecm(tv.shape, PREC_NONE, "i"),
@@ -235,9 +242,15 @@ class PythonASTBuilderBase(ASTBuilderBase[Generable]):
                                     tv.dtype.numpy_dtype.name
                                     if tv.dtype.numpy_dtype.name != "bool"
                                     else "bool_")
-                                )) for tv in sorted(
-                kernel.temporary_variables.values(),
-                key=lambda key_tv: key_tv.name) if tv.shape]
+                                ))
+
+    @override
+    def emit_dealloc_temp(self,
+                codegen_state: CodeGenerationState,
+                var_name: str) -> Generable:
+        from genpy import Line
+
+        return Line()
 
     @override
     def get_expression_to_code_mapper(self, codegen_state: CodeGenerationState):

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -40,6 +40,58 @@ from loopy.version import (
 
 logger = logging.getLogger(__name__)
 
+def test_temporary_memory_allocation(ctx_factory: cl.CtxFactory):
+    from pyopencl.tools import ImmediateAllocator, MemoryPool
+
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+    n = 16
+
+    knl = lp.make_kernel(
+            "{ [i]: 0<=i<n}",
+            """
+            for i
+                <> b[i] = a[i]
+                ... gbarrier
+                <> c[i] = b[i] + 1
+                ... gbarrier
+                <> d[i] = c[i] + 1
+                ... gbarrier
+                <> e[i] = d[i] + 1
+                ... gbarrier
+                <> f[i] = e[i] + 1
+                ... gbarrier
+                <> g[i] = f[i] + 1
+                ... gbarrier
+                <> h[i] = g[i] + 1
+                ... gbarrier
+                <> j[i] = h[i] + 1
+                ... gbarrier
+                <> k[i] = j[i] + 1
+                ... gbarrier
+                <> l[i] = k[i] + 1
+                ... gbarrier
+                <> m[i] = l[i] + 1
+                ... gbarrier
+                out[i] = m[i]
+            end
+            """, seq_dependencies=True)
+
+    knl = lp.add_and_infer_dtypes(knl,
+            {"a": np.float32})
+
+    temp_vars = list(knl.default_entrypoint.temporary_variables)
+    knl = lp.set_temporary_address_space(knl, temp_vars, "global")
+
+    knl = lp.split_iname(knl, "i", 128, outer_tag="g.0", inner_tag="l.0")
+
+    mem_pool_alloc = MemoryPool(ImmediateAllocator(cq))
+
+    a = np.arange(n, dtype=np.float32)
+    knl(cq, a=a, allocator=mem_pool_alloc)
+
+    # FIXME This relies on the memory pool not freeing any memory it allocates
+    assert mem_pool_alloc.managed_bytes < len(temp_vars) * a.nbytes
 
 def test_globals_decl_once_with_multi_subprogram(ctx_factory: cl.CtxFactory):
     ctx = ctx_factory()

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -38,6 +38,58 @@ from loopy.version import LOOPY_USE_LANGUAGE_VERSION_2018_2  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
+def test_temporary_memory_allocation(ctx_factory: cl.CtxFactory):
+    from pyopencl.tools import ImmediateAllocator, MemoryPool
+
+    ctx = ctx_factory()
+    cq = cl.CommandQueue(ctx)
+    n = 16
+
+    knl = lp.make_kernel(
+            "{ [i]: 0<=i<n}",
+            """
+            for i
+                <> b[i] = a[i]
+                ... gbarrier
+                <> c[i] = b[i] + 1
+                ... gbarrier
+                <> d[i] = c[i] + 1
+                ... gbarrier
+                <> e[i] = d[i] + 1
+                ... gbarrier
+                <> f[i] = e[i] + 1
+                ... gbarrier
+                <> g[i] = f[i] + 1
+                ... gbarrier
+                <> h[i] = g[i] + 1
+                ... gbarrier
+                <> j[i] = h[i] + 1
+                ... gbarrier
+                <> k[i] = j[i] + 1
+                ... gbarrier
+                <> l[i] = k[i] + 1
+                ... gbarrier
+                <> m[i] = l[i] + 1
+                ... gbarrier
+                out[i] = m[i]
+            end
+            """, seq_dependencies=True)
+
+    knl = lp.add_and_infer_dtypes(knl,
+            {"a": np.float32})
+
+    temp_vars = list(knl.default_entrypoint.temporary_variables)
+    knl = lp.set_temporary_address_space(knl, temp_vars, "global")
+
+    knl = lp.split_iname(knl, "i", 128, outer_tag="g.0", inner_tag="l.0")
+
+    mem_pool_alloc = MemoryPool(ImmediateAllocator(cq))
+
+    a = np.arange(n, dtype=np.float32)
+    knl(cq, a=a, allocator=mem_pool_alloc)
+
+    # FIXME This relies on the memory pool not freeing any memory it allocates
+    assert mem_pool_alloc.managed_bytes < len(temp_vars) * a.nbytes
 
 def test_globals_decl_once_with_multi_subprogram(ctx_factory: cl.CtxFactory):
     ctx = ctx_factory()

--- a/test/test_loopy.py
+++ b/test/test_loopy.py
@@ -40,6 +40,7 @@ from loopy.version import (
 
 logger = logging.getLogger(__name__)
 
+
 def test_temporary_memory_allocation(ctx_factory: cl.CtxFactory):
     from pyopencl.tools import ImmediateAllocator, MemoryPool
 
@@ -92,6 +93,7 @@ def test_temporary_memory_allocation(ctx_factory: cl.CtxFactory):
 
     # FIXME This relies on the memory pool not freeing any memory it allocates
     assert mem_pool_alloc.managed_bytes < len(temp_vars) * a.nbytes
+
 
 def test_globals_decl_once_with_multi_subprogram(ctx_factory: cl.CtxFactory):
     ctx = ctx_factory()


### PR DESCRIPTION
For python and pyopencl targets, move temporary global allocations to be directly ahead of the first write, then deallocate the temporary after the last write, rather than allocating all of the temporaries up front and deleting at the end.