### PR TITLE
Avoid copying kernels repeatedly in `duplicate_inames`/`rename_inames_in_batch`

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -73956,8 +73956,8 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 17,
+                    "startColumn": 23,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             }

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -527,7 +527,7 @@ class SetOperationCacheManager:
 # }}}
 
 
-# {{{ domain change helper
+# {{{ domain change helpers
 
 class DomainChanger:
     """Helps change the domain responsible for *inames* within a kernel.
@@ -582,6 +582,90 @@ class DomainChanger:
         else:
             return self.kernel.copy(
                 domains=self.get_domains_with(replacement),
+
+                # Changing the domain might look like it wants to change grid
+                # sizes. Not true.
+                # (Relevant for 'slab decomposition')
+                overridden_get_grid_sizes_for_insn_ids=(
+                    self.kernel.get_grid_sizes_for_insn_ids))
+
+
+class MultiDomainChanger:
+    """
+    Like :class:`DomainChanger`, but operates on multiple collections of inames.
+    """
+
+    kernel: LoopKernel
+    leaf_domain_indices: list[int | None]
+
+    def __init__(self, kernel: LoopKernel, inames: Sequence[Collection[InameStr]]):
+        """
+        :arg inames: a sequence of non-mutable iterable
+        """
+
+        self.kernel = kernel
+        self.leaf_domain_indices = []
+        for inms in inames:
+            if inms:
+                ldi = kernel.get_leaf_domain_indices(inms)
+                if len(ldi) > 1:
+                    raise RuntimeError("Inames '%s' require more than one leaf "
+                            "domain, which makes the domain change that is part "
+                            "of your current operation ambiguous." % ", ".join(inms))
+
+                self.leaf_domain_indices.append(ldi[0])
+            else:
+                self.leaf_domain_indices.append(None)
+
+    @property
+    def domains(self) -> Sequence[isl.BasicSet]:
+        trivial_domain = self.kernel.combine_domains(())
+
+        result: list[isl.BasicSet] = []
+        for idx in self.leaf_domain_indices:
+            if idx is None:
+                result.append(trivial_domain)
+            else:
+                result.append(self.kernel.domains[idx])
+
+        return result
+
+    def get_domains_with(
+            self, replacements: Sequence[isl.BasicSet]) -> Sequence[isl.BasicSet]:
+        if len(replacements) != len(self.leaf_domain_indices):
+            raise LoopyError("replacements has incorrect length.")
+
+        index_to_replacements: dict[int | None, isl.BasicSet] = {}
+        for idx, repl in zip(self.leaf_domain_indices, replacements, strict=True):
+            try:
+                existing_repl = index_to_replacements[idx]
+            except KeyError:
+                index_to_replacements[idx] = repl
+            else:
+                if repl != existing_repl:
+                    raise LoopyError(
+                        "found multiple inconsistent replacements for the same "
+                        "domain.")
+
+        result = list(self.kernel.domains)
+        for idx, replacement in zip(
+                self.leaf_domain_indices, replacements, strict=True):
+            if idx is not None:
+                result[idx] = replacement
+            else:
+                result.append(replacement)
+
+        return result
+
+    def get_kernel_with(self, replacements: Sequence[isl.BasicSet]):
+        if all(
+                replacement == domain
+                for domain, replacement in zip(
+                    self.domains, replacements, strict=True)):
+            return self.kernel
+        else:
+            return self.kernel.copy(
+                domains=self.get_domains_with(replacements),
 
                 # Changing the domain might look like it wants to change grid
                 # sizes. Not true.

--- a/loopy/kernel/tools.py
+++ b/loopy/kernel/tools.py
@@ -41,7 +41,7 @@ from typing import (
 )
 
 import numpy as np
-from typing_extensions import deprecated, override
+from typing_extensions import override
 
 import islpy as isl
 import pymbolic.primitives as p
@@ -529,67 +529,6 @@ class SetOperationCacheManager:
 
 # {{{ domain change helpers
 
-class DomainChanger:
-    """Helps change the domain responsible for *inames* within a kernel.
-
-    .. note: Does not perform an in-place change!
-    """
-
-    kernel: LoopKernel
-    leaf_domain_index: int | None
-
-    def __init__(self, kernel: LoopKernel, inames: Collection[InameStr]):
-        """
-        :arg inames: a non-mutable iterable
-        """
-
-        self.kernel = kernel
-        if inames:
-            ldi = kernel.get_leaf_domain_indices(inames)
-            if len(ldi) > 1:
-                raise RuntimeError("Inames '%s' require more than one leaf "
-                        "domain, which makes the domain change that is part "
-                        "of your current operation ambiguous." % ", ".join(inames))
-
-            self.leaf_domain_index, = ldi
-
-        else:
-            self.leaf_domain_index = None
-
-    @property
-    def domain(self):
-        if self.leaf_domain_index is None:
-            return self.kernel.combine_domains(())
-        else:
-            return self.kernel.domains[self.leaf_domain_index]
-
-    @deprecated("use .domain instead")
-    def get_original_domain(self):
-        return self.domain
-
-    def get_domains_with(self, replacement: isl.BasicSet):
-        result = list(self.kernel.domains)
-        if self.leaf_domain_index is not None:
-            result[self.leaf_domain_index] = replacement
-        else:
-            result.append(replacement)
-
-        return result
-
-    def get_kernel_with(self, replacement: isl.BasicSet):
-        if replacement == self.domain:
-            return self.kernel
-        else:
-            return self.kernel.copy(
-                domains=self.get_domains_with(replacement),
-
-                # Changing the domain might look like it wants to change grid
-                # sizes. Not true.
-                # (Relevant for 'slab decomposition')
-                overridden_get_grid_sizes_for_insn_ids=(
-                    self.kernel.get_grid_sizes_for_insn_ids))
-
-
 class MultiDomainChanger:
     """
     Like :class:`DomainChanger`, but operates on multiple collections of inames.
@@ -672,6 +611,39 @@ class MultiDomainChanger:
                 # (Relevant for 'slab decomposition')
                 overridden_get_grid_sizes_for_insn_ids=(
                     self.kernel.get_grid_sizes_for_insn_ids))
+
+
+class DomainChanger:
+    """Helps change the domain responsible for *inames* within a kernel.
+
+    .. note: Does not perform an in-place change!
+    """
+
+    kernel: LoopKernel
+
+    _multi_changer: MultiDomainChanger
+
+    def __init__(self, kernel: LoopKernel, inames: Collection[InameStr]):
+        """
+        :arg inames: a non-mutable iterable
+        """
+
+        self.kernel = kernel
+        self._multi_changer = MultiDomainChanger(kernel, [inames])
+
+    @property
+    def leaf_domain_index(self) -> int | None:
+        return self._multi_changer.leaf_domain_indices[0]
+
+    @property
+    def domain(self):
+        return self._multi_changer.domains[0]
+
+    def get_domains_with(self, replacement: isl.BasicSet):
+        return self._multi_changer.get_domains_with([replacement])
+
+    def get_kernel_with(self, replacement: isl.BasicSet):
+        return self._multi_changer.get_kernel_with([replacement])
 
 # }}}
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -1017,14 +1017,37 @@ def duplicate_inames(
 
     # {{{ duplicate the inames
 
+    from collections import defaultdict
+
     from loopy.isl_helpers import duplicate_axes
-    from loopy.kernel.tools import DomainChanger
+    from loopy.kernel.tools import MultiDomainChanger
 
-    for old_iname, new_iname in zip(inames, new_suffixed_inames, strict=True):
-        domch = DomainChanger(kernel, frozenset([old_iname]))
+    domch = MultiDomainChanger(kernel, [frozenset([iname]) for iname in inames])
 
-        dup_iname = duplicate_axes(domch.domain, [old_iname], [new_iname])
-        kernel = kernel.copy(domains=domch.get_domains_with(dup_iname))
+    # Group inames that share a leaf domain so that all of a domain's new axes
+    # are added in a single duplicate_axes call
+    leaf_idx_to_group: dict[int, tuple[list[InameStr], list[InameStr]]] = \
+        defaultdict(lambda: ([], []))
+    for leaf_idx, old_iname, new_iname in zip(
+            domch.leaf_domain_indices, inames, new_suffixed_inames, strict=True):
+        assert isinstance(leaf_idx, int)
+        old_grp, new_grp = leaf_idx_to_group[leaf_idx]
+        old_grp.append(old_iname)
+        new_grp.append(new_iname)
+
+    leaf_idx_to_dup = {
+        leaf_idx: duplicate_axes(kernel.domains[leaf_idx], old_grp, new_grp)
+        for leaf_idx, (old_grp, new_grp) in leaf_idx_to_group.items()}
+
+    def verify_is_int(idx: int | None) -> int:
+        assert isinstance(idx, int)
+        return idx
+
+    dup_inames = [
+        leaf_idx_to_dup[verify_is_int(leaf_idx)]
+        for leaf_idx in domch.leaf_domain_indices]
+
+    kernel = kernel.copy(domains=domch.get_domains_with(dup_inames))
 
     # }}}
 

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -2476,153 +2476,6 @@ def add_inames_for_unused_hw_axes(kernel: LoopKernel,
 
 @for_each_kernel
 @remove_any_newly_unused_inames
-def rename_inames(
-            kernel: LoopKernel,
-            old_inames: Collection[InameStr],
-            new_iname: InameStr,
-            existing_ok: bool = False,
-            within: ToStackMatchConvertible = None,
-            raise_on_domain_mismatch: bool | None = None
-        ) -> LoopKernel:
-    r"""
-    :arg old_inames: a collection of inames that must be renamed to *new_iname*.
-    :arg within: a stack match, as understood by :func:`loopy.match.parse_stack_match`.
-    :arg existing_ok: execute even if *new_iname* already exists.
-    :arg raise_on_domain_mismatch: if *True*, raises an error if
-        :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
-        \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
-    """
-
-    if isinstance(old_inames, str) or not isinstance(old_inames, Collection):
-        raise LoopyError("'old_inames' must be a collection of strings: "
-                         f"{type(old_inames)}")
-    old_inames = frozenset(_to_inames_tuple(old_inames))
-
-    if new_iname in old_inames:
-        raise LoopyError("'new_iname' is part of inames being renamed: "
-                         f"'{new_iname}' in {_to_inames_str(old_inames)}")
-
-    if new_iname in (kinames := (kernel.all_variable_names() - kernel.all_inames())):
-        raise LoopyError(f"new iname '{new_iname}' is already a variable in the"
-                         f"kernel: {kinames}")
-
-    if any((len(insn.within_inames & old_inames) > 1) for insn in kernel.instructions):
-        raise LoopyError("'old_inames' contains nested inames -- renaming is illegal")
-
-    if raise_on_domain_mismatch is None:
-        raise_on_domain_mismatch = __debug__
-
-    var_name_gen = kernel.get_var_name_generator()
-
-    # sort to have deterministic implementation.
-    sorted_old_inames = sorted(old_inames)
-
-    # FIXME: distinguish existing iname vs. existing other variable
-    does_exist = new_iname in kernel.all_inames()
-
-    if not (old_inames <= kernel.all_inames()):
-        raise LoopyError(
-                f"old inames {_to_inames_str(old_inames - kernel.all_inames())}"
-                " do not exist.")
-
-    if does_exist and not existing_ok:
-        raise LoopyError(f"iname '{new_iname}' conflicts with an existing identifier"
-                         " --cannot rename")
-
-    if not does_exist:
-        # {{{ rename old_inames[0] -> new_iname
-        # so that the code below can focus on "merging" inames that already exist
-
-        kernel = duplicate_inames(
-                kernel, sorted_old_inames[0], within=within, new_inames=[new_iname])
-
-        # old_iname[0] is already renamed to new_iname => do not rename again.
-        sorted_old_inames = sorted_old_inames[1:]
-
-        # }}}
-
-    del does_exist
-    assert new_iname in kernel.all_inames()
-
-    if raise_on_domain_mismatch:
-        for old_iname in sorted_old_inames:
-            # {{{ check that the domains match up
-
-            dom = kernel.get_inames_domain(frozenset((old_iname, new_iname)))
-
-            var_dict = dom.get_var_dict()
-            _, old_idx = var_dict[old_iname]
-            _, new_idx = var_dict[new_iname]
-
-            par_idx = dom.dim(dim_type.param)
-            dom_old = dom.move_dims(
-                    dim_type.param, par_idx, dim_type.set, old_idx, 1)
-            dom_old = dom_old.move_dims(dim_type.set,
-                                        dom_old.dim(dim_type.set),
-                                        dim_type.param, par_idx, 1)
-            dom_old = dom_old.project_out(dim_type.set,
-                                          new_idx
-                                          if new_idx < old_idx
-                                          else new_idx - 1,
-                                          1)
-
-            par_idx = dom.dim(dim_type.param)
-            dom_new = dom.move_dims(dim_type.param, par_idx,
-                                    dim_type.set, new_idx, 1)
-            dom_new = dom_new.move_dims(dim_type.set, dom_new.dim(dim_type.set),
-                                        dim_type.param, par_idx, 1)
-            dom_new = dom_new.project_out(dim_type.set,
-                                          old_idx
-                                          if old_idx < new_idx
-                                          else old_idx - 1, 1)
-
-            if not (dom_old <= dom_new <= dom_old):
-                raise LoopyError(
-                        f"inames {old_iname} and {new_iname} do not iterate over "
-                        "the same domain")
-
-            # }}}
-
-    subst_dict = {old_iname: prim.Variable(new_iname)
-                  for old_iname in sorted_old_inames}
-
-    from loopy.match import parse_stack_match
-    within = parse_stack_match(within)
-
-    from pymbolic.mapper.substitutor import make_subst_func
-    rule_mapping_context = SubstitutionRuleMappingContext(
-            kernel.substitutions, var_name_gen)
-    smap = RuleAwareSubstitutionMapper(rule_mapping_context,
-                    make_subst_func(subst_dict), within)
-
-    from loopy.kernel.instruction import MultiAssignmentBase
-
-    def does_insn_involve_iname(
-            kernel: LoopKernel,
-            insn: InstructionBase,
-            stack: RuleStack) -> bool:
-        return bool(not isinstance(insn, MultiAssignmentBase)
-                or old_inames & insn.dependency_names()
-                or old_inames & insn.reduction_inames())
-
-    kernel = rule_mapping_context.finish_kernel(
-            smap.map_kernel(kernel, within=does_insn_involve_iname,
-                            map_tvs=False, map_args=False))
-
-    new_instructions = [
-        insn.copy(within_inames=(
-            (insn.within_inames - old_inames) | frozenset([new_iname])))
-        if ((len(old_inames & insn.within_inames) != 0) and within(kernel, insn, ()))
-        else insn
-        for insn in kernel.instructions]
-
-    kernel = kernel.copy(instructions=new_instructions)
-
-    return kernel
-
-
-@for_each_kernel
-@remove_any_newly_unused_inames
 def rename_inames_multi(
             kernel: LoopKernel,
             old_inames: Sequence[Collection[InameStr]],
@@ -2829,6 +2682,29 @@ def rename_inames_multi(
     kernel = kernel.copy(instructions=new_instructions)
 
     return kernel
+
+
+@for_each_kernel
+@remove_any_newly_unused_inames
+def rename_inames(
+            kernel: LoopKernel,
+            old_inames: Collection[InameStr],
+            new_iname: InameStr,
+            existing_ok: bool = False,
+            within: ToStackMatchConvertible = None,
+            raise_on_domain_mismatch: bool | None = None
+        ) -> LoopKernel:
+    r"""
+    :arg old_inames: a collection of inames that must be renamed to *new_iname*.
+    :arg within: a stack match, as understood by :func:`loopy.match.parse_stack_match`.
+    :arg existing_ok: execute even if *new_iname* already exists.
+    :arg raise_on_domain_mismatch: if *True*, raises an error if
+        :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
+        \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
+    """
+    return rename_inames_multi(
+        kernel, [old_inames], [new_iname], existing_ok, within,
+        raise_on_domain_mismatch)
 
 
 @for_each_kernel

--- a/loopy/transform/iname.py
+++ b/loopy/transform/iname.py
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from collections import defaultdict
 from collections.abc import (
     Callable,
     Collection,
@@ -2614,6 +2615,216 @@ def rename_inames(
         if ((len(old_inames & insn.within_inames) != 0) and within(kernel, insn, ()))
         else insn
         for insn in kernel.instructions]
+
+    kernel = kernel.copy(instructions=new_instructions)
+
+    return kernel
+
+
+@for_each_kernel
+@remove_any_newly_unused_inames
+def rename_inames_multi(
+            kernel: LoopKernel,
+            old_inames: Sequence[Collection[InameStr]],
+            new_inames: Sequence[InameStr],
+            existing_ok: bool = False,
+            within: ToStackMatchConvertible = None,
+            raise_on_domain_mismatch: bool | None = None
+        ) -> LoopKernel:
+    r"""
+    Multiple new iname version of :func:`loopy.rename_inames`.
+
+    :arg old_inames: a sequence of (disjoint) collections of inames that must be
+        renamed.
+    :arg new_inames: a sequence of new inames corresponding to the entries in
+        *old_inames*.
+    :arg within: a stack match, as understood by :func:`loopy.match.parse_stack_match`.
+    :arg existing_ok: execute even if *new_iname* already exists.
+    :arg raise_on_domain_mismatch: if *True*, raises an error if
+        :math:`\exists (i_1,i_2) \in \{\text{old\_inames}\}^2 |
+        \mathcal{D}_{i_1} \neq \mathcal{D}_{i_2}`.
+    """
+    if len(new_inames) != len(old_inames):
+        raise LoopyError("'new_inames' and 'old_inames' must have the same length.")
+
+    old_inames = list(old_inames)
+
+    kinames = kernel.all_variable_names() - kernel.all_inames()
+
+    for i in range(len(old_inames)):
+        if isinstance(old_inames[i], str) or not isinstance(old_inames[i], Collection):
+            raise LoopyError("'old_inames[i]' must be a collection of strings: "
+                             f"{type(old_inames[i])}")
+        old_inames[i] = _to_inames_tuple(old_inames[i])
+
+        old_inames_i_set = frozenset(old_inames[i])
+
+        if new_inames[i] in old_inames_i_set:
+            raise LoopyError("'new_iname' is part of inames being renamed: "
+                             f"'{new_inames[i]}' in {_to_inames_str(old_inames[i])}")
+
+        if new_inames[i] in kinames:
+            raise LoopyError(f"new iname '{new_inames[i]}' is already a variable in "
+                             f"the kernel: {kinames}")
+
+        if any(
+                (len(insn.within_inames & old_inames_i_set) > 1)
+                for insn in kernel.instructions):
+            raise LoopyError(
+                "'old_inames' contains nested inames -- renaming is illegal")
+
+        if not (old_inames_i_set <= kernel.all_inames()):
+            raise LoopyError(
+                f"old inames {_to_inames_str(old_inames_i_set - kernel.all_inames())}"
+                " do not exist.")
+
+    old_iname_to_count = defaultdict(int)
+    for i in range(len(old_inames)):
+        for iname in old_inames[i]:
+            old_iname_to_count[iname] += 1
+    for iname, count in old_iname_to_count.items():
+        if count > 1:
+            raise LoopyError(f"old iname {iname} occurs in multiple entries.")
+
+    does_not_exist_indices: list[int] = []
+    for i in range(len(new_inames)):
+        # FIXME: distinguish existing iname vs. existing other variable
+        does_exist = new_inames[i] in kernel.all_inames()
+        if does_exist and not existing_ok:
+            raise LoopyError(
+                f"iname '{new_inames[i]}' conflicts with an existing identifier "
+                "-- cannot rename")
+        if not does_exist:
+            does_not_exist_indices.append(i)
+
+    if raise_on_domain_mismatch is None:
+        raise_on_domain_mismatch = __debug__
+
+    # sort to have deterministic implementation.
+    sorted_old_inames = [
+        sorted(inames)
+        for inames in old_inames]
+
+    if does_not_exist_indices:
+        # {{{ rename sorted_old_inames[i][0] -> new_iname
+        # so that the code below can focus on "merging" inames that already exist
+
+        duplicate_from_inames = [
+            sorted_old_inames[i][0] for i in does_not_exist_indices]
+        duplicate_to_inames = [new_inames[i] for i in does_not_exist_indices]
+
+        kernel = duplicate_inames(
+                kernel, duplicate_from_inames, within=within,
+                new_inames=duplicate_to_inames)
+
+        # sorted_old_inames[i][0] is already renamed to new_iname => do not rename
+        # again.
+        sorted_old_inames = [
+            inames[1:]
+            for inames in sorted_old_inames]
+
+        # }}}
+
+    del does_not_exist_indices
+    for iname in new_inames:
+        assert iname in kernel.all_inames()
+
+    if raise_on_domain_mismatch:
+        for i in range(len(old_inames)):
+            new_iname = new_inames[i]
+            for old_iname in sorted_old_inames[i]:
+                # {{{ check that the domains match up
+
+                dom = kernel.get_inames_domain(frozenset((old_iname, new_iname)))
+
+                var_dict = dom.get_var_dict()
+                _, old_idx = var_dict[old_iname]
+                _, new_idx = var_dict[new_iname]
+
+                par_idx = dom.dim(dim_type.param)
+                dom_old = dom.move_dims(
+                        dim_type.param, par_idx, dim_type.set, old_idx, 1)
+                dom_old = dom_old.move_dims(dim_type.set,
+                                            dom_old.dim(dim_type.set),
+                                            dim_type.param, par_idx, 1)
+                dom_old = dom_old.project_out(dim_type.set,
+                                              new_idx
+                                              if new_idx < old_idx
+                                              else new_idx - 1,
+                                              1)
+
+                par_idx = dom.dim(dim_type.param)
+                dom_new = dom.move_dims(dim_type.param, par_idx,
+                                        dim_type.set, new_idx, 1)
+                dom_new = dom_new.move_dims(dim_type.set, dom_new.dim(dim_type.set),
+                                            dim_type.param, par_idx, 1)
+                dom_new = dom_new.project_out(dim_type.set,
+                                              old_idx
+                                              if old_idx < new_idx
+                                              else old_idx - 1, 1)
+
+                if not (dom_old <= dom_new <= dom_old):
+                    raise LoopyError(
+                            f"inames {old_iname} and {new_iname} do not iterate over "
+                            "the same domain")
+
+            # }}}
+
+    all_old_inames = frozenset([
+        iname
+        for inames in sorted_old_inames
+        for iname in inames])
+
+    old_iname_to_new_iname = {
+        old_iname: new_iname
+        for old_inms, new_iname in zip(sorted_old_inames, new_inames, strict=True)
+        for old_iname in old_inms}
+
+    subst_dict = {old_iname: prim.Variable(new_iname)
+                  for old_iname, new_iname in old_iname_to_new_iname.items()}
+
+    from loopy.match import parse_stack_match
+    within = parse_stack_match(within)
+
+    from pymbolic.mapper.substitutor import make_subst_func
+    var_name_gen = kernel.get_var_name_generator()
+    rule_mapping_context = SubstitutionRuleMappingContext(
+            kernel.substitutions, var_name_gen)
+    smap = RuleAwareSubstitutionMapper(rule_mapping_context,
+                    make_subst_func(subst_dict), within)
+
+    from loopy.kernel.instruction import MultiAssignmentBase
+
+    def does_insn_involve_iname(
+            kernel: LoopKernel,
+            insn: InstructionBase,
+            stack: RuleStack) -> bool:
+        return bool(not isinstance(insn, MultiAssignmentBase)
+                or all_old_inames & insn.dependency_names()
+                or all_old_inames & insn.reduction_inames())
+
+    kernel = rule_mapping_context.finish_kernel(
+            smap.map_kernel(kernel, within=does_insn_involve_iname,
+                            map_tvs=False, map_args=False))
+
+    new_instructions: list[InstructionBase] = []
+    for insn in kernel.instructions:
+        if not within(kernel, insn, ()):
+            new_instructions.append(insn)
+            continue
+        new_within_inames_list: list[InameStr] = []
+        for iname in insn.within_inames:
+            try:
+                new_iname = old_iname_to_new_iname[iname]
+            except KeyError:
+                new_iname = iname
+            new_within_inames_list.append(new_iname)
+        new_within_inames = frozenset(new_within_inames_list)
+        if new_within_inames != insn.within_inames:
+            new_insn = insn.copy(within_inames=new_within_inames)
+        else:
+            new_insn = insn
+        new_instructions.append(new_insn)
 
     kernel = kernel.copy(instructions=new_instructions)
 

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -965,17 +965,21 @@ def rename_inames_in_batch(
     :arg batches: A mapping from ``new_iname`` to a collection of
         inames that are to be renamed to ``new_iname``.
     """
-    from loopy.transform.iname import remove_unused_inames, rename_inames
+    from loopy.transform.iname import remove_unused_inames, rename_inames_multi
 
-    for new_iname, candidates in batches.items():
-        kernel = cast("LoopKernel", rename_inames(
-            kernel, candidates, new_iname,
+    old_inames = list(batches.values())
+    new_inames = list(batches.keys())
 
-            # type-ignore because remove_newly_unused_inames is added by a
-            # decorator in a non-type-able way.
-            remove_newly_unused_inames=False  # pyright: ignore[reportCallIssue]
-        ))
+    kernel = cast("LoopKernel", rename_inames_multi(
+        kernel, old_inames, new_inames,
 
+        # type-ignore because remove_newly_unused_inames is added by a
+        # decorator in a non-type-able way.
+        remove_newly_unused_inames=False  # pyright: ignore[reportCallIssue]
+    ))
+
+    # FIXME: Set remove_newly_unused_inames==True above and remove this, now that
+    # there's just one call?
     return remove_unused_inames(kernel, fset_union(batches.values()))
 
 

--- a/loopy/transform/loop_fusion.py
+++ b/loopy/transform/loop_fusion.py
@@ -965,22 +965,11 @@ def rename_inames_in_batch(
     :arg batches: A mapping from ``new_iname`` to a collection of
         inames that are to be renamed to ``new_iname``.
     """
-    from loopy.transform.iname import remove_unused_inames, rename_inames_multi
+    from loopy.transform.iname import rename_inames_multi
 
     old_inames = list(batches.values())
     new_inames = list(batches.keys())
 
-    kernel = cast("LoopKernel", rename_inames_multi(
-        kernel, old_inames, new_inames,
-
-        # type-ignore because remove_newly_unused_inames is added by a
-        # decorator in a non-type-able way.
-        remove_newly_unused_inames=False  # pyright: ignore[reportCallIssue]
-    ))
-
-    # FIXME: Set remove_newly_unused_inames==True above and remove this, now that
-    # there's just one call?
-    return remove_unused_inames(kernel, fset_union(batches.values()))
-
+    return rename_inames_multi(kernel, old_inames, new_inames)
 
 # vim: foldmethod=marker


### PR DESCRIPTION
Adds `MultiDomainChanger` to avoid excessive kernel copies in `duplicate_inames`. Also adds `rename_inames_multi` to do the same for `rename_inames_in_batch`.

This is another one of the optimizations shown in the plot in #1026.