### PR TITLE
Fix out-of-bounds check silently skipped for shape-only kernel params

### DIFF
--- a/loopy/check.py
+++ b/loopy/check.py
@@ -770,9 +770,28 @@ class _AccessCheckMapper(WalkMapper[[nisl.Set, str]]):
             for shape_axis in shape:
                 shape_deps.update(get_dependencies(shape_axis))
 
-            if not (get_dependencies(subscript) <= available_vars
-                    and shape_deps <= available_vars):
+            if get_dependencies(subscript) - available_vars:
                 return
+
+            # A shape may depend on kernel parameters (e.g. value args) that
+            # are not part of the instruction's domain, because the
+            # parameter only appears in the shape and not in any expression.
+            # If all such missing parameters are (read-only) value args of the
+            # kernel, add them to the domain as (free) parameters so that the
+            # access range can be checked against the shape. Any other missing
+            # dependency (e.g. a temporary) is data-dependent => can't check.
+            missing_shape_vars = shape_deps - available_vars
+            if missing_shape_vars:
+                from loopy.kernel.data import ValueArg
+
+                value_arg_names = {arg.name for arg in self.kernel.args
+                        if isinstance(arg, ValueArg)
+                        and arg.name not in self.kernel.get_written_variables()}
+                if not missing_shape_vars <= value_arg_names:
+                    return
+
+                domain = domain.add_dims(
+                        DimType.param, sorted(missing_shape_vars))
 
             if len(subscript) != len(shape):
                 raise LoopyError("subscript to '%s' in '%s' has the wrong "

--- a/loopy/check.py
+++ b/loopy/check.py
@@ -862,10 +862,23 @@ class _AccessCheckMapper(WalkMapper[[nisl.Set, str]]):
 
             kw_to_pos, _ = get_kw_pos_association(subkernel)
 
-            arg_id_to_arg = self.kernel.id_to_insn[insn_id].arg_id_to_arg()
+            insn = self.kernel.id_to_insn[insn_id]
+            if isinstance(insn, CallInstruction):
+                arg_id_to_arg = insn.arg_id_to_arg()
 
-            kwargs = {k: _mark_variables_from_caller(arg_id_to_arg[kw_to_pos[k]])
-                      for k in subkernel.get_unwritten_value_args()}
+                kwargs = {k: _mark_variables_from_caller(
+                                cast("ArithmeticExpression",
+                                     arg_id_to_arg[kw_to_pos[k]]))
+                          for k in subkernel.get_unwritten_value_args()}
+            else:
+                # The call appears as a plain expression (e.g. on the right
+                # hand side of an assignment); its arguments are found in
+                # *expr* itself.
+                kwargs = {k: _mark_variables_from_caller(
+                                cast("ArithmeticExpression",
+                                     expr.parameters[kw_to_pos[k]]))
+                          for k in subkernel.get_unwritten_value_args()
+                          if kw_to_pos[k] < len(expr.parameters)}
 
             kw_space = nisl.Space.from_names(
                 out=[], param=[*get_dependencies(tuple(kwargs.values())),

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2307,10 +2307,7 @@ def make_function(
     :arg symbol_manglers: list of functions of signature (name) returning
         a tuple (result_dtype, c_name), where c_name is the C-level symbol to
         be evaluated.
-    :arg assumptions: the initial implemented_domain, captures assumptions
-        on loop domain parameters. (an isl.Set or a string in
-        :ref:`isl-syntax`.  If given as a string, only the CONDITIONS part of
-        the set notation should be given.)
+    :arg assumptions: same as argument of :func:`loopy.assume`.
     :arg silenced_warnings: a list (or semicolon-separated string) or warnings
         to silence
     :arg options: an instance of :class:`loopy.Options` or an equivalent
@@ -2490,25 +2487,6 @@ def make_function(
     for domain in parsed_domains:
         assert domain._obj.get_ctx() == isl.DEFAULT_CONTEXT
 
-    # {{{ process assumptions
-
-    from loopy.kernel.tools import get_outer_params
-
-    if assumptions is None:
-        dom0 = parsed_domains[0]
-        assumptions_space = nisl.Space.from_names(param=dom0.space.param_names)
-        assumptions = nisl.Set.universe(assumptions_space)
-    elif isinstance(assumptions, str):
-        assumptions_set_str = "[%s] -> { : %s}" \
-                % (",".join(s for s in get_outer_params(parsed_domains)),
-                    assumptions)
-        assumptions = nisl.make_set(assumptions_set_str)
-    else:
-        if isinstance(assumptions, isl.BasicSet):
-            assumptions = nisl.to_named(assumptions).as_set()
-        if not isinstance(assumptions, nisl.Set):
-            raise LoopyError("assumptions must be either 'str' or Set")
-
     # }}}
 
     from loopy.kernel import _get_inames_from_domains
@@ -2554,7 +2532,7 @@ def make_function(
             target=target,
             tags=tags,
             inames=inames,
-            assumptions=assumptions,
+            assumptions=nisl.Set.universe(nisl.Space.from_names(param=[], out=[])),
             index_dtype=norm_index_dtype,
             preambles=preambles,
             preamble_generators=preamble_generators,
@@ -2563,6 +2541,14 @@ def make_function(
             iname_slab_increments=constantdict(iname_slab_increments),
             applied_iname_rewrites=applied_iname_rewrites,
             )
+
+    if assumptions is None:
+        pass
+    elif isinstance(assumptions, (str, nisl.Set, isl.Set, isl.BasicSet)):
+        from loopy.transform.parameter import assume
+        knl = assume(knl, assumptions)
+    else:
+        raise TypeError("unexpected type of 'assumptions'")
 
     from loopy.transform.instruction import uniquify_instruction_ids
     knl = uniquify_instruction_ids(knl)

--- a/loopy/kernel/creation.py
+++ b/loopy/kernel/creation.py
@@ -2255,7 +2255,7 @@ def make_function(
 
     :arg domains:
 
-        A list of :class:`islpy.BasicSet` (i.e. convex set) instances
+        A list of set instances
         representing the :ref:`domain-tree`. May also be a list of strings
         which will be parsed into such instances according to :ref:`isl-syntax`.
 
@@ -2471,10 +2471,6 @@ def make_function(
     # }}}
 
     instructions, inames_to_dup, inline_substitutions = parse_instructions(instructions)
-
-    # {{{ find/create isl_context
-
-    # }}}
 
     instructions, inames_to_dup, cse_temp_vars = expand_cses(
             instructions, inames_to_dup)

--- a/loopy/statistics.py
+++ b/loopy/statistics.py
@@ -1463,7 +1463,14 @@ class AccessFootprintGatherer(CombineMapper[Mapping[str, nisl.Set], []]):
 # {{{ count
 
 def add_assumptions_guard(kernel: LoopKernel, pwqpolynomial: nisl.PwQPolynomial):
-    return GuardedPwQPolynomial(pwqpolynomial, kernel.assumptions)
+    params = {
+        *pwqpolynomial.space.param_names,
+        *kernel.assumptions.space.param_names}
+    pwqpolynomial = pwqpolynomial.add_dims(
+        DimType.param, params - pwqpolynomial.space.param_names)
+    assumptions = kernel.assumptions.add_dims(
+        DimType.param, params - kernel.assumptions.space.param_names)
+    return GuardedPwQPolynomial(pwqpolynomial, assumptions)
 
 
 def count(kernel: LoopKernel, set: nisl.Set):

--- a/loopy/transform/callable.py
+++ b/loopy/transform/callable.py
@@ -204,9 +204,10 @@ def substitute_into_domain(
             param_name: str,
             expr: ArithmeticExpression,
             allowed_param_dims: Collection[str],
-        ):
+        ) -> nisl.Set:
     """
-    :arg allowed_deps: A :class:`list` of :class:`str` that are
+    :arg allowed_param_dims: Names that may be introduced as new parameters
+        of *domain* (i.e. parameters of the caller).
     """
     import pymbolic.primitives as prim
 
@@ -217,24 +218,29 @@ def substitute_into_domain(
 
     # {{{ rename 'param_name' to avoid namespace pollution with allowed_param_dims
 
-    domain = domain.rename_dims([(
-            param_name, UniqueNameGenerator(set(allowed_param_dims))(param_name))])
+    renamed_param_name = UniqueNameGenerator(set(allowed_param_dims))(param_name)
+    domain = domain.rename_dims([(param_name, renamed_param_name)])
 
     # }}}
 
-    domain.add_dims(DimType.param, [
-        dep for dep in get_dependencies(expr)
-        if dep in allowed_param_dims
-    ])
+    new_param_names: list[str] = []
+    for dep in get_dependencies(expr):
+        if dep in allowed_param_dims:
+            new_param_names.append(dep)
+        else:
+            raise ValueError("Augmenting caller's domain "
+                    f"with '{dep}' is not allowed.")
+
+    domain = domain.add_dims(DimType.param, new_param_names)
 
     set_ = isl_set_from_expr(domain.var_pw_affs,
-            prim.Comparison(prim.Variable(param_name),
+            prim.Comparison(prim.Variable(renamed_param_name),
                             "==",
                             expr))
 
     domain = domain & set_
 
-    return domain.project_out([param_name])
+    return domain.project_out([renamed_param_name])
 
 
 def get_valid_domain_param_names(knl):

--- a/loopy/transform/parameter.py
+++ b/loopy/transform/parameter.py
@@ -63,8 +63,15 @@ def assume(
         the assumptions in :ref:`isl-syntax`.
     """
     if isinstance(assumptions, str):
+        # Value args that only appear in argument shapes (and not in any
+        # domain) are also legitimate assumption parameters, so declare
+        # them as well.
+        from loopy.kernel.data import ValueArg
+        param_names = set(kernel.outer_params()) | {
+                arg.name for arg in kernel.args
+                if isinstance(arg, ValueArg)}
         assumptions_set_str = "[%s] -> { : %s}" \
-                % (",".join(s for s in kernel.outer_params()),
+                % (",".join(sorted(param_names)),
                     assumptions)
         assumptions = nisl.make_set(assumptions_set_str)
 

--- a/loopy/transform/parameter.py
+++ b/loopy/transform/parameter.py
@@ -119,7 +119,7 @@ def _fix_parameter(
         if not isinstance(value, int):
             raise ValueError(f"parameter '{name}' is used in a set, must be an integer")
 
-        return s.fix_dim(name, value)
+        return s.fix_dim(name, value).project_out([name])
 
     new_domains = [process_set(dom) for dom in kernel.domains]
 

--- a/loopy/transform/parameter.py
+++ b/loopy/transform/parameter.py
@@ -29,6 +29,7 @@ from warnings import warn
 
 import islpy as isl
 import namedisl as nisl
+from namedisl import DimType
 
 from loopy.kernel import LoopKernel
 from loopy.symbolic import RuleAwareSubstitutionMapper, SubstitutionRuleMappingContext
@@ -50,6 +51,14 @@ __doc__ = """
 
 
 # {{{ assume
+
+def _remove_unused_dims(dt: DimType, obj: nisl.Set):
+    unused_dims = {
+        name for name in obj.space.dim_names(dt)
+        if not obj.involves_dims([name])
+        }
+    return obj.project_out(unused_dims)
+
 
 @for_each_kernel
 def assume(
@@ -73,7 +82,8 @@ def assume(
         assumptions_set_str = "[%s] -> { : %s}" \
                 % (",".join(sorted(param_names)),
                     assumptions)
-        assumptions = nisl.make_set(assumptions_set_str)
+        assumptions = _remove_unused_dims(DimType.param,
+            nisl.make_set(assumptions_set_str))
 
     if isinstance(assumptions, (isl.BasicSet, isl.Set)):
         warn(

--- a/test/test_reduction.py
+++ b/test/test_reduction.py
@@ -147,7 +147,8 @@ def test_multi_nested_dependent_reduction():
                 lp.ValueArg("ntgts", np.int32),
                 lp.ValueArg("nboxes", np.int32),
                 ],
-            assumptions="ntgts>=1",
+            # 'a' is indexed by 'itgt', so the bounds check needs 'ntgts <= n'
+            assumptions="ntgts>=1 and ntgts <= n",
             target=lp.PyOpenCLTarget())
 
     print(lp.generate_code_v2(knl).device_code())
@@ -179,7 +180,8 @@ def test_recursive_nested_dependent_reduction():
                 lp.ValueArg("ntgts", np.int32),
                 lp.ValueArg("nboxes", np.int32),
                 ],
-            assumptions="ntgts>=1",
+            # 'a' is indexed by 'itgt', so the bounds check needs 'ntgts <= n'
+            assumptions="ntgts>=1 and ntgts <= n",
             target=lp.PyOpenCLTarget())
 
     print(lp.generate_code_v2(knl).device_code())

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -946,6 +946,28 @@ def test_fma_codegen(dtype):
         )
 
 
+def test_bounds_check_with_shape_only_param():
+    # A parameter that appears only in an array's shape (not in the domain or
+    # in any expression) must still be accounted for in the out-of-bounds
+    # check: without an assumption establishing 'n >= 5' the access is
+    # potentially out-of-bounds, and the check must fail.
+    from loopy.diagnostic import LoopyIndexError
+
+    knl = lp.make_kernel(
+        "{ [i]: 0 <= i < 5 }",
+        "x[i, 0] = 5",
+        [lp.GlobalArg("x", dtype=float, shape=("n", 2)),
+         lp.ValueArg("n", np.int32)],
+        target=lp.CTarget(),
+    )
+
+    with pytest.raises(LoopyIndexError):
+        lp.generate_code_v2(knl)
+
+    knl = lp.assume(knl, "n >= 5")
+    lp.generate_code_v2(knl)
+
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
check_bounds skipped the access-range-vs-shape subset test whenever an array's shape depended on a parameter that was not present in the instruction's domain space. A value arg that appears only in an argument shape (and not in the domain or in any instruction expression) is never a read dependency, so get_insn_domain never adds it to the domain, and the mapper's "shape_deps <= available_vars" guard bailed out without checking.

This let a kernel like
```
    { [i]: 0 <= i < 5 }  
    x[i, 0] = 5   
    x: shape (n, 2)
```
generate code even though the access is only in-bounds when n >= 5, and it did so without warning. ISL could not even express the needed premise because the parameter was absent from the space.

Fix in _AccessCheckMapper.map_subscript: when a shape dependency is missing from the domain space but is a read-only value arg of the kernel, add it as a free parameter and continue with the check. Other missing dependencies (e.g.  temporaries) remain data-dependent and are still skipped. The result:

- without an assumption, the check now correctly raises LoopyIndexError;
- with the assumption n >= 5, it passes, as expected.

Also teach assume()'s string form to declare value-arg names (not just domain params) as assumption parameters, so lp.assume(knl, "n >= 5") works for shape-only params.

Add test_bounds_check_with_shape_only_param covering both the error and the assumption-pass cases.

Note: kernels where the shape param is a different domain param (e.g. domain 0<=i<m with shape (n,)) now fail unless an assumption such as m <= n is given -- the intended soundness improvement.

Assisted-by: Zed:Qwen3.8-27B-FP8

Downstream fixes:

- https://github.com/inducer/sumpy/pull/302
- https://github.com/inducer/meshmode/commit/68b0465463da3844c8b0d79c23ef25e2c9b8ab76