### PR TITLE
Avoid unnecessary kernel copies in `DomainChanger.get_kernel_with`

### DIFF
--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -577,7 +577,10 @@ class DomainChanger:
         return result
 
     def get_kernel_with(self, replacement: isl.BasicSet):
-        return self.kernel.copy(
+        if replacement == self.domain:
+            return self.kernel
+        else:
+            return self.kernel.copy(
                 domains=self.get_domains_with(replacement),
 
                 # Changing the domain might look like it wants to change grid


### PR DESCRIPTION
Avoids copying the kernel when `get_kernel_with` is called with a domain that is unchanged. I'm seeing this happen a lot specifically in `intersect_kernel_with_slab`.

@inducer Here's a breakdown of how much each of the changes I made contributes to the total time difference. I'll submit PRs for the other changes after this.

<img width="512" alt="mg_loopy_optimizations" src="https://github.com/user-attachments/assets/fb55271d-9c84-47f8-a760-2aad556c057f" />