### PR TITLE
Cache domain inames in kernel

### DIFF
--- a/loopy/kernel/__init__.py
+++ b/loopy/kernel/__init__.py
@@ -107,13 +107,6 @@ class KernelState(IntEnum):
     LINEARIZED = 3
 
 
-def _get_inames_from_domains(
-            domains: Sequence[isl.Set | isl.BasicSet]
-        ) -> AbstractSet[InameStr]:
-    return fset_union(
-            frozenset(dom.get_var_names_not_none(dim_type.set)) for dom in domains)
-
-
 @dataclass(frozen=True)
 class _BoundsRecord:
     lower_bound_pw_aff: isl.PwAff
@@ -182,6 +175,11 @@ class LoopKernel(Taggable):
     options: Options
     target: TargetBase
     tags: frozenset[Tag]
+
+    # Cached inames per domain (keyed by object ID)
+    _domain_inames: constantdict[int, frozenset[InameStr]] = field(
+        repr=False, compare=False)
+
     state: KernelState = KernelState.INITIAL
     name: str = "loopy_kernel"
 
@@ -231,6 +229,8 @@ class LoopKernel(Taggable):
             raise TypeError("index_dtype must be signed")
 
         assert self.assumptions.get_ctx() == isl.DEFAULT_CONTEXT
+
+        assert len(self._domain_inames) == len(self.domains)
 
     # {{{ symbol mangling
 
@@ -1402,6 +1402,12 @@ class LoopKernel(Taggable):
         from loopy.kernel.tools import SetOperationCacheManager
         object.__setattr__(self, "_cache_manager", SetOperationCacheManager())
 
+        # _domain_inames is keyed by object id, which is not preserved across
+        # pickling, so recompute it from the (just-restored) domains.
+        object.__setattr__(self, "_domain_inames", constantdict({
+            id(dom): frozenset(dom.get_var_names_not_none(dim_type.set))
+            for dom in self.domains}))
+
     # }}}
 
     # {{{ persistent hash key generation / comparison
@@ -1455,13 +1461,43 @@ class LoopKernel(Taggable):
     # }}}
 
     def get_copy_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-        if "domains" in kwargs:
-            inames = kwargs.get("inames", self.inames)
-            domains = kwargs["domains"]
-            kwargs["inames"] = {name: inames.get(name, KernelIname(name, frozenset()))
-                                for name in _get_inames_from_domains(domains)}
+        all_inames: AbstractSet[InameStr]
 
-            assert all(dom.get_ctx() == isl.DEFAULT_CONTEXT for dom in domains)
+        domain_inames: constantdict[int, frozenset[InameStr]]
+        changed_domain_inames: bool
+
+        if "domains" in kwargs:
+            domains = kwargs["domains"]
+
+            def get_inames_from_domain(dom: isl.BasicSet) -> frozenset[InameStr]:
+                try:
+                    return self._domain_inames[id(dom)]
+                except KeyError:
+                    assert dom.get_ctx() == isl.DEFAULT_CONTEXT
+                    return frozenset(dom.get_var_names_not_none(dim_type.set))
+
+            domain_inames = constantdict({
+                id(dom): get_inames_from_domain(dom)
+                for dom in domains})
+
+            changed_domain_inames = (
+                domain_inames.keys() != self._domain_inames.keys())
+
+            kwargs["_domain_inames"] = domain_inames
+
+        else:
+            domain_inames = self._domain_inames
+            changed_domain_inames = False
+
+        if changed_domain_inames or "inames" in kwargs:
+            all_inames: AbstractSet[InameStr] = fset_union(domain_inames.values())
+
+            inames = kwargs.get("inames", self.inames)
+
+            if inames.keys() != all_inames:
+                kwargs["inames"] = {
+                    name: inames.get(name, KernelIname(name, frozenset()))
+                    for name in all_inames}
 
         return kwargs
 

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2504,10 +2504,15 @@ def make_function(
 
     # }}}
 
-    from loopy.kernel import _get_inames_from_domains
     from loopy.kernel.data import Iname
+
+    domain_inames: dict[int, frozenset[InameStr]] = {
+        id(dom): frozenset(dom.get_var_names_not_none(dim_type.set))
+        for dom in domains}
+
+    from pytools import fset_union
     inames = {name: Iname(name, frozenset())
-              for name in _get_inames_from_domains(domains)}
+              for name in fset_union(domain_inames.values())}
 
     substitutions = constantdict(substitutions)
     for sname, rule in inline_substitutions.items():
@@ -2555,6 +2560,7 @@ def make_function(
             name=name,
             iname_slab_increments=constantdict(iname_slab_increments),
             applied_iname_rewrites=applied_iname_rewrites,
+            _domain_inames=constantdict(domain_inames),
             )
 
     from loopy.transform.instruction import uniquify_instruction_ids

--- a/loopy/transform/fusion.py
+++ b/loopy/transform/fusion.py
@@ -244,9 +244,14 @@ def _fuse_two_kernels(kernela: LoopKernel, kernelb: LoopKernel):
 
     # }}}
 
+    domain_inames = constantdict({
+        id(dom): frozenset(dom.get_var_names_not_none(dim_type.set))
+        for dom in new_domains})
+
     from loopy.kernel import LoopKernel
     return LoopKernel(
             domains=new_domains,
+            _domain_inames=domain_inames,
             instructions=new_instructions,
             args=new_args,
             name=f"{kernela.name}_and_{kernelb.name}",


### PR DESCRIPTION
Avoids re-gathering inames from domains that haven't changed.

May not be needed after namedisl? Leaving as draft for now.

This is another one of the optimizations shown in the plot in #1026.