### PR TITLE
Use `orig_kernel` when finding most recent global barrier in `realize_reduction`

### DIFF
--- a/loopy/transform/realize_reduction.py
+++ b/loopy/transform/realize_reduction.py
@@ -2142,7 +2142,8 @@ def realize_reduction_for_single_kernel(
             )
 
             if kernel_has_global_barriers(orig_kernel):
-                global_barrier = find_most_recent_global_barrier(kernel, insn.id)
+                global_barrier = find_most_recent_global_barrier(
+                    orig_kernel, insn.id)
 
                 if global_barrier is not None:
                     gb_dep = frozenset([global_barrier])


### PR DESCRIPTION
Avoids recomputation of barrier order for each reduction. AFAIK, `realize_reduction` doesn't modify any of the barriers or their order, so this should be OK.

This is another one of the optimizations shown in the plot in #1026.